### PR TITLE
Android: ensure window.mobileApp exists early

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -404,6 +404,8 @@ public class WebViewDialog extends Dialog {
         applyInsets();
 
         _webView.addJavascriptInterface(new JavaScriptInterface(), "AndroidInterface");
+        // Provide window.mobileApp at document start via native interface
+        _webView.addJavascriptInterface(new JavaScriptInterface(), "mobileApp");
         _webView.addJavascriptInterface(new PreShowScriptInterface(), "PreShowScriptInterface");
         _webView.addJavascriptInterface(new PrintInterface(this._context, _webView), "PrintInterface");
         _webView.getSettings().setJavaScriptEnabled(true);
@@ -1278,27 +1280,27 @@ public class WebViewDialog extends Dialog {
             String script = String.format(
                 """
                 (function() {
-                  if (window.AndroidInterface) {
-                    // Create mobileApp object for backward compatibility
-                    if (!window.mobileApp) {
-                      window.mobileApp = {
-                        postMessage: function(message) {
-                          try {
-                            var msg = typeof message === 'string' ? message : JSON.stringify(message);
-                            window.AndroidInterface.postMessage(msg);
-                          } catch(e) {
-                            console.error('Error in mobileApp.postMessage:', e);
-                          }
-                        },
-                        close: function() {
-                          try {
-                            window.AndroidInterface.close();
-                          } catch(e) {
-                            console.error('Error in mobileApp.close:', e);
-                          }
-                        }%s
-                      };
-                    }
+                  // Prefer AndroidInterface when available, otherwise fall back to native window.mobileApp
+                  var nativeBridge = window.AndroidInterface || window.mobileApp;
+                  if (nativeBridge) {
+                    // Wrap native bridge to normalize behavior (stringify objects, expose close/hide/show)
+                    window.mobileApp = {
+                      postMessage: function(message) {
+                        try {
+                          var msg = typeof message === 'string' ? message : JSON.stringify(message);
+                          nativeBridge.postMessage(msg);
+                        } catch(e) {
+                          console.error('Error in mobileApp.postMessage:', e);
+                        }
+                      },
+                      close: function() {
+                        try {
+                          nativeBridge.close();
+                        } catch(e) {
+                          console.error('Error in mobileApp.close:', e);
+                        }
+                      }%s
+                    };
                   }
                   // Override window.print function to use our PrintInterface
                   if (window.PrintInterface) {


### PR DESCRIPTION
Expose window.mobileApp via addJavascriptInterface so it exists at document start on Android. Normalize the injected wrapper to use the native bridge while preserving stringify behavior for postMessage. This helps avoid undefined errors in early page scripts (e.g., AWARE hidden mode).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and stability of native feature integration in the in-app browser by enhancing the fallback mechanism for cross-platform communication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->