### PR TITLE
feat: add support for user certificate selection (mutual TLS) in WebView

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -24,6 +24,8 @@ import android.print.PrintAttributes;
 import android.print.PrintDocumentAdapter;
 import android.print.PrintManager;
 import android.provider.MediaStore;
+import android.security.KeyChain;
+import android.security.KeyChainAliasCallback;
 import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Log;
@@ -65,6 +67,8 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -2151,6 +2155,41 @@ public class WebViewDialog extends Dialog {
             }
           }
           return false;
+        }
+
+        @Override
+        public void onReceivedClientCertRequest(WebView view, android.webkit.ClientCertRequest request) {
+          Log.i("InAppBrowser", "onReceivedClientCertRequest CALLED");
+          Log.i("InAppBrowser", "Host: " + request.getHost());
+          Log.i("InAppBrowser", "Port: " + request.getPort());
+          Log.i("InAppBrowser", "Principals: " + java.util.Arrays.toString(request.getPrincipals()));
+          Log.i("InAppBrowser", "KeyTypes: " + java.util.Arrays.toString(request.getKeyTypes()));
+
+          KeyChain.choosePrivateKeyAlias(activity, new KeyChainAliasCallback() {
+              @Override
+              public void alias(String alias) {
+                if (alias != null) {
+                  try {
+                    PrivateKey privateKey = KeyChain.getPrivateKey(activity, alias);
+                    X509Certificate[] certChain = KeyChain.getCertificateChain(activity, alias);
+                    request.proceed(privateKey, certChain);
+                    Log.i("InAppBrowser", "Selected certificate: " + alias);
+                  } catch (Exception e) {
+                    request.cancel();
+                    Log.e("InAppBrowser", "Error selecting certificate: " + e.getMessage());
+                  }
+                } else {
+                  request.cancel();
+                  Log.i("InAppBrowser", "No certificate found");
+                }
+              }
+            },
+            null, // keyTypes
+            null, // issuers
+            request.getHost(),
+            request.getPort(),
+            null // alias (null = system asks user to choose)
+          );
         }
 
         private String randomRequestId() {


### PR DESCRIPTION
### Summary

Adds support for client certificate authentication in the InAppBrowser WebView on Android. When a website requests a client certificate, the Android system certificate selector is shown so the user can choose the appropriate certificate.

### Details

- Implements `onReceivedClientCertRequest` in the Android WebView.
- Uses `KeyChain.choosePrivateKeyAlias` to prompt the user for certificate selection.
- If the user selects a certificate, it is used for the TLS handshake.
- If no certificate is found or the user cancels, the request is canceled.
- Adds logging for debugging (host, port, key types).

### Motivation

Some secure sites (such as government or enterprise portals) require client certificate authentication. Previously, the certificate selector was not shown in the Android WebView, making access impossible. This change enables proper mTLS flows in those cases.

### Breaking changes

- None. This only affects Android and only when a site requests a client certificate.

### How to test

1. Install a valid user certificate on your Android device.
2. Open a site that requires client certificate authentication in the InAppBrowser.
3. The system should show the certificate selector. Choose a certificate and verify access.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for client certificate authentication in the in-app browser. Users will now be prompted to select a certificate when required by a website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->