### PR TITLE
Add cookies management support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ Clear all cookies
 ### getCookies(...)
 
 ```typescript
-getCookies(options: { url: string; }) => Promise<{ cookies: Record<string, string>; }>
+getCookies(options: GetCookieOptions) => Promise<{ cookies: Record<string, string>; }>
 ```
 
 Get cookies for a specific URL.
 
-| Param         | Type                          | Description                                        |
-| ------------- | ----------------------------- | -------------------------------------------------- |
-| **`options`** | <code>{ url: string; }</code> | The options, including the URL to get cookies for. |
+| Param         | Type                                                          | Description                                        |
+| ------------- | ------------------------------------------------------------- | -------------------------------------------------- |
+| **`options`** | <code><a href="#getcookieoptions">GetCookieOptions</a></code> | The options, including the URL to get cookies for. |
 
 **Returns:** <code>Promise&lt;{ cookies: <a href="#record">Record</a>&lt;string, string&gt;; }&gt;</code>
 
@@ -253,6 +253,23 @@ Reload the current web page.
 #### Headers
 
 
+#### GetCookieOptions
+
+| Prop                  | Type                 |
+| --------------------- | -------------------- |
+| **`url`**             | <code>string</code>  |
+| **`includeHttpOnly`** | <code>boolean</code> |
+
+
+#### HttpCookie
+
+| Prop        | Type                |
+| ----------- | ------------------- |
+| **`url`**   | <code>string</code> |
+| **`key`**   | <code>string</code> |
+| **`value`** | <code>string</code> |
+
+
 #### OpenWebViewOptions
 
 | Prop                         | Type                                                            | Description                                                                                                                                                                       | Default                                                    | Since  |
@@ -315,6 +332,32 @@ Reload the current web page.
 Construct a type with a set of properties K of type T
 
 <code>{ [P in K]: T; }</code>
