### PR TITLE
Fix Android WebView titles not being used and being overridden on page opening.

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -245,7 +245,8 @@ public class InAppBrowserPlugin
     options.setUrl(url);
     options.setHeaders(call.getObject("headers"));
     options.setShowReloadButton(call.getBoolean("showReloadButton", false));
-    if (Boolean.TRUE.equals(call.getBoolean("visibleTitle", true))) {
+    options.setVisibleTitle(call.getBoolean("visibleTitle", true));
+    if (Boolean.TRUE.equals(options.getVisibleTitle())) {
       options.setTitle(call.getString("title", "New Window"));
     } else {
       options.setTitle(call.getString("title", ""));

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -353,7 +353,9 @@ public class WebViewDialog extends Dialog {
           super.onPageStarted(view, url, favicon);
           try {
             URI uri = new URI(url);
-            setTitle(uri.getHost());
+            if (TextUtils.isEmpty(_options.getTitle())) {
+              setTitle(uri.getHost());
+            }
           } catch (URISyntaxException e) {
             // Do nothing
           }


### PR DESCRIPTION
- The `visibleTitle` value was not being set when parsing the options, so all calls `getVisibleTitle` would return false and end up never displaying the title on Android.
- The title would get overridden once the page opens, defaulting to the URI host even if a value as set.