### PR TITLE
fix: auto define width to screen width if not specified, but height specified

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -653,6 +653,12 @@ public class InAppBrowserPlugin extends Plugin implements WebViewDialog.Permissi
         Integer x = call.getInt("x");
         Integer y = call.getInt("y");
 
+        // Validate dimension parameters
+        if (width != null && height == null) {
+            call.reject("Height must be specified when width is provided");
+            return;
+        }
+
         if (width != null) {
             options.setWidth(width);
         }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -267,7 +267,7 @@ public class WebViewDialog extends Dialog {
         setContentView(R.layout.activity_browser);
 
         // If custom dimensions are set, configure for touch passthrough
-        if (_options != null && _options.getWidth() != null && _options.getHeight() != null) {
+        if (_options != null && (_options.getWidth() != null || _options.getHeight() != null)) {
             Window window = getWindow();
             if (window != null) {
                 // Make the dialog background transparent
@@ -2990,6 +2990,12 @@ public class WebViewDialog extends Dialog {
             params.width = (int) getPixels(width);
             params.height = (int) getPixels(height);
             params.x = (x != null) ? (int) getPixels(x) : 0;
+            params.y = (y != null) ? (int) getPixels(y) : 0;
+        } else if (height != null && width == null) {
+            // If only height is specified, use custom height with fullscreen width
+            params.width = WindowManager.LayoutParams.MATCH_PARENT;
+            params.height = (int) getPixels(height);
+            params.x = 0;
             params.y = (y != null) ? (int) getPixels(y) : 0;
         } else {
             // Default to fullscreen

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -374,6 +374,12 @@ public class InAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         let x = call.getFloat("x")
         let y = call.getFloat("y")
 
+        // Validate dimension parameters
+        if width != nil && height == nil {
+            call.reject("Height must be specified when width is provided")
+            return
+        }
+
         DispatchQueue.main.async {
             guard let url = URL(string: urlString) else {
                 call.reject("Invalid URL format")
@@ -604,17 +610,22 @@ public class InAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
             }
 
             // Configure modal presentation for touch passthrough if custom dimensions are set
-            if let width = width, let height = height {
+            if width != nil || height != nil {
                 self.navigationWebViewController?.modalPresentationStyle = .overFullScreen
 
                 // Create a pass-through container
                 let containerView = PassThroughView()
                 containerView.backgroundColor = .clear
+                
+                // Calculate dimensions - use screen width if only height is provided
+                let finalWidth = width != nil ? CGFloat(width!) : UIScreen.main.bounds.width
+                let finalHeight = height != nil ? CGFloat(height!) : UIScreen.main.bounds.height
+                
                 containerView.targetFrame = CGRect(
                     x: CGFloat(x ?? 0),
                     y: CGFloat(y ?? 0),
-                    width: CGFloat(width),
-                    height: CGFloat(height)
+                    width: finalWidth,
+                    height: finalHeight
                 )
 
                 // Replace the navigation controller's view with our pass-through container
@@ -625,8 +636,8 @@ public class InAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
                     originalView.frame = CGRect(
                         x: CGFloat(x ?? 0),
                         y: CGFloat(y ?? 0),
-                        width: CGFloat(width),
-                        height: CGFloat(height)
+                        width: finalWidth,
+                        height: finalHeight
                     )
                 }
             } else {

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -1914,13 +1914,22 @@ extension WKWebViewController: WKNavigationDelegate {
     open func applyCustomDimensions() {
         guard let navigationController = navigationController else { return }
 
-        // Only apply custom dimensions if both width and height are specified
+        // Apply custom dimensions if both width and height are specified
         if let width = customWidth, let height = customHeight {
             let x = customX ?? 0
             let y = customY ?? 0
 
             // Set the frame for the navigation controller's view
             navigationController.view.frame = CGRect(x: x, y: y, width: width, height: height)
+        } 
+        // If only height is specified, use fullscreen width
+        else if let height = customHeight, customWidth == nil {
+            let x = customX ?? 0
+            let y = customY ?? 0
+            let screenWidth = UIScreen.main.bounds.width
+
+            // Set the frame with fullscreen width and custom height
+            navigationController.view.frame = CGRect(x: x, y: y, width: screenWidth, height: height)
         }
         // Otherwise, use default fullscreen behavior (no action needed)
     }


### PR DESCRIPTION
This PR is the response and fix to #391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for in-app browser window dimensions to ensure proper configuration across Android and iOS.
  * Improved handling of partial dimension specifications when only height or width is provided.
  * Increased consistency in dimension behavior across platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->