### PR TITLE
expose removeAllListeners

### DIFF
--- a/ios/Plugin/InAppBrowserPlugin.m
+++ b/ios/Plugin/InAppBrowserPlugin.m
@@ -12,4 +12,5 @@ CAP_PLUGIN(InAppBrowserPlugin, "InAppBrowser",
            CAP_PLUGIN_METHOD(hide, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(executeScript, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(insertCSS, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(removeAllListeners, CAPPluginReturnPromise);
 )


### PR DESCRIPTION
For the purposes of cleaning up listeners, allows calling of `removeAllListeners` on iOS.

Android can already call it.