### PR TITLE
Feature: Add option to ignore untrusted ssl certs in web view

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Reload the current web page.
 | **`visibleTitle`**                     | <code>boolean</code>                                            | visibleTitle: if true the website title would be shown else shown empty                                                                                                           | <code>true</code>                                          | 1.2.5  |
 | **`toolbarColor`**                     | <code>string</code>                                             | toolbarColor: color of the toolbar in hex format                                                                                                                                  | <code>'#ffffff''</code>                                    | 1.2.5  |
 | **`showArrow`**                        | <code>boolean</code>                                            | showArrow: if true an arrow would be shown instead of cross for closing the window                                                                                                | <code>false</code>                                         | 1.2.5  |
+| **`ignoreUntrustedSSLError`**          | <code>boolean</code>                                            | ignoreUntrustedSSLError: if true, the webview will ignore untrusted SSL errors allowing the user to view the website.                                                             | <code>false</code>                                         | 6.1.0  |
 
 
 #### DisclaimerOptions

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -252,7 +252,7 @@ public class InAppBrowserPlugin
     }
     options.setToolbarColor(call.getString("toolbarColor", "#ffffff"));
     options.setArrow(Boolean.TRUE.equals(call.getBoolean("showArrow", false)));
-
+    options.setIgnoreUntrustedSSLError(Boolean.TRUE.equals(call.getBoolean("ignoreUntrustedSSLError", false)));
     options.setShareDisclaimer(call.getObject("shareDisclaimer", null));
     options.setShareSubject(call.getString("shareSubject", null));
     options.setToolbarType(call.getString("toolbarType", ""));

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
@@ -24,6 +24,7 @@ public class Options {
   private boolean VisibleTitle;
   private String ToolbarColor;
   private boolean ShowArrow;
+  private boolean ignoreUntrustedSSLError;
 
   public PluginCall getPluginCall() {
     return pluginCall;
@@ -189,5 +190,12 @@ public class Options {
 
   public void setArrow(boolean _showArrow) {
     this.ShowArrow = _showArrow;
+  }
+  public boolean ignoreUntrustedSSLError() {
+    return ignoreUntrustedSSLError;
+  }
+
+  public void setIgnoreUntrustedSSLError(boolean _ignoreUntrustedSSLError) {
+    this.ignoreUntrustedSSLError = _ignoreUntrustedSSLError;
   }
 }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -1,5 +1,6 @@
 package ee.forgr.capacitor_inappbrowser;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
@@ -10,12 +11,14 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.net.Uri;
+import android.net.http.SslError;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 import android.webkit.PermissionRequest;
+import android.webkit.SslErrorHandler;
 import android.webkit.WebChromeClient;
 import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
@@ -413,7 +416,20 @@ public class WebViewDialog extends Dialog {
           super.onReceivedError(view, request, error);
           _options.getCallbacks().pageLoadError();
         }
+
+        @SuppressLint("WebViewClientOnReceivedSslError")
+        @Override
+        public void onReceivedSslError(WebView view, SslErrorHandler handler,
+                                       SslError error) {
+          boolean ignoreSSLUntrustedError = _options.ignoreUntrustedSSLError();
+          if(ignoreSSLUntrustedError && error.getPrimaryError() == SslError.SSL_UNTRUSTED) handler.proceed();
+          else {
+            super.onReceivedSslError(view, handler, error);
+          }
+        }
       }
+
+
     );
   }
 

--- a/ios/Plugin/InAppBrowserPlugin.swift
+++ b/ios/Plugin/InAppBrowserPlugin.swift
@@ -127,6 +127,7 @@ public class InAppBrowserPlugin: CAPPlugin {
         if toolbarType != "activity" {
             disclaimerContent = nil
         }
+        let ignoreUntrustedSSLError = call.getBool("ignoreUntrustedSSLError", false)
 
         self.isPresentAfterPageLoad = call.getBool("isPresentAfterPageLoad", false)
         let showReloadButton = call.getBool("showReloadButton", false)
@@ -162,6 +163,7 @@ public class InAppBrowserPlugin: CAPPlugin {
                 self.webViewController?.closeModalOk = closeModalOk
                 self.webViewController?.closeModalCancel = closeModalCancel
             }
+            self.webViewController?.ignoreUntrustedSSLError = ignoreUntrustedSSLError
             self.navigationWebViewController = UINavigationController.init(rootViewController: self.webViewController!)
             self.navigationWebViewController?.navigationBar.isTranslucent = false
             self.navigationWebViewController?.toolbar.isTranslucent = false

--- a/ios/Plugin/WKWebViewController.swift
+++ b/ios/Plugin/WKWebViewController.swift
@@ -89,6 +89,7 @@ open class WKWebViewController: UIViewController {
     open var closeModalDescription = ""
     open var closeModalOk = ""
     open var closeModalCancel = ""
+    open var ignoreUntrustedSSLError = false;
 
     func setHeaders(headers: [String: String]) {
         self.headers = headers
@@ -780,7 +781,21 @@ extension WKWebViewController: WKNavigationDelegate {
             let credential = URLCredential(trust: challenge.protectionSpace.serverTrust!)
             completionHandler(.useCredential, credential)
         } else {
-            completionHandler(.performDefaultHandling, nil)
+            guard self.ignoreUntrustedSSLError else {
+                completionHandler(.performDefaultHandling, nil)
+                return
+            }
+            /* allows to open links with self-signed certificates
+             Follow Apple's guidelines https://developer.apple.com/documentation/foundation/url_loading_system/handling_an_authentication_challenge/performing_manual_server_trust_authentication
+             */
+            guard let serverTrust = challenge.protectionSpace.serverTrust  else {
+                completionHandler(.useCredential, nil)
+                return
+            }
+            let credential = URLCredential(trust: serverTrust)
+            completionHandler(.useCredential, credential)
+            
+           
         }
     }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -205,6 +205,13 @@ export interface OpenWebViewOptions {
    * @default false
    */
   showArrow?: boolean;
+    /**
+   * ignoreUntrustedSSLError: if true, the webview will ignore untrusted SSL errors allowing the user to view the website.
+   *
+   * @since 6.1.0
+   * @default false
+   */
+    ignoreUntrustedSSLError?: boolean;
 }
 
 export interface InAppBrowserPlugin {


### PR DESCRIPTION
Support ignoring SSL certificate errors in the web view, allowing the user to continue browsing to the page as normal.

Fixes #122 