### PR TITLE
fix: link open in external browser for iOS and Android

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -1570,6 +1570,29 @@ extension WKWebViewController: WKUIDelegate {
             }
         }
     }
+    
+    public func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
+        // Handle target="_blank" links and popup windows
+        // When preventDeeplink is true, we should load these in the same webview instead of opening externally
+        if let url = navigationAction.request.url {
+            print("[InAppBrowser] Handling popup/new window request for URL: \(url.absoluteString)")
+            
+            // If preventDeeplink is true, load the URL in the current webview
+            if preventDeeplink {
+                print("[InAppBrowser] preventDeeplink is true, loading popup URL in current webview")
+                DispatchQueue.main.async { [weak self] in
+                    self?.load(remote: url)
+                }
+                return nil
+            }
+            
+            // Otherwise, check if we should handle it externally
+            // But since preventDeeplink is false here, we won't block it
+            return nil
+        }
+        
+        return nil
+    }
 }
 
 // MARK: - Host Blocking Utilities


### PR DESCRIPTION
This PR fixes opening links marked with `target="_blank"`.

When `preventDeepLink` is set to true:
Link is always opened in the web view, without redirecting to an external browser

When `preventDeepLink` is set to false:
Link is opened in an external browser

This behavior is not consistent between iOS and Android.
Fixes https://github.com/Cap-go/capacitor-inappbrowser/issues/308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced popup and external link handling: when deeplink prevention is disabled, target="_blank" links now open in the default browser instead of creating in-app popups.
  * Improved diagnostic logging for popup window events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->