### PR TITLE
override doUpdateVisitedHistory and make it call urlChangeEvent callb…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ InAppBrowser.open("YOUR_URL");
 ### open(...)
 
 ```typescript
-open(options: OpenOptions) => any
+open(options: OpenOptions) => Promise<any>
 ```
 
 Open url in a new window fullscreen
@@ -53,7 +53,7 @@ Open url in a new window fullscreen
 | ------------- | --------------------------------------------------- |
 | **`options`** | <code><a href="#openoptions">OpenOptions</a></code> |
 
-**Returns:** <code>any</code>
+**Returns:** <code>Promise&lt;any&gt;</code>
 
 **Since:** 0.1.0
 
@@ -63,12 +63,12 @@ Open url in a new window fullscreen
 ### clearCookies()
 
 ```typescript
-clearCookies() => any
+clearCookies() => Promise<any>
 ```
 
 Clear all cookies
 
-**Returns:** <code>any</code>
+**Returns:** <code>Promise&lt;any&gt;</code>
 
 **Since:** 0.5.0
 
@@ -78,10 +78,10 @@ Clear all cookies
 ### close()
 
 ```typescript
-close() => any
+close() => Promise<any>
 ```
 
-**Returns:** <code>any</code>
+**Returns:** <code>Promise&lt;any&gt;</code>
 
 --------------------
 
@@ -89,7 +89,7 @@ close() => any
 ### openWebView(...)
 
 ```typescript
-openWebView(options: OpenWebViewOptions) => any
+openWebView(options: OpenWebViewOptions) => Promise<any>
 ```
 
 Open url in a new webview with toolbars
@@ -98,7 +98,7 @@ Open url in a new webview with toolbars
 | ------------- | ----------------------------------------------------------------- |
 | **`options`** | <code><a href="#openwebviewoptions">OpenWebViewOptions</a></code> |
 
-**Returns:** <code>any</code>
+**Returns:** <code>Promise&lt;any&gt;</code>
 
 **Since:** 0.1.0
 
@@ -108,14 +108,14 @@ Open url in a new webview with toolbars
 ### setUrl(...)
 
 ```typescript
-setUrl(options: { url: string; }) => any
+setUrl(options: { url: string; }) => Promise<any>
 ```
 
 | Param         | Type                          |
 | ------------- | ----------------------------- |
 | **`options`** | <code>{ url: string; }</code> |
 
-**Returns:** <code>any</code>
+**Returns:** <code>Promise&lt;any&gt;</code>
 
 --------------------
 
@@ -126,14 +126,14 @@ setUrl(options: { url: string; }) => any
 addListener(eventName: "urlChangeEvent", listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
-Listen for url change
+Listen for url change, only for openWebView
 
 | Param              | Type                                                            |
 | ------------------ | --------------------------------------------------------------- |
 | **`eventName`**    | <code>'urlChangeEvent'</code>                                   |
 | **`listenerFunc`** | <code><a href="#urlchangelistener">UrlChangeListener</a></code> |
 
-**Returns:** <code>any</code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 0.0.1
 
@@ -146,14 +146,14 @@ Listen for url change
 addListener(eventName: "closeEvent", listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
-Listen for close click
+Listen for close click only for openWebView
 
 | Param              | Type                                                            |
 | ------------------ | --------------------------------------------------------------- |
 | **`eventName`**    | <code>'closeEvent'</code>                                       |
 | **`listenerFunc`** | <code><a href="#urlchangelistener">UrlChangeListener</a></code> |
 
-**Returns:** <code>any</code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 0.4.0
 
@@ -173,7 +173,7 @@ Will be triggered when user clicks on confirm button when disclaimer is required
 | **`eventName`**    | <code>'confirmBtnClicked'</code>                                  |
 | **`listenerFunc`** | <code><a href="#confirmbtnlistener">ConfirmBtnListener</a></code> |
 
-**Returns:** <code>any</code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 0.0.1
 
@@ -183,12 +183,10 @@ Will be triggered when user clicks on confirm button when disclaimer is required
 ### removeAllListeners()
 
 ```typescript
-removeAllListeners() => any
+removeAllListeners() => Promise<void>
 ```
 
 Remove all listeners for this plugin.
-
-**Returns:** <code>any</code>
 
 **Since:** 1.0.0
 
@@ -235,18 +233,18 @@ Remove all listeners for this plugin.
 | **`cancelBtn`**  | <code>string</code> |
 
 
+#### PluginListenerHandle
+
+| Prop         | Type                                      |
+| ------------ | ----------------------------------------- |
+| **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
+
+
 #### UrlEvent
 
 | Prop      | Type                | Description               | Since |
 | --------- | ------------------- | ------------------------- | ----- |
 | **`url`** | <code>string</code> | Emit when the url changes | 0.0.1 |
-
-
-#### PluginListenerHandle
-
-| Prop         | Type                      |
-| ------------ | ------------------------- |
-| **`remove`** | <code>() =&gt; any</code> |
 
 
 #### BtnEvent

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -198,8 +198,15 @@ public class WebViewDialog extends Dialog {
           } catch (URISyntaxException e) {
             // Do nothing
           }
-          _options.getCallbacks().urlChangeEvent(url);
         }
+
+        public void doUpdateVisitedHistory(WebView view, String url, boolean isReload) {
+          if(!isReload){
+            _options.getCallbacks().urlChangeEvent(url);
+          }
+          super.doUpdateVisitedHistory(view, url, isReload);
+        }
+
 
         @Override
         public void onPageFinished(WebView view, String url) {


### PR DESCRIPTION
**override doUpdateVisitedHistory and make it call urlChangeEvent callback instead of onPageStarted.**
the issue this PR is fixing is when the query string gets appended to a URL, in Android this change is not detected in onPageStarted so I have to use doUpdateVisitedHistory method.