### PR TITLE
Fix android clearCookies method

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -236,16 +236,9 @@ public class InAppBrowserPlugin
       CookieManager cookieManager = CookieManager.getInstance();
       String cookie = cookieManager.getCookie(url);
       if (cookie != null) {
-        String[] cookies = cookie.split(";");
-        for (String c : cookies) {
-          String cookieName = c.substring(0, c.indexOf("="));
-          cookieManager.setCookie(
-            url,
-            cookieName + "=; Expires=Thu, 01 Jan 1970 00:00:01 GMT"
-          );
-          if (clearCache) {
-            cookieManager.removeSessionCookie();
-          }
+        cookieManager.removeAllCookies(null);
+        if (Boolean.TRUE.equals(clearCache)) {
+          cookieManager.removeSessionCookies(null);
         }
       }
       call.resolve();


### PR DESCRIPTION
- Existing clearCookies method is not clearing/overwriting cookies that are set by the browser. Since the method is meant to clear all cookies instead of targeting specific cookie pairs anyways, this PR updates the method to call the `removeAllCookies` method instead.
- Also updated the call to `removeSessionCookie` (now deprecated) to use `removeSessionCookies` instead