### PR TITLE
fix(android): removes overrides for js window object

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -1296,22 +1296,6 @@ public class WebViewDialog extends Dialog {
                 }
               };
             }
-            // Also provide direct window methods for convenience
-            window.postMessage = function(data) {
-              try {
-                var message = typeof data === 'string' ? data : JSON.stringify(data);
-                window.AndroidInterface.postMessage(message);
-              } catch(e) {
-                console.error('Error in postMessage:', e);
-              }
-            };
-            window.close = function() {
-              try {
-                window.AndroidInterface.close();
-              } catch(e) {
-                console.error('Error in close:', e);
-              }
-            };
           }
           // Override window.print function to use our PrintInterface
           if (window.PrintInterface) {


### PR DESCRIPTION
Fixes #368 

Current behaviour in iOS does not override global methods inside `window` object. So, this PR aligns Android code with iOS code.