### PR TITLE
[Android Only] Introduce "white panel mode" & hardware acceleration

### DIFF
--- a/FelixHealthInappbrowser.podspec
+++ b/FelixHealthInappbrowser.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'CapgoInappbrowser'
+  s.name = 'FelixHealthInappbrowser'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ setUrl(options: { url: string; }) => Promise<any>
 ### addListener('urlChangeEvent', ...)
 
 ```typescript
-addListener(eventName: 'urlChangeEvent', listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
+addListener(eventName: "urlChangeEvent", listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
 ```
 
 Listen for url change, only for openWebView
@@ -194,7 +194,7 @@ Listen for url change, only for openWebView
 ### addListener('closeEvent', ...)
 
 ```typescript
-addListener(eventName: 'closeEvent', listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
+addListener(eventName: "closeEvent", listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
 ```
 
 Listen for close click only for openWebView
@@ -214,7 +214,7 @@ Listen for close click only for openWebView
 ### addListener('confirmBtnClicked', ...)
 
 ```typescript
-addListener(eventName: 'confirmBtnClicked', listenerFunc: ConfirmBtnListener) => Promise<PluginListenerHandle>
+addListener(eventName: "confirmBtnClicked", listenerFunc: ConfirmBtnListener) => Promise<PluginListenerHandle>
 ```
 
 Will be triggered when user clicks on confirm button when disclaimer is required, works only on iOS
@@ -419,18 +419,18 @@ Construct a type with a set of properties K of type T
 
 | Members          | Value                     |
 | ---------------- | ------------------------- |
-| **`ACTIVITY`**   | <code>'activity'</code>   |
-| **`NAVIGATION`** | <code>'navigation'</code> |
-| **`BLANK`**      | <code>'blank'</code>      |
-| **`DEFAULT`**    | <code>''</code>           |
+| **`ACTIVITY`**   | <code>"activity"</code>   |
+| **`NAVIGATION`** | <code>"navigation"</code> |
+| **`BLANK`**      | <code>"blank"</code>      |
+| **`DEFAULT`**    | <code>""</code>           |
 
 
 #### BackgroundColor
 
 | Members     | Value                |
 | ----------- | -------------------- |
-| **`WHITE`** | <code>'white'</code> |
-| **`BLACK`** | <code>'black'</code> |
+| **`WHITE`** | <code>"white"</code> |
+| **`BLACK`** | <code>"black"</code> |
 
 </docgen-api>
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ Reload the current web page.
 | **`ignoreUntrustedSSLError`**          | <code>boolean</code>                                            | ignoreUntrustedSSLError: if true, the webview will ignore untrusted SSL errors allowing the user to view the website.                                                             | <code>false</code>                                         | 6.1.0  |
 | **`whitePanelMode`**                   | <code>boolean</code>                                            | useWhitePanelMode: Android only. If true, the webview will override the system theme to show status bar and navigation bar in white color.                                        |                                                            |        |
 | **`enableHardwareAcceleration`**       | <code>boolean</code>                                            | enableHardwareAcceleration: Android only. If true, the webview will use hardware acceleration to render the web content.                                                          |                                                            |        |
+| **`autoclosePatterns`**                | <code>string[]</code>                                           | autoclosePatterns: Whenever a URL matches any of the patterns, the webview will be closed automatically.                                                                          |                                                            |        |
 
 
 #### DisclaimerOptions

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ setUrl(options: { url: string; }) => Promise<any>
 ### addListener('urlChangeEvent', ...)
 
 ```typescript
-addListener(eventName: "urlChangeEvent", listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
+addListener(eventName: 'urlChangeEvent', listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
 ```
 
 Listen for url change, only for openWebView
@@ -194,7 +194,7 @@ Listen for url change, only for openWebView
 ### addListener('closeEvent', ...)
 
 ```typescript
-addListener(eventName: "closeEvent", listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
+addListener(eventName: 'closeEvent', listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
 ```
 
 Listen for close click only for openWebView
