### PR TITLE
fix(android): allow `show()` with `AWARE` invisibility mode

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -883,10 +883,6 @@ public class InAppBrowserPlugin extends Plugin implements WebViewDialog.Permissi
                         call.reject("WebView is not initialized");
                         return;
                     }
-                    if (!webViewDialog.isFakeVisibleMode()) {
-                        call.reject("show() is only supported when invisibilityMode is FAKE_VISIBLE");
-                        return;
-                    }
                     if (!webViewDialog.isShowing()) {
                         webViewDialog.show();
                     }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -1080,10 +1080,6 @@ public class WebViewDialog extends Dialog {
         return isHiddenModeActive;
     }
 
-    public boolean isFakeVisibleMode() {
-        return _options != null && _options.getInvisibilityMode() == Options.InvisibilityMode.FAKE_VISIBLE;
-    }
-
     /**
      * Apply window insets to the WebView to properly handle edge-to-edge display
      * and fix status bar overlap issues on Android 15+


### PR DESCRIPTION
Fix Android `show()` to work with `invisibilityMode: AWARE` (same as iOS)
Removed the `isFakeVisibleMode`, not used anymore

Tested both methods `AWARE` and `FAKE_VISIBLE`, both working

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the in-app browser could not be displayed under certain conditions. The browser will now show correctly regardless of its previous visibility state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->