### PR TITLE
feat: use preventDeeplink parameter also on ios

### DIFF
--- a/ios/Plugin/InAppBrowserPlugin.swift
+++ b/ios/Plugin/InAppBrowserPlugin.swift
@@ -179,6 +179,7 @@ public class InAppBrowserPlugin: CAPPlugin {
         let closeModalOk = call.getString("closeModalOk", "OK")
         let closeModalCancel = call.getString("closeModalCancel", "Cancel")
         let isInspectable = call.getBool("isInspectable", false)
+        let preventDeeplink = call.getBool("preventDeeplink", false)
         let isAnimated = call.getBool("isAnimated", true)
 
         var disclaimerContent = call.getObject("shareDisclaimer")
@@ -198,11 +199,12 @@ public class InAppBrowserPlugin: CAPPlugin {
             let url = URL(string: urlString)
 
             if self.isPresentAfterPageLoad {
-                self.webViewController = WKWebViewController.init(url: url!, headers: headers, isInspectable: isInspectable, credentials: credentials)
+                self.webViewController = WKWebViewController.init(url: url!, headers: headers, isInspectable: isInspectable, credentials: credentials, preventDeeplink: preventDeeplink)
             } else {
                 self.webViewController = WKWebViewController.init()
                 self.webViewController?.setHeaders(headers: headers)
                 self.webViewController?.setCredentials(credentials: credentials)
+                self.webViewController?.setPreventDeeplink(preventDeeplink: preventDeeplink)
             }
 
             self.webViewController?.source = .remote(url!)
@@ -327,6 +329,7 @@ public class InAppBrowserPlugin: CAPPlugin {
         }
 
         let isInspectable = call.getBool("isInspectable", false)
+        let preventDeeplink = call.getBool("preventDeeplink", false)
 
         self.currentPluginCall = call
 
@@ -350,11 +353,12 @@ public class InAppBrowserPlugin: CAPPlugin {
             let url = URL(string: urlString)
 
             if self.isPresentAfterPageLoad {
-                self.webViewController = WKWebViewController.init(url: url!, headers: headers, isInspectable: isInspectable, credentials: credentials)
+                self.webViewController = WKWebViewController.init(url: url!, headers: headers, isInspectable: isInspectable, credentials: credentials, preventDeeplink: preventDeeplink)
             } else {
                 self.webViewController = WKWebViewController.init()
                 self.webViewController?.setHeaders(headers: headers)
                 self.webViewController?.setCredentials(credentials: credentials)
+                self.webViewController?.setPreventDeeplink(preventDeeplink: preventDeeplink)
             }
 
             self.webViewController?.source = .remote(url!)


### PR DESCRIPTION
The parameter 'preventDeeplink' already exists in the API - but so far it is only used in Android.
With this PR, the parameter is also used in the iOS part.

This line here may look quite weird, but it works:     static let preventDeeplinkActionPolicy = WKNavigationActionPolicy(rawValue: WKNavigationActionPolicy.allow.rawValue + 2)!

source: https://stackoverflow.com/a/52425266/4685928