### PR TITLE
fix: prevent race condition in setHidden() async path

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -1045,6 +1045,9 @@ public class WebViewDialog extends Dialog {
                             Log.w("InAppBrowser", "Unable to apply hidden mode: decorView is null after show()");
                             return;
                         }
+                        // Set flag immediately to prevent race condition if setHidden(false)
+                        // is called before the posted runnable executes
+                        isHiddenModeActive = true;
                         decorView.post(this::applyHiddenMode);
                     } catch (Exception e) {
                         Log.w("InAppBrowser", "Unable to show dialog before hiding", e);


### PR DESCRIPTION
## Summary
- Fixes a race condition in `setHidden()` when the dialog window doesn't exist yet
- Sets `isHiddenModeActive` flag immediately before posting `applyHiddenMode` to the UI thread

## Problem
When `setHidden(true)` is called before the dialog is shown:
1. `show()` is called to initialize the window
2. `applyHiddenMode` is posted to the UI thread (async)
3. `_options.setHidden(true)` runs immediately

If `setHidden(false)` is called before the posted runnable executes:
- `isHiddenModeActive` was still `false` (not set until `applyHiddenMode` runs)
- `restoreVisibleMode()` was incorrectly skipped
- `_options.setHidden(false)` was called
- The posted `applyHiddenMode` finally runs, leaving the dialog hidden with inconsistent `_options` state

## Solution
Set `isHiddenModeActive = true` immediately before posting the runnable, ensuring the flag is in the correct state if `setHidden(false)` is called before the async operation completes.

## Test plan
- [ ] Test rapid show/hide toggling on Android
- [ ] Verify dialog visibility state remains consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a race condition that could cause the hidden mode to not apply correctly when toggled rapidly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->