### PR TITLE
Enable file and image picker for Android

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -7,4 +7,6 @@
         <data android:scheme="http" />
       </intent>
     </queries>
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+  <uses-permission android:name="android.permission.CAMERA"/>
 </manifest>


### PR DESCRIPTION
There are multiple issues of the file picker and image picker not opening up for Android.

This PR adds the missing functionality to support Android file picker when using the plugin.

Additions:

- `handleOnActivityResult` to trigger the callback that will open the file system picker activity
- `openFileChooser` the method that makes the picker actually open

Fixes https://github.com/Cap-go/capacitor-inappbrowser/issues/113 and https://github.com/Cap-go/capacitor-inappbrowser/issues/64