### PR TITLE
fix(android): fixes compiling for sdk 33

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,7 +58,6 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation "androidx.browser:browser:$androidxBrowserVersion"
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.android.material:material:1.10.0'
+    implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
-    implementation 'com.google.android.material:material:1.10.0'
 }


### PR DESCRIPTION
Project used implementation 'com.google.android.material:material:1.10.0' which does not compile Android SDK 33, but requires SDK 34. This SDK is not yet officially recommended or supported in Capacitor v5.

Also, this project used to implement material package twice in gradle file. This PR removes the duplicate and lowers the library to support compiling for SDK 33.

**Issue this fixes:**
Fixes build time issues:
```
3 issues were found when checking AAR metadata:

  1.  Dependency 'androidx.activity:activity-compose:1.8.0' requires libraries and applications that
      depend on it to compile against version 34 or later of the
      Android APIs.

      :app is currently compiled against android-33.

      Also, the maximum recommended compile SDK version for Android Gradle
      plugin 8.0.0 is 33.

      Recommended action: Update this project's version of the Android Gradle
      plugin to one that supports 34, then update this project to use
      compileSdk of at least 34.

      Note that updating a library or application's compileSdk (which
      allows newer APIs to be used) can be done separately from updating
      targetSdk (which opts the app in to new runtime behavior) and
      minSdk (which determines which devices the app can be installed
      on).

  2.  Dependency 'androidx.activity:activity-ktx:1.8.0' requires libraries and applications that
      depend on it to compile against version 34 or later of the
      Android APIs.

      :app is currently compiled against android-33.

      Also, the maximum recommended compile SDK version for Android Gradle
      plugin 8.0.0 is 33.

      Recommended action: Update this project's version of the Android Gradle
      plugin to one that supports 34, then update this project to use
      compileSdk of at least 34.

      Note that updating a library or application's compileSdk (which
      allows newer APIs to be used) can be done separately from updating
      targetSdk (which opts the app in to new runtime behavior) and
      minSdk (which determines which devices the app can be installed
      on).

  3.  Dependency 'androidx.activity:activity:1.8.0' requires libraries and applications that
      depend on it to compile against version 34 or later of the
      Android APIs.

      :app is currently compiled against android-33.

      Also, the maximum recommended compile SDK version for Android Gradle
      plugin 8.0.0 is 33.

      Recommended action: Update this project's version of the Android Gradle
      plugin to one that supports 34, then update this project to use
      compileSdk of at least 34.

      Note that updating a library or application's compileSdk (which
      allows newer APIs to be used) can be done separately from updating
      targetSdk (which opts the app in to new runtime behavior) and
      minSdk (which determines which devices the app can be installed
      on).
```

**More info:**
- [Official upgrade information for Capacitor v5](https://capacitorjs.com/docs/updating/5-0#update-android-project-variables)
- [Capacitor v6 supports SDK 34, but is not yet stable](https://capacitorjs.com/docs/next/updating/6-0)
  - When starting to support v6 this plugin should maybe support ['com.google.android.material:material:1.11.0'](https://github.com/material-components/material-components-android/releases/tag/1.11.0)