### PR TITLE
Fix user-agent & iOS Crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ captures
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild
+example-app

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -69,7 +69,7 @@ public class WebViewDialog extends Dialog {
       Iterator<String> keys = _options.getHeaders().keys();
       while (keys.hasNext()) {
         String key = keys.next();
-        if (TextUtils.equals(key, "User-Agent")) {
+        if (TextUtils.equals(key.toLowerCase(), "user-agent")) {
           _webView
             .getSettings()
             .setUserAgentString(_options.getHeaders().getString(key));
@@ -98,7 +98,7 @@ public class WebViewDialog extends Dialog {
       Iterator<String> keys = _options.getHeaders().keys();
       while (keys.hasNext()) {
         String key = keys.next();
-        if (TextUtils.equals(key, "User-Agent")) {
+        if (TextUtils.equals(key.toLowerCase(), "user-agent")) {
           _webView
             .getSettings()
             .setUserAgentString(_options.getHeaders().getString(key));

--- a/ios/Plugin/WKWebViewController.swift
+++ b/ios/Plugin/WKWebViewController.swift
@@ -261,7 +261,7 @@ open class WKWebViewController: UIViewController {
         var topPadding = CGFloat(0.0)
         if #available(iOS 11.0, *) {
             let window = UIApplication.shared.keyWindow
-            bottomPadding = (window?.safeAreaInsets.bottom)!
+            bottomPadding = window?.safeAreaInsets.bottom ?? 0.0
             topPadding = (window?.safeAreaInsets.top)!
         }
         if UIDevice.current.orientation.isPortrait {

--- a/ios/Plugin/WKWebViewController.swift
+++ b/ios/Plugin/WKWebViewController.swift
@@ -28,6 +28,16 @@ private struct UrlsHandledByApp {
     @objc optional func webViewController(_ controller: WKWebViewController, decidePolicy url: URL, navigationType: NavigationType) -> Bool
 }
 
+extension Dictionary {
+    func mapKeys<T>(_ transform: (Key) throws -> T) rethrows -> Dictionary<T, Value> {
+        var dictionary = Dictionary<T, Value>()
+        for (key, value) in self {
+            dictionary[try transform(key)] = value
+        }
+        return dictionary
+    }
+}
+
 open class WKWebViewController: UIViewController {
 
     public init() {
@@ -82,9 +92,12 @@ open class WKWebViewController: UIViewController {
 
     func setHeaders(headers: [String: String]) {
         self.headers = headers
-        let userAgent = self.headers?["User-Agent"]
+        let lowercasedHeaders = headers.mapKeys { $0.lowercased() }
+        let userAgent = lowercasedHeaders["user-agent"]
         self.headers?.removeValue(forKey: "User-Agent")
-        if userAgent != nil {
+        self.headers?.removeValue(forKey: "user-agent")
+
+        if let userAgent = userAgent {
             self.customUserAgent = userAgent
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capgo/inappbrowser",
-  "version": "1.2.4",
+  "version": "1.2.1",
   "description": "Capacitor plugin in app browser",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capgo/inappbrowser",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "description": "Capacitor plugin in app browser",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capgo/inappbrowser",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Capacitor plugin in app browser",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Current implementation for setting `User-Agent` was case sensitive so `user-agent` didn't work

Tested Google Sign In on both iOS & Android

Also fixes a crash on iOS caused by `bottomPadding` being null

<img width="1440" alt="image" src="https://github.com/Cap-go/capacitor-inappbrowser/assets/62795688/f6058fa1-e738-49d2-9c73-3833ddd4c7d5">

/claim #66