### PR TITLE
Add support for Android intent url scheme

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -588,7 +588,7 @@ public class WebViewDialog extends Dialog {
             } catch (ActivityNotFoundException e) {
               // Do nothing
             } catch (URISyntaxException e) {
-              // Do nothin
+              // Do nothing
             }
           }
           return false;

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -588,7 +588,7 @@ public class WebViewDialog extends Dialog {
             } catch (ActivityNotFoundException e) {
               // Do nothing
             } catch (URISyntaxException e) {
-              throw new RuntimeException(e);
+              // Do nothin
             }
           }
           return false;

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -575,12 +575,20 @@ public class WebViewDialog extends Dialog {
 
           if (!url.startsWith("https://") && !url.startsWith("http://")) {
             try {
-              Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+              Intent intent;
+              if (url.startsWith("intent://")) {
+                intent = Intent.parseUri(url, Intent.URI_INTENT_SCHEME);
+              } else {
+                intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+              }
+
               intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
               context.startActivity(intent);
               return true;
             } catch (ActivityNotFoundException e) {
               // Do nothing
+            } catch (URISyntaxException e) {
+              throw new RuntimeException(e);
             }
           }
           return false;


### PR DESCRIPTION
Android supports the intent:// url scheme, currently these do not work in the InAppBrowser. Building on the work that is done for PR #108, it is an easy fix to support these.

I encountered the URL scheme as the dutch bank ABN Ambro uses it to open their banking app.