### PR TITLE
feat: add an explicit mode for a toolbar with just a close button

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,7 @@ Construct a type with a set of properties K of type T
 | **`ACTIVITY`**   | <code>"activity"</code>   | Shows a simple toolbar with just a close button and share button | 0.1.0 |
 | **`NAVIGATION`** | <code>"navigation"</code> | Shows a full navigation toolbar with back/forward buttons        | 0.1.0 |
 | **`BLANK`**      | <code>"blank"</code>      | Shows no toolbar                                                 | 0.1.0 |
+| **`COMPACT`**    | <code>"compact"</code>    | Shows a simple toolbar with just a close button                  | 7.6.8 |
 
 
 #### BackgroundColor

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -32,6 +32,11 @@ export enum ToolBarType {
    */
   ACTIVITY = "activity",
   /**
+   * Shows a simple toolbar with just a close button
+   * @since 7.6.8
+   */
+  COMPACT = "compact",
+  /**
    * Shows a full navigation toolbar with back/forward buttons
    * @since 0.1.0
    */


### PR DESCRIPTION
We'd like to have a close button without a share button, see also #272

If there is no Toolbar Type provided, e.g. ACTIVITY/NAVIGATION, the code just shows a toolbar with a close button. That's why I introduce Toolbartype COMPACT

Using Toolbartype COMPACT the toolbar looks like this on iOS:
<img width="469" alt="image" src="https://github.com/user-attachments/assets/64136689-55bb-410a-adab-b01476dfef4e" />
on Android:
![image](https://github.com/user-attachments/assets/c2a5cbd8-9ade-4072-8822-de4693eebf49)
