### PR TITLE
feat: close webview from within

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -333,6 +333,9 @@ public class WebViewDialog extends Dialog {
       "            if (window.AndroidInterface) { " +
       "                window.AndroidInterface.postMessage(JSON.stringify(message)); " +
       "            } " +
+      "        }, " +
+      "        close: function() { " +
+      "            window.AndroidInterface.close(); " +
       "        } " +
       "    }; " +
       "}";

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -132,6 +132,21 @@ public class WebViewDialog extends Dialog {
       // Handle message from JavaScript
       _options.getCallbacks().javascriptCallback(message);
     }
+
+    @JavascriptInterface
+    public void close() {
+      // close webview
+      activity.runOnUiThread(
+        new Runnable() {
+          @Override
+          public void run() {
+            dismiss();
+            _options.getCallbacks().closeEvent(_webView.getUrl());
+            _webView.destroy();
+          }
+        }
+      );
+    }
   }
 
   public class PreShowScriptInterface {

--- a/ios/Plugin/WKWebViewController.swift
+++ b/ios/Plugin/WKWebViewController.swift
@@ -280,6 +280,9 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
                                         if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.messageHandler) {
                                                 window.webkit.messageHandlers.messageHandler.postMessage(message);
                                         }
+                                },
+                                close: function() {
+                                        window.webkit.messageHandlers.close.postMessage(null);
                                 }
                         };
                 }

--- a/ios/Plugin/WKWebViewController.swift
+++ b/ios/Plugin/WKWebViewController.swift
@@ -267,6 +267,8 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
             }
             print("[InAppBrowser - preShowScriptError]: Error!!!!")
             semaphore.signal()
+        } else if message.name == "close" {
+          closeView()
         }
     }
 
@@ -299,6 +301,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
         userContentController.add(self, name: "messageHandler")
         userContentController.add(self, name: "preShowScriptError")
         userContentController.add(self, name: "preShowScriptSuccess")
+        userContentController.add(self, name: "close")
         webConfiguration.userContentController = userContentController
         let webView = WKWebView(frame: .zero, configuration: webConfiguration)
 


### PR DESCRIPTION
Hey, I added the functionality to close the webview from within via javascript.

Android:
`window.AndroidInterface.close();`

iOS:
`window.webkit.messageHandlers.close.postMessage(null);`

If you think that would be a good addition, let me know. If you would change the implementation also let me know.
All the best!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled seamless closing of web views via JavaScript on both Android and iOS platforms, allowing pages to trigger view closures directly for a smoother and more interactive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->