### PR TITLE
feat(android): handle opening deeplinks inside webview

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -329,19 +329,19 @@ public class WebViewDialog extends Dialog {
           WebView view,
           WebResourceRequest request
         ) {
-					Context context = view.getContext();
-					String url = request.getUrl().toString();
+          Context context = view.getContext();
+          String url = request.getUrl().toString();
 
-					if (!url.startsWith("https://") && !url.startsWith("http://")) {
-						try {
-							Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-							intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-							context.startActivity(intent);
-							return true;
-						} catch (ActivityNotFoundException e) {
-							// Do nothing
-						}
-					}
+          if (!url.startsWith("https://") && !url.startsWith("http://")) {
+            try {
+              Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+              intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+              context.startActivity(intent);
+              return true;
+            } catch (ActivityNotFoundException e) {
+              // Do nothing
+            }
+          }
           return false;
         }
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -326,6 +326,20 @@ public class WebViewDialog extends Dialog {
           WebView view,
           WebResourceRequest request
         ) {
+          Context context = view.getContext();
+          String url = request.getUrl().toString();
+
+          if (!url.startsWith("https://") && !url.startsWith("http://")) {
+            try {
+              Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+              intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+              context.startActivity(intent);
+              return true;
+            } catch (ActivityNotFoundException e) {
+              // Do nothing
+            }
+          }
+
           return false;
         }
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -3,10 +3,13 @@ package ee.forgr.capacitor_inappbrowser;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Color;
+import android.net.Uri;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
@@ -326,20 +329,19 @@ public class WebViewDialog extends Dialog {
           WebView view,
           WebResourceRequest request
         ) {
-          Context context = view.getContext();
-          String url = request.getUrl().toString();
+					Context context = view.getContext();
+					String url = request.getUrl().toString();
 
-          if (!url.startsWith("https://") && !url.startsWith("http://")) {
-            try {
-              Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-              intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-              context.startActivity(intent);
-              return true;
-            } catch (ActivityNotFoundException e) {
-              // Do nothing
-            }
-          }
-
+					if (!url.startsWith("https://") && !url.startsWith("http://")) {
+						try {
+							Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+							intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+							context.startActivity(intent);
+							return true;
+						} catch (ActivityNotFoundException e) {
+							// Do nothing
+						}
+					}
           return false;
         }
 


### PR DESCRIPTION
Handles opening deeplink in another app from the webview. Fix for the issue: #98 

When webview tries to navigate to URL scheme which is not handled by browser (something else than `http://` or `https://`) we should try to open it in the corresponding application. If app matching the deepLink schema is not found do nothing and show browser's error page.

Within iOS this seems to be handled already, but it were missing from the Android solution as far as I understood correctly.

**Example**
This example uses deeplink to phone app with URL tel://0401231234

1. Open inapp-browser to deeplink testing site: https://halgatewood.com/deeplink?link=tel%3A%2F%2F0401231234
    - `Browser.openWebView({ url: 'https://halgatewood.com/deeplink?link=tel%3A%2F%2F0401231234', title: 'Deep link test', toolbarType: 'navigation' })`
2. Click link to navigate to it
3. Phone should open the app associated with the URL scheme "tel://"

https://github.com/Cap-go/capacitor-inappbrowser/assets/7661970/184dcb06-e3b0-467f-ae6b-2fe046193838

