### PR TITLE
fix: Android close

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -140,7 +140,7 @@ public class WebViewDialog extends Dialog {
                 @Override
                 public void onClick(View view) {
                     dismiss();
-                    _options.getCallbacks().urlChangeEvent(_webView.getUrl());
+                    _options.getCallbacks().closeEvent(_webView.getUrl());
                 }
             }
         );


### PR DESCRIPTION
I was testing #20 and found that it didn't work on Android.

Can confirm close works on iOS.