### PR TITLE
fix(android): use androidsvg-aar to avoid duplicate class conflict

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation 'com.caverock:androidsvg:1.4'
+    implementation 'com.caverock:androidsvg-aar:1.4'
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.window:window:1.5.1"
     testImplementation "junit:junit:$junitVersion"


### PR DESCRIPTION
## Summary
- switch Android dependency from `com.caverock:androidsvg:1.4` to `com.caverock:androidsvg-aar:1.4`
- avoids duplicate class conflicts when apps also depend on plugins pulling `androidsvg-aar` (e.g. RevenueCat UI)

## Why
Issue #448 reports Android build failures due to duplicate classes from both `androidsvg` and `androidsvg-aar` being present in the dependency graph. This change aligns this plugin with the AAR artifact already used in other plugin ecosystems and resolves that conflict.

## Validation
- compile-time dependency change only (no Java/Kotlin behavior changes)
- reporter in #448 already confirmed this exact switch resolves their build

Closes #448


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AndroidSVG library dependency in Android build configuration to use an alternative artifact variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->