@@ -214,7 +214,7 @@ Listen for close click only for openWebView
 ### addListener('confirmBtnClicked', ...)
 
 ```typescript
-addListener(eventName: "confirmBtnClicked", listenerFunc: ConfirmBtnListener) => Promise<PluginListenerHandle>
+addListener(eventName: 'confirmBtnClicked', listenerFunc: ConfirmBtnListener) => Promise<PluginListenerHandle>
 ```
 
 Will be triggered when user clicks on confirm button when disclaimer is required, works only on iOS
@@ -326,6 +326,8 @@ Reload the current web page.
 | **`toolbarColor`**                     | <code>string</code>                                             | toolbarColor: color of the toolbar in hex format                                                                                                                                  | <code>'#ffffff''</code>                                    | 1.2.5  |
 | **`showArrow`**                        | <code>boolean</code>                                            | showArrow: if true an arrow would be shown instead of cross for closing the window                                                                                                | <code>false</code>                                         | 1.2.5  |
 | **`ignoreUntrustedSSLError`**          | <code>boolean</code>                                            | ignoreUntrustedSSLError: if true, the webview will ignore untrusted SSL errors allowing the user to view the website.                                                             | <code>false</code>                                         | 6.1.0  |
+| **`whitePanelMode`**                   | <code>boolean</code>                                            | useWhitePanelMode: Android only. If true, the webview will override the system theme to show status bar and navigation bar in white color.                                        |                                                            |        |
+| **`enableHardwareAcceleration`**       | <code>boolean</code>                                            | enableHardwareAcceleration: Android only. If true, the webview will use hardware acceleration to render the web content.                                                          |                                                            |        |
 
 
 #### DisclaimerOptions
@@ -417,18 +419,18 @@ Construct a type with a set of properties K of type T
 
 | Members          | Value                     |
 | ---------------- | ------------------------- |
-| **`ACTIVITY`**   | <code>"activity"</code>   |
-| **`NAVIGATION`** | <code>"navigation"</code> |
-| **`BLANK`**      | <code>"blank"</code>      |
-| **`DEFAULT`**    | <code>""</code>           |
+| **`ACTIVITY`**   | <code>'activity'</code>   |
+| **`NAVIGATION`** | <code>'navigation'</code> |
+| **`BLANK`**      | <code>'blank'</code>      |
+| **`DEFAULT`**    | <code>''</code>           |
 
 
 #### BackgroundColor
 
 | Members     | Value                |
 | ----------- | -------------------- |
-| **`WHITE`** | <code>"white"</code> |
-| **`BLACK`** | <code>"black"</code> |
+| **`WHITE`** | <code>'white'</code> |
+| **`BLACK`** | <code>'black'</code> |
 
 </docgen-api>
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -338,6 +338,16 @@ public class InAppBrowserPlugin
         }
       }
     );
