### PR TITLE
fix(ios): allow any 7.x Capacitor version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["InappbrowserPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.4.3")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
It's not a good practice to force to use latest version of `@capacitor/ios` when using SPM, it should allow the whole 7.x range
Same way you use `"@capacitor/ios": "^7.0.0"` in the `package.json` the `Package.swift` should also allow a range.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Adjusted an iOS build dependency to an earlier supported version.
  - No changes to features, UI, or public APIs.
  - No configuration or migration steps required for users.
  - No expected impact on app functionality or performance.
  - Routine maintenance to keep the mobile build consistent across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->