### PR TITLE
Forward volume key events to the MainActivity

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -30,6 +30,7 @@ import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Log;
 import android.util.TypedValue;
+import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
@@ -2676,6 +2677,28 @@ public class WebViewDialog extends Dialog {
             }
             super.onBackPressed();
         }
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        // Forward volume key events to the MainActivity
+        switch (keyCode) {
+            case KeyEvent.KEYCODE_VOLUME_UP:
+            case KeyEvent.KEYCODE_VOLUME_DOWN:
+                return activity.onKeyDown(keyCode, event);
+        }
+        return super.onKeyDown(keyCode, event);
+    }
+
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        // Forward volume key events to the MainActivity
+        switch (keyCode) {
+            case KeyEvent.KEYCODE_VOLUME_UP:
+            case KeyEvent.KEYCODE_VOLUME_DOWN:
+                return activity.onKeyUp(keyCode, event);
+        }
+        return super.onKeyUp(keyCode, event);
     }
 
     public static String getReasonPhrase(int statusCode) {


### PR DESCRIPTION
A basic implementation of #397 - forward volume up/down key events to the MainActivity.

This allows implementing features like "hold volume down for 5 seconds to exit", in case `disableGoBackOnNativeApplication=true` or the Android navbar is disabled.

Example code for MainActivity (obviously if you want to do it properly with plugin events then you can do that, this is just the quick and easy way):

```
    private long volumeDownHoldStart = 0;

    @Override
    public boolean onKeyDown(int keyCode, KeyEvent event) {
        if (keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
            // NOTE: This event repeats whilst the button is held, so we can just use that instead of messing with timers
            if (volumeDownHoldStart < 0) {
                // Still holding after trigger.
                // Ignore until keyUp event.
                return true;
            } else if (volumeDownHoldStart == 0) {
                volumeDownHoldStart = SystemClock.elapsedRealtime();
                // Don't return - allows single press to still change volume
            } else {
                long holdTime = SystemClock.elapsedRealtime() - volumeDownHoldStart;
                if (holdTime >= 5000) {
                    volumeDownHoldStart = -1;
                    bridge.triggerJSEvent("volumeHeld", "window");
                }
                return true;
            }
        }
        return super.onKeyDown(keyCode, event);
    }

    @Override
    public boolean onKeyUp(int keyCode, KeyEvent event) {
        if (keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
            volumeDownHoldStart = 0;
        }
        return super.onKeyUp(keyCode, event);
    }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Volume key controls are now fully functional within the in-app browser. Users can adjust audio volume using their device's physical volume buttons while browsing. The browser now properly handles and forwards volume key interactions to the system, providing a more seamless and native-like browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->