### PR TITLE
fix: don't override window.postMessage on Android, fix window.close o…

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -1297,14 +1297,6 @@ public class WebViewDialog extends Dialog {
               };
             }
             // Also provide direct window methods for convenience
-            window.postMessage = function(data) {
-              try {
-                var message = typeof data === 'string' ? data : JSON.stringify(data);
-                window.AndroidInterface.postMessage(message);
-              } catch(e) {
-                console.error('Error in postMessage:', e);
-              }
-            };
             window.close = function() {
               try {
                 window.AndroidInterface.close();

--- a/example-app/package-lock.json
+++ b/example-app/package-lock.json
@@ -24,7 +24,7 @@
     },
     "..": {
       "name": "@capgo/inappbrowser",
-      "version": "7.20.5",
+      "version": "7.20.6",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^7.0.0",

--- a/example-app/src/js/capacitor-welcome.js
+++ b/example-app/src/js/capacitor-welcome.js
@@ -90,6 +90,9 @@ window.customElements.define(
         <p>
           <button class="button" id="open-test-webapp-activity" style="background-color: #ffc107; color: #212529;">🧪 Open Test Webapp (Activity Mode)</button>
         </p>
+        <p>
+          <button class="button" id="open-test-webapp-close-modal" style="background-color: #dc3545;">🚪 Open Test Webapp (Close Confirmation)</button>
+        </p>
         <div id="webapp-status" style="margin-top: 10px; padding: 10px; background-color: #f8f9fa; border-radius: 5px; font-size: 0.8em; color: #666;">
           <strong>Setup:</strong> Make sure to copy url.js.example to url.js and configure your local server URL.
         </div>
@@ -256,6 +259,67 @@ window.customElements.define(
             });
           } catch (e) {
             console.error("Error opening test webapp in activity mode:", e);
+            alert(
+              "Error opening test webapp. Make sure your local server is running and url.js is configured correctly.",
+            );
+          }
+        });
+
+      // Test webapp with close confirmation modal
+      self.shadowRoot
+        .querySelector("#open-test-webapp-close-modal")
+        .addEventListener("click", async function (e) {
+          try {
+            // Try to load custom URL configuration
+            let urlToUse = testWebappUrl;
+            try {
+              const { url } = await import("./url.js");
+              urlToUse = url;
+            } catch (e) {
+              console.warn(
+                "url.js not found, using default URL. Copy url.js.example to url.js and configure your server URL.",
+              );
+            }
+
+            await InAppBrowser.openWebView({
+              url: urlToUse,
+              toolbarColor: "#dc3545",
+              toolbarTextColor: "#ffffff",
+              toolbarType: ToolBarType.NAVIGATION,
+              backgroundColor: BackgroundColor.WHITE,
+              title: "Close Confirmation Test",
+              showReloadButton: true,
+              visibleTitle: true,
+              showArrow: false,
+              closeModal: true,
+              closeModalTitle: "Close Browser?",
+              closeModalDescription: "Are you sure you want to close this browser? Any unsaved changes will be lost.",
+              closeModalOk: "Yes, Close",
+              closeModalCancel: "Stay Here"
+            });
+
+            // Add event listeners for close confirmation testing
+            InAppBrowser.addListener("urlChangeEvent", (result) => {
+              console.log("🔄 [Close Modal] URL changed:", result.url);
+            });
+
+            InAppBrowser.addListener("closeEvent", () => {
+              console.log("❌ [Close Modal] Browser closed");
+            });
+
+            InAppBrowser.addListener("confirmBtnClicked", (result) => {
+              console.log("✅ [Close Modal] Confirm button clicked for URL:", result.url);
+            });
+
+            InAppBrowser.addListener("browserPageLoaded", () => {
+              console.log("✅ [Close Modal] Page loaded");
+            });
+
+            InAppBrowser.addListener("messageFromWebview", (event) => {
+              console.log("💬 [Close Modal] Message from webview:", event.detail);
+            });
+          } catch (e) {
+            console.error("Error opening test webapp with close modal:", e);
             alert(
               "Error opening test webapp. Make sure your local server is running and url.js is configured correctly.",
             );

--- a/example-webapp/index.php
+++ b/example-webapp/index.php
@@ -55,6 +55,12 @@ session_start();
         .button.javascript:hover {
             background-color: #e0a800;
         }
+        .button.close {
+            background-color: #dc3545;
+        }
+        .button.close:hover {
+            background-color: #c82333;
+        }
         .navigation-info {
             background-color: #e9ecef;
             padding: 15px;
@@ -114,6 +120,14 @@ session_start();
         
         <!-- External then back -->
         <a href="external-redirect.php" class="button redirect">🌐 External Site Test</a>
+        
+        <h3>Close Browser Tests:</h3>
+        <p style="color: #666; font-size: 14px;">Test the new window.close() functionality (works in InAppBrowser)</p>
+        
+        <!-- Close tests -->
+        <button onclick="testWindowClose()" class="button close">❌ Test window.close()</button>
+        <button onclick="testMobileAppClose()" class="button close">📱 Test mobileApp.close()</button>
+        <button onclick="testCloseWithConfirm()" class="button close">⚠️ Test close() with confirmation</button>
 
         <div id="section1" style="margin-top: 50px; padding: 20px; background-color: #f8f9fa; border-radius: 5px;">
             <h4>Section 1 (Hash Target)</h4>
@@ -130,5 +144,57 @@ session_start();
             </ol>
         </div>
     </div>
+
+    <script>
+        function testWindowClose() {
+            console.log('Testing window.close()...');
+            alert('Testing window.close() - this should close the browser immediately (bypassing close confirmation)');
+            try {
+                window.close();
+            } catch (e) {
+                console.error('Error calling window.close():', e);
+                alert('Error: ' + e.message);
+            }
+        }
+
+        function testMobileAppClose() {
+            console.log('Testing mobileApp.close()...');
+            alert('Testing mobileApp.close() - this should close the browser through the mobileApp interface');
+            try {
+                if (window.mobileApp && window.mobileApp.close) {
+                    window.mobileApp.close();
+                } else {
+                    alert('mobileApp.close() not available - this only works in InAppBrowser');
+                }
+            } catch (e) {
+                console.error('Error calling mobileApp.close():', e);
+                alert('Error: ' + e.message);
+            }
+        }
+
+        function testCloseWithConfirm() {
+            console.log('Testing close with user confirmation...');
+            if (confirm('This will test programmatic closing. Do you want to close the browser?')) {
+                alert('User confirmed - closing browser with window.close()');
+                try {
+                    window.close();
+                } catch (e) {
+                    console.error('Error calling window.close():', e);
+                    alert('Error: ' + e.message);
+                }
+            } else {
+                alert('User cancelled - browser will stay open');
+            }
+        }
+
+        // Add some debug info
+        console.log('InAppBrowser Close Test Page Loaded');
+        console.log('Available close methods:');
+        console.log('- window.close:', typeof window.close);
+        console.log('- window.mobileApp:', typeof window.mobileApp);
+        if (window.mobileApp) {
+            console.log('- window.mobileApp.close:', typeof window.mobileApp.close);
+        }
+    </script>
 </body>
 </html>

--- a/example-webapp/page1.php
+++ b/example-webapp/page1.php
@@ -54,6 +54,12 @@ session_start();
         .button.redirect:hover {
             background-color: #c82333;
         }
+        .button.close {
+            background-color: #dc3545;
+        }
+        .button.close:hover {
+            background-color: #c82333;
+        }
         .navigation-info {
             background-color: #d4edda;
             padding: 15px;
@@ -111,6 +117,10 @@ session_start();
         <!-- Same page with query params -->
         <a href="page1.php?test=1" class="button">🔗 Same Page + Query</a>
         <a href="page1.php?test=2&more=data" class="button">🔗 Same Page + More Queries</a>
+        
+        <h3>Close Browser Tests (Page 1):</h3>
+        <button onclick="testWindowClose()" class="button close">❌ Test window.close()</button>
+        <button onclick="testMobileAppClose()" class="button close">📱 Test mobileApp.close()</button>
 
         <?php if (isset($_GET['test'])): ?>
         <div style="margin-top: 20px; padding: 15px; background-color: #fff3cd; border-radius: 5px;">
@@ -129,5 +139,35 @@ session_start();
             </ul>
         </div>
     </div>
+
+    <script>
+        function testWindowClose() {
+            console.log('Testing window.close() from Page 1...');
+            alert('Testing window.close() from Page 1 - should close immediately');
+            try {
+                window.close();
+            } catch (e) {
+                console.error('Error calling window.close():', e);
+                alert('Error: ' + e.message);
+            }
+        }
+
+        function testMobileAppClose() {
+            console.log('Testing mobileApp.close() from Page 1...');
+            alert('Testing mobileApp.close() from Page 1');
+            try {
+                if (window.mobileApp && window.mobileApp.close) {
+                    window.mobileApp.close();
+                } else {
+                    alert('mobileApp.close() not available - this only works in InAppBrowser');
+                }
+            } catch (e) {
+                console.error('Error calling mobileApp.close():', e);
+                alert('Error: ' + e.message);
+            }
+        }
+
+        console.log('Page 1 loaded - Close test functions available');
+    </script>
 </body>
 </html>

--- a/example-webapp/page2.php
+++ b/example-webapp/page2.php
@@ -54,6 +54,12 @@ session_start();
         .button.ajax:hover {
             background-color: #138496;
         }
+        .button.close {
+            background-color: #dc3545;
+        }
+        .button.close:hover {
+            background-color: #c82333;
+        }
         .navigation-info {
             background-color: #cce7ff;
             padding: 15px;
@@ -110,6 +116,10 @@ session_start();
         
         <!-- Back navigation -->
         <button onclick="history.back()" class="button">⬅️ JavaScript Back</button>
+        
+        <h3>Close Browser Tests (Page 2):</h3>
+        <button onclick="testWindowClose()" class="button close">❌ Test window.close()</button>
+        <button onclick="testMobileAppClose()" class="button close">📱 Test mobileApp.close()</button>
 
         <div id="ajax-content">
             <h4>AJAX Content Loaded!</h4>
@@ -165,6 +175,34 @@ session_start();
                 document.getElementById('ajax-content').style.display = 'none';
             }
         });
+
+        function testWindowClose() {
+            console.log('Testing window.close() from Page 2...');
+            alert('Testing window.close() from Page 2 - should close immediately');
+            try {
+                window.close();
+            } catch (e) {
+                console.error('Error calling window.close():', e);
+                alert('Error: ' + e.message);
+            }
+        }
+
+        function testMobileAppClose() {
+            console.log('Testing mobileApp.close() from Page 2...');
+            alert('Testing mobileApp.close() from Page 2');
+            try {
+                if (window.mobileApp && window.mobileApp.close) {
+                    window.mobileApp.close();
+                } else {
+                    alert('mobileApp.close() not available - this only works in InAppBrowser');
+                }
+            } catch (e) {
+                console.error('Error calling mobileApp.close():', e);
+                alert('Error: ' + e.message);
+            }
+        }
+
+        console.log('Page 2 loaded - Close test functions available');
     </script>
 </body>
 </html>

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -538,6 +538,14 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
                                 }
                         };
                 }
+                // Also provide direct window methods for convenience
+                window.close = function() {
+                  try {
+                    window.webkit.messageHandlers.close.postMessage(null);
+                  } catch(e) {
+                    console.error('Error in close:', e);
+                  }
+                };
                 """
         DispatchQueue.main.async {
             self.webView?.evaluateJavaScript(script) { result, error in


### PR DESCRIPTION
…n iOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Close confirmation workflow when opening the test webapp in the in-app browser.
  * New buttons across the example webapp to test window.close and app close actions.
  * iOS webviews now support window.close from loaded pages.

* **Improvements**
  * Enhanced logging and error handling for opening/closing flows.
  * Added visual styling for close action buttons.

* **Refactor**
  * Streamlined Android webview messaging to reduce unnecessary exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->