### PR TITLE
fix(android): avoid RelativeLayout cast crash in hidden mode

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -49,6 +49,7 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.ImageButton;
 import android.widget.ImageView;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.Toolbar;
@@ -991,7 +992,7 @@ public class WebViewDialog extends Dialog {
                 window.setLayout(1, 1);
                 _webView.setAlpha(0f);
                 _webView.setVisibility(View.INVISIBLE);
-                _webView.setLayoutParams(new ViewGroup.LayoutParams(0, 0));
+                _webView.setLayoutParams(new RelativeLayout.LayoutParams(0, 0));
             } else {
                 _webView.setAlpha(0f);
                 _webView.setVisibility(View.INVISIBLE);


### PR DESCRIPTION
Replace `new ViewGroup.LayoutParams(0, 0)` with `new RelativeLayout.LayoutParams(0, 0)` in the `invisibilityMode == AWARE` path

The WebView is inside a `RelativeLayout`, so assigning generic `ViewGroup.LayoutParams` can break parent layout measurement


Closes #439 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout parameter handling in hidden mode to ensure proper rendering when content is obscured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->