### PR TITLE
fixed typo in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npx cap sync
 ```js
 import { InAppBrowser } from '@capgo/inappbrowser'
 
-InAppBrowser.open("YOUR_URL");
+InAppBrowser.open({ url: "YOUR_URL" });
 ```
 
 ## API


### PR DESCRIPTION
Hey!
I've corrected a typo in the Readme for calling the `InAppBrowser.open({ url: '...' })` method.