+
+
+#### GetCookieOptions
+
+<code><a href="#omit">Omit</a>&lt;<a href="#httpcookie">HttpCookie</a>, 'key' | 'value'&gt;</code>
+
+
+#### Omit
+
+Construct a type with the properties of T except for those in type K.
+
+<code><a href="#pick">Pick</a>&lt;T, <a href="#exclude">Exclude</a>&lt;keyof T, K&gt;&gt;</code>
+
+
+#### Pick
+
+From T, pick a set of properties whose keys are in the union K
+
+<code>{ [P in K]: T[P]; }</code>
+
+
+#### Exclude
+
+<a href="#exclude">Exclude</a> from T those types that are assignable to U
+
+<code>T extends U ? never : T</code>
 
 
 #### UrlChangeListener

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Then the permission will be asked when the camera is used.
 
 * [`open(...)`](#open)
 * [`clearCookies()`](#clearcookies)
+* [`getCookies(...)`](#getcookies)
 * [`close()`](#close)
 * [`openWebView(...)`](#openwebview)
 * [`setUrl(...)`](#seturl)
@@ -82,6 +83,23 @@ Clear all cookies
 **Returns:** <code>Promise&lt;any&gt;</code>
 
 **Since:** 0.5.0
+
+--------------------
+
+
+### getCookies(...)
+
+```typescript
+getCookies(options: { url: string; }) => Promise<{ cookies: Record<string, string>; }>
+```
+
+Get cookies for a specific URL.
+
+| Param         | Type                          | Description                                        |
+| ------------- | ----------------------------- | -------------------------------------------------- |
+| **`options`** | <code>{ url: string; }</code> | The options, including the URL to get cookies for. |
+
+**Returns:** <code>Promise&lt;{ cookies: <a href="#record">Record</a>&lt;string, string&gt;; }&gt;</code>
 
 --------------------
 
@@ -290,6 +308,13 @@ Reload the current web page.
 
 
 ### Type Aliases
+
+
+#### Record
+
+Construct a type with a set of properties K of type T
+
+<code>{ [P in K]: T; }</code>
 
 
 #### UrlChangeListener

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -213,31 +213,25 @@ public class InAppBrowserPlugin
 
   @PluginMethod
   public void getCookies(PluginCall call) {
-    String urlString = call.getString("url");
-    Boolean includeHttpOnly = call.getBoolean("includeHttpOnly", true);
-
-    if (urlString == null || urlString.isEmpty()) {
-      call.reject("URL is required");
-      return;
-    }
-
-    CookieManager cookieManager = CookieManager.getInstance();
-    String cookiesString = cookieManager.getCookie(urlString);
-    if (cookiesString == null) {
-      call.resolve(new JSObject());
-      return;
-    }
-
-    String[] cookiePairs = cookiesString.split("; ");
-    JSObject result = new JSObject();
-    for (String cookie : cookiePairs) {
-      String[] parts = cookie.split("=", 2);
-      if (parts.length == 2) {
-        result.put(parts[0], parts[1]);
+    String url = call.getString("url");
+    if (url == null || TextUtils.isEmpty(url)) {
+      call.reject("Invalid URL");
+    } else {
+      CookieManager cookieManager = CookieManager.getInstance();
+      String cookieString = cookieManager.getCookie(url);
+      if (cookieString != null) {
+        String[] cookiePairs = cookieString.split("; ");
+        JSObject result = new JSObject();
+        for (String cookie : cookiePairs) {
+          String[] parts = cookie.split("=", 2);
+          if (parts.length == 2) {
+            result.put(parts[0], parts[1]);
+          }
+        }
+        call.resolve(result);
       }
+      call.resolve(new JSObject());
     }
-
-    call.resolve(result);
   }
 
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -187,27 +187,23 @@ public class InAppBrowserPlugin
 
   @PluginMethod
   public void clearCookies(PluginCall call) {
-    if (webViewDialog == null) {
-      call.reject("WebView is not open");
+    String url = call.getString("url");
+    if (url == null || TextUtils.isEmpty(url)) {
+      call.reject("Invalid URL");
     } else {
-      String url = currentUrl;
-      if (url == null || TextUtils.isEmpty(url)) {
-        call.reject("Invalid URL");
-      } else {
-        CookieManager cookieManager = CookieManager.getInstance();
-        String cookie = cookieManager.getCookie(url);
-        if (cookie != null) {
-          String[] cookies = cookie.split(";");
-          for (String c : cookies) {
-            String cookieName = c.substring(0, c.indexOf("="));
-            cookieManager.setCookie(
-              url,
-              cookieName + "=; Expires=Thu, 01 Jan 1970 00:00:01 GMT"
-            );
-          }
+      CookieManager cookieManager = CookieManager.getInstance();
+      String cookie = cookieManager.getCookie(url);
+      if (cookie != null) {
+        String[] cookies = cookie.split(";");
+        for (String c : cookies) {
+          String cookieName = c.substring(0, c.indexOf("="));
+          cookieManager.setCookie(
+            url,
+            cookieName + "=; Expires=Thu, 01 Jan 1970 00:00:01 GMT"
+          );
         }
-        call.resolve();
       }
+      call.resolve();
     }
   }
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -212,6 +212,36 @@ public class InAppBrowserPlugin
   }
 
   @PluginMethod
+  public void getCookies(PluginCall call) {
+    String urlString = call.getString("url");
+    Boolean includeHttpOnly = call.getBoolean("includeHttpOnly", true);
+
+    if (urlString == null || urlString.isEmpty()) {
+      call.reject("URL is required");
+      return;
+    }
+
+    CookieManager cookieManager = CookieManager.getInstance();
+    String cookiesString = cookieManager.getCookie(urlString);
+    if (cookiesString == null) {
+      call.resolve(new JSObject());
+      return;
+    }
+
+    String[] cookiePairs = cookiesString.split("; ");
+    JSObject result = new JSObject();
+    for (String cookie : cookiePairs) {
+      String[] parts = cookie.split("=", 2);
+      if (parts.length == 2) {
+        result.put(parts[0], parts[1]);
+      }
+    }
+
+    call.resolve(result);
+  }
+
+
+  @PluginMethod
   public void openWebView(PluginCall call) {
     String url = call.getString("url");
     if (url == null || TextUtils.isEmpty(url)) {

--- a/ios/Plugin/InAppBrowserPlugin.m
+++ b/ios/Plugin/InAppBrowserPlugin.m
@@ -6,6 +6,7 @@
 CAP_PLUGIN(InAppBrowserPlugin, "InAppBrowser",
            CAP_PLUGIN_METHOD(openWebView, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(clearCookies, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(getCookies, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(reload, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(open, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setUrl, CAPPluginReturnPromise);

--- a/ios/Plugin/InAppBrowserPlugin.swift
+++ b/ios/Plugin/InAppBrowserPlugin.swift
@@ -56,18 +56,24 @@ public class InAppBrowserPlugin: CAPPlugin {
 
     @objc func getCookies(_ call: CAPPluginCall) {
         let urlString = call.getString("url") ?? ""
+        let includeHttpOnly = call.getBool("includeHttpOnly") ?? true
+
         guard let url = URL(string: urlString) else {
             call.reject("Invalid URL")
             return
         }
 
         WKWebsiteDataStore.default().httpCookieStore.getAllCookies { cookies in
-            let cookieDict = cookies.reduce(into: [String: String]()) { dict, cookie in
-                dict[cookie.name] = cookie.value
+            var cookieDict = [String: String]()
+            for cookie in cookies {
+                if includeHttpOnly || !cookie.isHTTPOnly {
+                    cookieDict[cookie.name] = cookie.value
+                }
             }
             call.resolve(["cookies": cookieDict])
         }
     }
+
 
     @objc func openWebView(_ call: CAPPluginCall) {
         if !self.isSetupDone {

--- a/ios/Plugin/InAppBrowserPlugin.swift
+++ b/ios/Plugin/InAppBrowserPlugin.swift
@@ -54,6 +54,21 @@ public class InAppBrowserPlugin: CAPPlugin {
         call.resolve()
     }
 
+    @objc func getCookies(_ call: CAPPluginCall) {
+        let urlString = call.getString("url") ?? ""
+        guard let url = URL(string: urlString) else {
+            call.reject("Invalid URL")
+            return
+        }
+
+        WKWebsiteDataStore.default().httpCookieStore.getAllCookies { cookies in
+            let cookieDict = cookies.reduce(into: [String: String]()) { dict, cookie in
+                dict[cookie.name] = cookie.value
+            }
+            call.resolve(["cookies": cookieDict])
+        }
+    }
+
     @objc func openWebView(_ call: CAPPluginCall) {
         if !self.isSetupDone {
             self.setup()

--- a/ios/Plugin/InAppBrowserPlugin.swift
+++ b/ios/Plugin/InAppBrowserPlugin.swift
@@ -50,6 +50,7 @@ public class InAppBrowserPlugin: CAPPlugin {
     }
 
     @objc func clearCookies(_ call: CAPPluginCall) {
+        let dataStore = WKWebsiteDataStore.default()
         let urlString = call.getString("url") ?? ""
 
         guard let url = URL(string: urlString) else {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -40,6 +40,10 @@ export interface GetCookieOptions {
   includeHttpOnly?: boolean;
 }
 
+export interface ClearCookieOptions {
+  url: string;
+}
+
 export interface OpenOptions {
   /**
    * Target URL to load.
@@ -186,11 +190,11 @@ export interface InAppBrowserPlugin {
   open(options: OpenOptions): Promise<any>;
 
   /**
-   * Clear all cookies
+   * Clear cookies of url
    *
    * @since 0.5.0
    */
-  clearCookies(): Promise<any>;
+  clearCookies(options: ClearCookieOptions): Promise<any>;
 
   /**
    * Get cookies for a specific URL.

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -35,6 +35,11 @@ export interface Headers {
   [key: string]: string;
 }
 
+export interface GetCookieOptions {
+  url: string;
+  includeHttpOnly?: boolean;
+}
+
 export interface OpenOptions {
   /**
    * Target URL to load.

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -197,7 +197,7 @@ export interface InAppBrowserPlugin {
    * @param options The options, including the URL to get cookies for.
    * @returns A promise that resolves with the cookies.
    */
-  getCookies(options: { url: string }): Promise<{ cookies: Record<string, string> }>;
+  getCookies(options: GetCookieOptions): Promise<{ cookies: Record<string, string> }>;
 
   close(): Promise<any>;
   /**

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -186,6 +186,14 @@ export interface InAppBrowserPlugin {
    * @since 0.5.0
    */
   clearCookies(): Promise<any>;
+
+  /**
+   * Get cookies for a specific URL.
+   * @param options The options, including the URL to get cookies for.
+   * @returns A promise that resolves with the cookies.
+   */
+  getCookies(options: { url: string }): Promise<{ cookies: Record<string, string> }>;
+
   close(): Promise<any>;
   /**
    * Open url in a new webview with toolbars

--- a/src/web.ts
+++ b/src/web.ts
@@ -17,6 +17,12 @@ export class InAppBrowserWeb extends WebPlugin implements InAppBrowserPlugin {
     return;
   }
 
+  async getCookies(_options: { url: string }): Promise<{ cookies: Record<string, string> }> {
+    // Web implementation to get cookies
+    const cookies = {}; // Logic to retrieve cookies for the specified URL
+    return Promise.resolve({ cookies });
+  }
+
   async openWebView(options: OpenWebViewOptions): Promise<any> {
     console.log("openWebView", options);
     return options;

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,10 +1,10 @@
 import { WebPlugin } from "@capacitor/core";
 
-import type {
+import {
   InAppBrowserPlugin,
   OpenWebViewOptions,
   OpenOptions,
-  GetCookieOptions,
+  GetCookieOptions, ClearCookieOptions,
 } from "./definitions";
 
 export class InAppBrowserWeb extends WebPlugin implements InAppBrowserPlugin {
@@ -13,8 +13,8 @@ export class InAppBrowserWeb extends WebPlugin implements InAppBrowserPlugin {
     return options;
   }
 
-  async clearCookies(): Promise<any> {
-    console.log("cleanCookies");
+  async clearCookies(options: ClearCookieOptions): Promise<any> {
+    console.log("cleanCookies", options);
     return;
   }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -4,6 +4,7 @@ import type {
   InAppBrowserPlugin,
   OpenWebViewOptions,
   OpenOptions,
+  GetCookieOptions,
 } from "./definitions";
 
 export class InAppBrowserWeb extends WebPlugin implements InAppBrowserPlugin {
@@ -17,10 +18,9 @@ export class InAppBrowserWeb extends WebPlugin implements InAppBrowserPlugin {
     return;
   }
 
-  async getCookies(_options: { url: string }): Promise<{ cookies: Record<string, string> }> {
+  async getCookies(options: GetCookieOptions): Promise<any> {
     // Web implementation to get cookies
-    const cookies = {}; // Logic to retrieve cookies for the specified URL
-    return Promise.resolve({ cookies });
+    return options;
   }
 
   async openWebView(options: OpenWebViewOptions): Promise<any> {


### PR DESCRIPTION
I've recently working on a project which I have to manually handle the cookie (credentials) in the client-side.
I've modified the plugin so it can read In-app Browser cookies by url. A httpOnly filter also has been implemented.

Example:
InAppBrowser.

```ts
import { InAppBrowser } from '@capgo/inappbrowser';

const webUrl = "https://m.facebook.com";

InAppBrowser.open(webUrl);

// Read the cookies after 10 seconds
setTimeout(() => {
  InAppBrowser.getCookies({
    url: webUrl
  }).then(console.log);
}, 10 * 1000);
```

Hope this helps.

Cheers,