+
+    options.setUseWhitePanelMode(call.getBoolean("whitePanelMode", false));
+    options.setUseHardwareAcceleration(
+      call.getBoolean("enableHardwareAcceleration", false)
+    );
+
+    boolean useWhitePanelMode = options.useWhitePanelMode();
+    int defaultTheme = android.R.style.Theme_NoTitleBar;
+    int lightPanelTheme = android.R.style.Theme_Light_Panel;
+
     this.getActivity()
       .runOnUiThread(
         new Runnable() {
@@ -345,7 +355,7 @@ public class InAppBrowserPlugin
           public void run() {
             webViewDialog = new WebViewDialog(
               getContext(),
-              android.R.style.Theme_NoTitleBar,
+              useWhitePanelMode ? lightPanelTheme : defaultTheme,
               options,
               InAppBrowserPlugin.this
             );

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -17,6 +17,7 @@ import androidx.browser.customtabs.CustomTabsClient;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.browser.customtabs.CustomTabsServiceConnection;
 import androidx.browser.customtabs.CustomTabsSession;
+import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PermissionState;
 import com.getcapacitor.Plugin;
@@ -26,6 +27,7 @@ import com.getcapacitor.annotation.ActivityCallback;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
 import com.getcapacitor.annotation.PermissionCallback;
+import java.lang.reflect.Array;
 import java.util.Iterator;
 
 @CapacitorPlugin(
@@ -347,6 +349,10 @@ public class InAppBrowserPlugin
     boolean useWhitePanelMode = options.useWhitePanelMode();
     int defaultTheme = android.R.style.Theme_NoTitleBar;
     int lightPanelTheme = android.R.style.Theme_Light_Panel;
+
+    options.setAutoClosePatterns(
+      call.getArray("autoclosePatterns", new JSArray())
+    );
 
     this.getActivity()
       .runOnUiThread(

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
@@ -1,5 +1,6 @@
 package ee.forgr.capacitor_inappbrowser;
 
+import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PluginCall;
 
@@ -27,6 +28,7 @@ public class Options {
   private boolean ignoreUntrustedSSLError;
   private boolean useWhitePanelMode;
   private boolean useHardwareAcceleration;
+  private JSArray autoClosePatterns;
 
   public PluginCall getPluginCall() {
     return pluginCall;
@@ -216,5 +218,13 @@ public class Options {
 
   public void setUseHardwareAcceleration(boolean _useHardwareAcceleration) {
     this.useHardwareAcceleration = _useHardwareAcceleration;
+  }
+
+  public JSArray getAutoClosePatterns() {
+    return autoClosePatterns;
+  }
+
+  public void setAutoClosePatterns(JSArray autoClosePatterns) {
+    this.autoClosePatterns = autoClosePatterns;
   }
 }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
@@ -25,6 +25,8 @@ public class Options {
   private String ToolbarColor;
   private boolean ShowArrow;
   private boolean ignoreUntrustedSSLError;
+  private boolean useWhitePanelMode;
+  private boolean useHardwareAcceleration;
 
   public PluginCall getPluginCall() {
     return pluginCall;
@@ -198,5 +200,21 @@ public class Options {
 
   public void setIgnoreUntrustedSSLError(boolean _ignoreUntrustedSSLError) {
     this.ignoreUntrustedSSLError = _ignoreUntrustedSSLError;
+  }
+
+  public boolean useWhitePanelMode() {
+    return useWhitePanelMode;
+  }
+
+  public void setUseWhitePanelMode(boolean _useWhitePanelMode) {
+    this.useWhitePanelMode = _useWhitePanelMode;
+  }
+
+  public boolean useHardwareAcceleration() {
+    return useHardwareAcceleration;
+  }
+
+  public void setUseHardwareAcceleration(boolean _useHardwareAcceleration) {
+    this.useHardwareAcceleration = _useHardwareAcceleration;
   }
 }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -71,11 +71,23 @@ public class WebViewDialog extends Dialog {
   public void presentWebView() {
     requestWindowFeature(Window.FEATURE_NO_TITLE);
     setCancelable(true);
-    getWindow()
-      .setFlags(
-        WindowManager.LayoutParams.FLAG_FULLSCREEN,
-        WindowManager.LayoutParams.FLAG_FULLSCREEN
-      );
+    if (!_options.useWhitePanelMode()) {
+      getWindow()
+        .setFlags(
+          WindowManager.LayoutParams.FLAG_FULLSCREEN,
+          WindowManager.LayoutParams.FLAG_FULLSCREEN
+        );
+    }
+
+    if (_options.useHardwareAcceleration()) {
+      // Enable hardware acceleration for the webdialog window
+      getWindow()
+        .setFlags(
+          WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED,
+          WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED
+        );
+    }
+
     setContentView(R.layout.activity_browser);
     getWindow()
       .setLayout(
@@ -84,6 +96,16 @@ public class WebViewDialog extends Dialog {
       );
 
     this._webView = findViewById(R.id.browser_view);
+
+    if (_options.useHardwareAcceleration()) {
+      // Enable hardware acceleration
+      _webView.setLayerType(View.LAYER_TYPE_HARDWARE, null);
+    }
+
+    if (_options.useWhitePanelMode()) {
+      // Show a white view until the page is loaded
+      _webView.setBackgroundColor(Color.WHITE);
+    }
 
     _webView.getSettings().setJavaScriptEnabled(true);
     _webView.getSettings().setJavaScriptCanOpenWindowsAutomatically(true);

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -29,8 +29,10 @@ import android.widget.ImageButton;
 import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.Toolbar;
+import com.getcapacitor.JSArray;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -121,6 +123,9 @@ public class WebViewDialog extends Dialog {
     _webView.getSettings().setAllowUniversalAccessFromFileURLs(true);
 
     _webView.setWebViewClient(new WebViewClient());
+
+    getWindow().getAttributes().windowAnimations =
+      com.google.android.material.R.style.Animation_Design_BottomSheetDialog;
 
     _webView.setWebChromeClient(
       new WebChromeClient() {
@@ -407,6 +412,19 @@ public class WebViewDialog extends Dialog {
         @Override
         public void onPageStarted(WebView view, String url, Bitmap favicon) {
           super.onPageStarted(view, url, favicon);
+          if (_options.getAutoClosePatterns().length() != 0) {
+            try {
+              String path = new URL(url).getPath();
+              if (_options.getAutoClosePatterns().toList().contains(path)) {
+                dismiss();
+                _options.getCallbacks().urlChangeEvent(url);
+                _webView.destroy();
+              }
+            } catch (Exception e) {
+              Log.e("AUTOCLOSE", "Unable to cast autoclose params");
+            }
+          }
+
           try {
             URI uri = new URI(url);
             if (TextUtils.isEmpty(_options.getTitle())) {

--- a/android/src/main/res/values/colors.xml
+++ b/android/src/main/res/values/colors.xml
@@ -2,4 +2,5 @@
 <resources>
     <color name="disable">#36262626</color>
     <color name="enable">#262626</color>
+    <color name="white">#FFFFFF</color>
 </resources>

--- a/ios/Plugin/InAppBrowserPlugin.swift
+++ b/ios/Plugin/InAppBrowserPlugin.swift
@@ -132,6 +132,8 @@ public class InAppBrowserPlugin: CAPPlugin {
         self.isPresentAfterPageLoad = call.getBool("isPresentAfterPageLoad", false)
         let showReloadButton = call.getBool("showReloadButton", false)
 
+        let autoClosePatterns = call.getArray("autoclosePatterns", [])
+
         DispatchQueue.main.async {
             let url = URL(string: urlString)
 
@@ -147,6 +149,7 @@ public class InAppBrowserPlugin: CAPPlugin {
             self.webViewController?.leftNavigationBarItemTypes = self.getToolbarItems(toolbarType: toolbarType)
             self.webViewController?.toolbarItemTypes = []
             self.webViewController?.doneBarButtonItemPosition = .right
+            self.webViewController?.autoClosePatterns = autoClosePatterns.map { $0 as! String }
             if call.getBool("showArrow", false) {
                 self.webViewController?.stopBarButtonItemImage = UIImage(named: "Forward@3x", in: Bundle(for: InAppBrowserPlugin.self), compatibleWith: nil)
             }

--- a/ios/Plugin/WKWebViewController.swift
+++ b/ios/Plugin/WKWebViewController.swift
@@ -91,6 +91,7 @@ open class WKWebViewController: UIViewController {
     open var closeModalCancel = ""
     open var ignoreUntrustedSSLError = false
     var viewWasPresented = false
+    open var autoClosePatterns: [String] = []
 
     func setHeaders(headers: [String: String]) {
         self.headers = headers
@@ -343,6 +344,23 @@ open class WKWebViewController: UIViewController {
                 self.navigationItem.title = webView?.url?.host
             }
         case "URL":
+            if self.autoClosePatterns.count != 0 {
+                if #available(iOS 16.0, *) {
+                    if let newPath = webView?.url?.path() {
+                        if self.autoClosePatterns.contains(newPath) {
+                            self.closeView()
+                        }
+                    }
+                } else {
+                    // To remove as soon as iOS < 16 is no longer supported
+                    if let fullUrl = webView?.url {
+                        let path = fullUrl.lastPathComponent == "/" ? "/" : "/" + fullUrl.lastPathComponent
+                        if self.autoClosePatterns.contains(path) {
+                            self.closeView()
+                        }
+                    }
+                }
+            }
             self.capBrowserPlugin?.notifyListeners("urlChangeEvent", data: ["url": webView?.url?.absoluteString ?? ""])
         default:
             super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
@@ -743,6 +761,7 @@ extension WKWebViewController: WKUIDelegate {
 extension WKWebViewController: WKNavigationDelegate {
     public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         updateBarButtonItems()
+
         self.progressView?.progress = 0
         if let u = webView.url {
             self.url = u

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@capgo/inappbrowser",
+  "name": "@felix-health/inappbrowser",
   "version": "6.0.27",
-  "description": "Capacitor plugin in app browser",
+  "description": "Capacitor plugin in app browser | Felix Health fork",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
@@ -13,14 +13,14 @@
     "ios/Plugin/",
     "CapgoInappbrowser.podspec"
   ],
-  "author": "Martin Donadieu",
+  "author": "Martin Donadieu + Felix Health",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Cap-go/capacitor-inappbrowser.git"
+    "url": "git+https://github.com/Felix-Health/capacitor-inappbrowser.git"
   },
   "bugs": {
-    "url": "https://github.com/Cap-go/capacitor-inappbrowser/issues"
+    "url": "https://github.com/Felix-Health/capacitor-inappbrowser/issues"
   },
   "keywords": [
     "capacitor",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felix-health/inappbrowser",
-  "version": "6.0.30",
+  "version": "6.0.31",
   "description": "Capacitor plugin in app browser | Felix Health fork",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felix-health/inappbrowser",
-  "version": "6.0.28",
+  "version": "6.0.29",
   "description": "Capacitor plugin in app browser | Felix Health fork",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "android/build.gradle",
     "dist/",
     "ios/Plugin/",
-    "CapgoInappbrowser.podspec"
+    "FelixHealthInappbrowser.podspec"
   ],
   "author": "Martin Donadieu + Felix Health",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felix-health/inappbrowser",
-  "version": "6.0.27",
+  "version": "6.0.28",
   "description": "Capacitor plugin in app browser | Felix Health fork",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felix-health/inappbrowser",
-  "version": "6.0.31",
+  "version": "6.0.32",
   "description": "Capacitor plugin in app browser | Felix Health fork",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felix-health/inappbrowser",
-  "version": "6.0.29",
+  "version": "6.0.30",
   "description": "Capacitor plugin in app browser | Felix Health fork",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -212,6 +212,14 @@ export interface OpenWebViewOptions {
    * @default false
    */
   ignoreUntrustedSSLError?: boolean;
+  /**
+   * useWhitePanelMode: Android only. If true, the webview will override the system theme to show status bar and navigation bar in white color.
+   */
+  whitePanelMode?: boolean;
+  /**
+   * enableHardwareAcceleration: Android only. If true, the webview will use hardware acceleration to render the web content.
+   */
+  enableHardwareAcceleration?: boolean;
 }
 
 export interface InAppBrowserPlugin {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -220,6 +220,10 @@ export interface OpenWebViewOptions {
    * enableHardwareAcceleration: Android only. If true, the webview will use hardware acceleration to render the web content.
    */
   enableHardwareAcceleration?: boolean;
+  /**
+   * autoclosePatterns: Whenever a URL matches any of the patterns, the webview will be closed automatically.
+   */
+  autoclosePatterns?: string[];
 }
 
 export interface InAppBrowserPlugin {


### PR DESCRIPTION
This pull request introduces two new features for **Android only**:

## Hardware Acceleration

Android WebViews are not as performant as their iOS counterparts and do not use hardware acceleration by default. By enabling hardware acceleration, the main render loop delivers a smoother experience and enhances performance.

This feature is introduced as an optional flag due to potential battery life tradeoffs on lower-end devices. To enable hardware acceleration, pass `enableHardwareAcceleration` to the config object.

**Note**: There is no equivalent feature for iOS, and it is not needed. Thus, this is an Android-specific feature.

## "White Panel Mode"

In some cases, developers may want to offer a sleeker experience or achieve parity between iOS and Android rendering of specific pages. 

By enabling "White Panel Mode":

- The WebView will use `Theme_Light_Panel` instead of `Theme_NoTitleBar`. This makes the safe areas render using the light theme and the system status bar visible.
- The background of the WebView changes to white, improving the perceived performance of the loading website by preventing a blink effect from black to white.

We decided to group these changes together as they both enhance cross-platform consistency and perceived performance optimizations for Android.