### PR TITLE
feat: use preventDeeplink parameter also on ios

### DIFF
--- a/ios/Plugin/InAppBrowserPlugin.swift
+++ b/ios/Plugin/InAppBrowserPlugin.swift
@@ -124,6 +124,7 @@ public class InAppBrowserPlugin: CAPPlugin {
         let closeModalOk = call.getString("closeModalOk", "OK")
         let closeModalCancel = call.getString("closeModalCancel", "Cancel")
         let isInspectable = call.getBool("isInspectable", false)
+        let preventDeeplink = call.getBool("preventDeeplink", false)
         let isAnimated = call.getBool("isAnimated", true)
 
         var disclaimerContent = call.getObject("shareDisclaimer")
@@ -141,10 +142,11 @@ public class InAppBrowserPlugin: CAPPlugin {
             let url = URL(string: urlString)
 
             if self.isPresentAfterPageLoad {
-                self.webViewController = WKWebViewController.init(url: url!, headers: headers, isInspectable: isInspectable)
+                self.webViewController = WKWebViewController.init(url: url!, headers: headers, isInspectable: isInspectable, preventDeeplink: preventDeeplink)
             } else {
                 self.webViewController = WKWebViewController.init()
                 self.webViewController?.setHeaders(headers: headers)
+                self.webViewController?.setPreventDeeplink(preventDeeplink: preventDeeplink)
             }
 
             self.webViewController?.source = .remote(url!)
@@ -250,6 +252,7 @@ public class InAppBrowserPlugin: CAPPlugin {
         }
 
         let isInspectable = call.getBool("isInspectable", false)
+        let preventDeeplink = call.getBool("preventDeeplink", false)
 
         self.currentPluginCall = call
 
@@ -271,10 +274,11 @@ public class InAppBrowserPlugin: CAPPlugin {
             let url = URL(string: urlString)
 
             if self.isPresentAfterPageLoad {
-                self.webViewController = WKWebViewController.init(url: url!, headers: headers, isInspectable: isInspectable)
+                self.webViewController = WKWebViewController.init(url: url!, headers: headers, isInspectable: isInspectable, preventDeeplink: preventDeeplink)
             } else {
                 self.webViewController = WKWebViewController.init()
                 self.webViewController?.setHeaders(headers: headers)
+                self.webViewController?.setPreventDeeplink(preventDeeplink: preventDeeplink)
             }
 
             self.webViewController?.source = .remote(url!)

--- a/ios/Plugin/WKWebViewController.swift
+++ b/ios/Plugin/WKWebViewController.swift
@@ -12,6 +12,7 @@ import WebKit
 private let estimatedProgressKeyPath = "estimatedProgress"
 private let titleKeyPath = "title"
 private let cookieKey = "Cookie"
+private let preventDeeplink: Bool = false
 
 private struct UrlsHandledByApp {
     static var hosts = ["itunes.apple.com"]
@@ -60,10 +61,11 @@ open class WKWebViewController: UIViewController {
         self.initWebview()
     }
 
-    public init(url: URL, headers: [String: String], isInspectable: Bool) {
+    public init(url: URL, headers: [String: String], isInspectable: Bool, preventDeeplink: Bool) {
         super.init(nibName: nil, bundle: nil)
         self.source = .remote(url)
         self.setHeaders(headers: headers)
+        self.preventDeeplink = preventDeeplink
         self.initWebview(isInspectable: isInspectable)
     }
 
@@ -804,6 +806,11 @@ extension WKWebViewController: WKNavigationDelegate {
 
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         var actionPolicy: WKNavigationActionPolicy = .allow
+
+        if self.preventDeeplink {
+            actionPolicy = .preventDeeplinkActionPolicy
+        }
+
         defer {
             decisionHandler(actionPolicy)
         }
@@ -837,4 +844,8 @@ extension WKWebViewController: WKNavigationDelegate {
 class BlockBarButtonItem: UIBarButtonItem {
 
     var block: ((WKWebViewController) -> Void)?
+}
+
+extension WKNavigationActionPolicy {
+    static let preventDeeplinkActionPolicy = WKNavigationActionPolicy(rawValue: WKNavigationActionPolicy.allow.rawValue + 2)!
 }


### PR DESCRIPTION
The parameter 'preventDeeplink' already exists in the API - but so far it is only used in Android.
With this PR, the parameter is also used in the iOS part.