### PR TITLE
fix(ios): dispose WKWebView on close and teardown resources (#343)

### DIFF
--- a/ios/Plugin/InAppBrowserPlugin.swift
+++ b/ios/Plugin/InAppBrowserPlugin.swift
@@ -752,8 +752,16 @@ public class InAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func close(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
-            self.navigationWebViewController?.dismiss(animated: true, completion: nil)
-            self.notifyListeners("closeEvent", data: ["url": self.webViewController?.url?.absoluteString ?? ""])
+            let currentUrl = self.webViewController?.url?.absoluteString ?? ""
+
+            self.webViewController?.cleanupWebView()
+
+            self.navigationWebViewController?.dismiss(animated: true) {
+                self.webViewController = nil
+                self.navigationWebViewController = nil
+            }
+
+            self.notifyListeners("closeEvent", data: ["url": currentUrl])
             call.resolve()
         }
     }

--- a/ios/Plugin/WKWebViewController.swift
+++ b/ios/Plugin/WKWebViewController.swift
@@ -969,7 +969,6 @@ fileprivate extension WKWebViewController {
         if !(self.navigationController?.navigationBar.isHidden)! {
             self.progressView?.frame.origin.y = CGFloat((self.navigationController?.navigationBar.frame.height)!)
             self.navigationController?.navigationBar.addSubview(self.progressView!)
-            webView?.addObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress), options: .new, context: nil)
         }
     }
 
@@ -1344,8 +1343,8 @@ fileprivate extension WKWebViewController {
     func close() {
         let currentUrl = webView?.url?.absoluteString ?? ""
         cleanupWebView()
-        dismiss(animated: true, completion: nil)
         capBrowserPlugin?.notifyListeners("closeEvent", data: ["url": currentUrl])
+        dismiss(animated: true, completion: nil)
     }
 
     open func setUpNavigationBarAppearance() {

--- a/ios/Plugin/WKWebViewController.swift
+++ b/ios/Plugin/WKWebViewController.swift
@@ -895,24 +895,31 @@ public extension WKWebViewController {
     }
 
     open func cleanupWebView() {
-        webView?.stopLoading()
-        webView?.loadHTMLString("", baseURL: nil)
+        guard let webView = self.webView else { return }
+        webView.stopLoading()
+        // Break delegate callbacks early
+        webView.navigationDelegate = nil
+        webView.uiDelegate = nil
+        webView.loadHTMLString("", baseURL: nil)
 
-        webView?.removeObserver(self, forKeyPath: estimatedProgressKeyPath)
+        webView.removeObserver(self, forKeyPath: estimatedProgressKeyPath)
         if websiteTitleInNavigationBar {
-            webView?.removeObserver(self, forKeyPath: titleKeyPath)
+            webView.removeObserver(self, forKeyPath: titleKeyPath)
         }
-        webView?.removeObserver(self, forKeyPath: #keyPath(WKWebView.url))
+        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.url))
 
-        webView?.configuration.userContentController.removeAllUserScripts()
-        webView?.configuration.userContentController.removeScriptMessageHandler(forName: "messageHandler")
-        webView?.configuration.userContentController.removeScriptMessageHandler(forName: "close")
-        webView?.configuration.userContentController.removeScriptMessageHandler(forName: "preShowScriptSuccess")
-        webView?.configuration.userContentController.removeScriptMessageHandler(forName: "preShowScriptError")
-        webView?.configuration.userContentController.removeScriptMessageHandler(forName: "magicPrint")
+        webView.configuration.userContentController.removeAllUserScripts()
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "messageHandler")
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "close")
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "preShowScriptSuccess")
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "preShowScriptError")
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "magicPrint")
 
-        webView?.removeFromSuperview()
-        webView = nil
+        webView.removeFromSuperview()
+        // Also clean progress bar view if present
+        progressView?.removeFromSuperview()
+        progressView = nil
+        self.webView = nil
     }
 }
 


### PR DESCRIPTION
- Add cleanupWebView() to explicitly stop, clear, and remove observers/handlers
- Call cleanupWebView() from closeView() and close()
- Update plugin close() to cleanup and clear references before/after dismiss
- Fixes #343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Close event from the in‑app browser now reliably includes the correct URL.
  * Improved teardown on close to prevent rare crashes, hangs, or memory leaks.
  * More consistent behavior when dismissing the in‑app browser across scenarios.

* **Refactor**
  * Centralized cleanup for the in‑app browser, reducing duplicated logic and improving reliability without changing the public interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->