### PR TITLE
feat: add text zoom option with openWebView

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -428,6 +428,8 @@ public class InAppBrowserPlugin
       Boolean.TRUE.equals(call.getBoolean("ignoreUntrustedSSLError", false))
     );
 
+    options.setTextZoom(call.getDouble("textZoom"));
+
     String proxyRequestsStr = call.getString("proxyRequests");
     if (proxyRequestsStr != null) {
       try {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
@@ -131,6 +131,7 @@ public class Options {
   private boolean ignoreUntrustedSSLError;
   private String preShowScript;
   private Pattern proxyRequestsPattern = null;
+  private Double textZoom;
 
   public Pattern getProxyRequestsPattern() {
     return proxyRequestsPattern;
@@ -154,6 +155,14 @@ public class Options {
 
   public void setTitle(String title) {
     this.title = title;
+  }
+
+  public Double getTextZoom() {
+    return textZoom;
+  }
+
+  public void setTextZoom(Double textZoom) {
+    this.textZoom = textZoom;
   }
 
   public boolean getCloseModal() {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -191,7 +191,10 @@ public class WebViewDialog extends Dialog {
     _webView.getSettings().setAllowFileAccessFromFileURLs(true);
     _webView.getSettings().setAllowUniversalAccessFromFileURLs(true);
     _webView.getSettings().setMediaPlaybackRequiresUserGesture(false);
-
+    //text zoom
+    int rounded = (int) Math.round(_options.getTextZoom() * 100);
+    _webView.getSettings().setTextZoom(rounded);
+    
     _webView.setWebViewClient(new WebViewClient());
 
     _webView.setWebChromeClient(

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -257,6 +257,10 @@ export interface OpenWebViewOptions {
       height?: number;
     };
   };
+  /**
+   * text zoom in webview, 1.0 is 100%, 1.2 is 120%
+   */
+  textZoom?: number
 }
 
 export interface InAppBrowserPlugin {


### PR DESCRIPTION
Original Issue #240 
I try to fix it
Here is an example how to use it
```
await InAppBrowser.openWebView({
      url: 'your url',
      textZoom: 1.5,  // 1.0 = 100%; 1.2 = 120%
      //...some other options
})
```
