### PR TITLE
fix: fixes confirm modals event sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,8 @@ Listen for close click only for openWebView
 addListener(eventName: "confirmBtnClicked", listenerFunc: ConfirmBtnListener) => Promise<PluginListenerHandle>
 ```
 
-Will be triggered when user clicks on confirm button when disclaimer is required
+Will be triggered when user clicks on confirm button when disclaimer is required,
+works with openWebView shareDisclaimer and closeModal
 
 | Param              | Type                                                              |
 | ------------------ | ----------------------------------------------------------------- |

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -688,8 +688,8 @@ public class InAppBrowserPlugin
         }
 
         @Override
-        public void confirmBtnClicked() {
-          notifyListeners("confirmBtnClicked", new JSObject());
+        public void confirmBtnClicked(String url) {
+          notifyListeners("confirmBtnClicked", new JSObject().put("url", url));
         }
 
         @Override

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCallbacks.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCallbacks.java
@@ -13,5 +13,5 @@ public interface WebViewCallbacks {
 
   public void buttonNearDoneClicked();
 
-  public void confirmBtnClicked();
+  public void confirmBtnClicked(String url);
 }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -2201,7 +2201,9 @@ public class WebViewDialog extends Dialog {
             .setPositiveButton(
               shareDisclaimer.getString("confirmBtn", "Confirm"),
               (dialog, which) -> {
-                _options.getCallbacks().confirmBtnClicked();
+                // Notify that confirm was clicked
+                String currentUrl = getUrl();
+                _options.getCallbacks().confirmBtnClicked(currentUrl);
                 shareUrl();
               }
             )

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -1870,6 +1870,8 @@ public class WebViewDialog extends Dialog {
                     String currentUrl = getUrl();
                     dismiss();
                     if (_options != null && _options.getCallbacks() != null) {
+                      // Notify that confirm was clicked
+                      _options.getCallbacks().confirmBtnClicked(currentUrl);
                       _options.getCallbacks().closeEvent(currentUrl);
                     }
                   }

--- a/ios/Plugin/WKWebViewController.swift
+++ b/ios/Plugin/WKWebViewController.swift
@@ -1269,6 +1269,7 @@ fileprivate extension WKWebViewController {
                 title: disclaimer["title"] as? String ?? "Title",
                 message: disclaimer["message"] as? String ?? "Message",
                 preferredStyle: UIAlertController.Style.alert)
+            let currentUrl = self.webView?.url?.absoluteString ?? ""
 
             // Add confirm button that continues with sharing
             alert.addAction(UIAlertAction(
@@ -1276,7 +1277,7 @@ fileprivate extension WKWebViewController {
                 style: UIAlertAction.Style.default,
                 handler: { _ in
                     // Notify that confirm was clicked
-                    self.capBrowserPlugin?.notifyListeners("confirmBtnClicked", data: nil)
+                    self.capBrowserPlugin?.notifyListeners("confirmBtnClicked", data: ["url": currentUrl])
 
                     // Show the share dialog
                     self.showShareSheet(items: items, sender: sender)

--- a/ios/Plugin/WKWebViewController.swift
+++ b/ios/Plugin/WKWebViewController.swift
@@ -1322,8 +1322,11 @@ fileprivate extension WKWebViewController {
     @objc func doneDidClick(sender: AnyObject) {
         // check if closeModal is true, if true display alert before close
         if self.closeModal {
+            let currentUrl = webView?.url?.absoluteString ?? ""
             let alert = UIAlertController(title: self.closeModalTitle, message: self.closeModalDescription, preferredStyle: UIAlertController.Style.alert)
             alert.addAction(UIAlertAction(title: self.closeModalOk, style: UIAlertAction.Style.default, handler: { _ in
+                // Notify that confirm was clicked
+                self.capBrowserPlugin?.notifyListeners("confirmBtnClicked", data: ["url": currentUrl])
                 self.closeView()
             }))
             alert.addAction(UIAlertAction(title: self.closeModalCancel, style: UIAlertAction.Style.default, handler: nil))

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -546,7 +546,8 @@ export interface InAppBrowserPlugin {
     listenerFunc: UrlChangeListener,
   ): Promise<PluginListenerHandle>;
   /**
-   * Will be triggered when user clicks on confirm button when disclaimer is required
+   * Will be triggered when user clicks on confirm button when disclaimer is required,
+   * works with openWebView shareDisclaimer and closeModal
    *
    * @since 0.0.1
    */


### PR DESCRIPTION
This PR fixes one issue and adds feature as documented for close modal's confirm button. Here is more detailed changes:

- Send current url with event data as documented earlier - https://github.com/Cap-go/capacitor-inappbrowser/commit/3e50d24e2aa8aeec1d74295975831def4ef8104e
- Notify listeners for `confirmBtnClicked` -event when confirming `closeModal` which is shown when user clicks top bar's close button - https://github.com/Cap-go/capacitor-inappbrowser/commit/961500b8507debc12c0666c74a7516d76b0874bd
- Clarify docs when `confirmBtnClicked` event is triggered