### PR TITLE
fix: actually implement background color of the browser

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -450,6 +450,7 @@ public class InAppBrowserPlugin
       options.setTitle(call.getString("title", ""));
     }
     options.setToolbarColor(call.getString("toolbarColor", "#ffffff"));
+    options.setBackgroundColor(call.getString("backgroundColor", "black"));
     options.setToolbarTextColor(call.getString("toolbarTextColor"));
     options.setArrow(Boolean.TRUE.equals(call.getBoolean("showArrow", false)));
     options.setIgnoreUntrustedSSLError(

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
@@ -167,6 +167,7 @@ public class Options {
   private PluginCall pluginCall;
   private boolean VisibleTitle;
   private String ToolbarColor;
+  private String BackgroundColor;
   private boolean ShowArrow;
   private boolean ignoreUntrustedSSLError;
   private String preShowScript;
@@ -372,6 +373,14 @@ public class Options {
 
   public void setToolbarColor(String toolbarColor) {
     this.ToolbarColor = toolbarColor;
+  }
+
+  public String getBackgroundColor() {
+    return BackgroundColor;
+  }
+
+  public void setBackgroundColor(String backgroundColor) {
+    this.BackgroundColor = backgroundColor;
   }
 
   public String getToolbarTextColor() {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -328,6 +328,10 @@ public class WebViewDialog extends Dialog {
     _webView.getSettings().setAllowUniversalAccessFromFileURLs(true);
     _webView.getSettings().setMediaPlaybackRequiresUserGesture(false);
 
+    // Set web view background color
+    int backgroundColor = _options.getBackgroundColor().equals("white") ? Color.WHITE : Color.BLACK;
+    _webView.setBackgroundColor(backgroundColor);
+
     // Set text zoom if specified in options
     if (_options.getTextZoom() > 0) {
       _webView.getSettings().setTextZoom(_options.getTextZoom());

--- a/ios/Plugin/InAppBrowserPlugin.swift
+++ b/ios/Plugin/InAppBrowserPlugin.swift
@@ -484,6 +484,9 @@ public class InAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
             self.navigationWebViewController?.navigationBar.setValue(true, forKey: "hidesShadow")
             self.navigationWebViewController?.toolbar.setShadowImage(UIImage(), forToolbarPosition: .any)
 
+            // Handle web view background color
+            webViewController.view.backgroundColor = backgroundColor
+
             // Handle toolbar color
             if let toolbarColor = call.getString("toolbarColor"), self.isHexColorCode(toolbarColor) {
                 // If specific color provided, use it


### PR DESCRIPTION
There is already an option backgroundcolor, but it wasn't used. Now it sets the background of webview. Currently the background is just black (also the new default). When opening a white website it is nicer to have a white color

**Current**
(There is black flash when the inAppBrowser opens on both iOS and Android)
![Current](https://github.com/user-attachments/assets/3c53b65c-b46a-459c-9b89-a1ed3a3a48d9)

**Expected**
With Background Color White there is still a flash page opens, but because it is white it looks nicer
![Expected](https://github.com/user-attachments/assets/77ba3790-e66f-4b31-b31c-4ab10f82505c)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled customizable background colors for in-app web views, allowing users to benefit from a more personalized visual experience on both Android and iOS. The new functionality applies a preferred background color—defaulting to black if unspecified—enhancing the overall app theme consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->