### PR TITLE
add option to prevents deep links from opening directly in one app when multiple duplicate apps are installed on the device

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,11 @@
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="ee.forgr.capacitor_inappbrowser">
+    <queries>
+      <intent>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="http" />
+      </intent>
+    </queries>
 </manifest>


### PR DESCRIPTION
This pull request adds new functionality to the @capgo/in-app-browser plugin that prevents deep links from opening directly in one app when multiple duplicate apps are installed on the device. For instance, if both WhatsApp and WhatsApp Business are installed, the user will now be prompted to choose which app to open the link in.

This new feature helps to provide a better user experience by allowing users to easily choose which app to use for specific links, without being redirected to a default app. 

I have tested this implementation and it works as expected. I believe this feature will be a valuable addition to the @capgo/in-app-browser plugin and I look forward to your feedback.