### PR TITLE
fix(ios): add cookie handling to proxy scheme handler

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
+++ b/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
@@ -7,7 +7,9 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler {
     private var pendingTasks: [String: WKURLSchemeTask] = [:]
     private var pendingBodies: [String: Data] = [:]
     private var pendingNetworkTasks: [String: URLSessionDataTask] = [:]
-    private var pendingWebViews: [String: WKWebView] = [:]
+    // Captured on the main thread in webView(_:start:) so we never access
+    // WKWebView.configuration from a background queue (Main Thread Checker crash).
+    private var pendingCookieStores: [String: WKHTTPCookieStore] = [:]
     private var stoppedRequests: Set<String> = []
     private let taskLock = NSLock()
     private let webviewId: String
@@ -45,9 +47,13 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler {
 
         let requestId = UUID().uuidString
 
+        // Capture the cookie store now while we're on the main thread.
+        // Accessing webView.configuration from a background queue triggers the Main Thread Checker.
+        let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
+
         taskLock.lock()
         pendingTasks[requestId] = urlSchemeTask
-        pendingWebViews[requestId] = webView
+        pendingCookieStores[requestId] = cookieStore
         taskLock.unlock()
 
         // Encode body to base64, buffering stream data for later pass-through
@@ -90,7 +96,7 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler {
                 return
             }
             self.pendingBodies.removeValue(forKey: requestId)
-            self.pendingWebViews.removeValue(forKey: requestId)
+            self.pendingCookieStores.removeValue(forKey: requestId)
             self.taskLock.unlock()
 
             print("[InAppBrowser] Proxy request timed out after \(Int(self.proxyTimeoutSeconds))s: \(requestId)")
@@ -109,7 +115,7 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler {
         if let key = requestIdToRemove {
             pendingTasks.removeValue(forKey: key)
             pendingBodies.removeValue(forKey: key)
-            pendingWebViews.removeValue(forKey: key)
+            pendingCookieStores.removeValue(forKey: key)
             networkTask = pendingNetworkTasks.removeValue(forKey: key)
             stoppedRequests.insert(key)
         }
@@ -124,16 +130,16 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler {
         guard let urlSchemeTask = pendingTasks[requestId] else {
             pendingTasks.removeValue(forKey: requestId)
             pendingBodies.removeValue(forKey: requestId)
-            pendingWebViews.removeValue(forKey: requestId)
+            pendingCookieStores.removeValue(forKey: requestId)
             taskLock.unlock()
             return
         }
         let bufferedBody = pendingBodies.removeValue(forKey: requestId)
-        let webView = pendingWebViews[requestId]
+        let cookieStore = pendingCookieStores[requestId]
 
         if isStopped {
             pendingTasks.removeValue(forKey: requestId)
-            pendingWebViews.removeValue(forKey: requestId)
+            pendingCookieStores.removeValue(forKey: requestId)
             taskLock.unlock()
             return
         }
@@ -141,9 +147,9 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler {
         if responseData != nil {
             // JS provided a response — remove from pending now
             pendingTasks.removeValue(forKey: requestId)
-            pendingWebViews.removeValue(forKey: requestId)
+            pendingCookieStores.removeValue(forKey: requestId)
         }
-        // For pass-through (nil), keep pendingTasks/pendingWebViews so stop can find them
+        // For pass-through (nil), keep pendingTasks/pendingCookieStores so stop can find them
         taskLock.unlock()
 
         if let responseData = responseData {
@@ -177,8 +183,8 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler {
             }
 
             // Sync Set-Cookie from JS-provided response to WKWebView cookie store
-            if let webView = webView {
-                syncCookies(from: httpResponse, to: webView) {
+            if let cookieStore = cookieStore {
+                syncCookies(from: httpResponse, to: cookieStore) {
                     urlSchemeTask.didReceive(httpResponse)
                     urlSchemeTask.didReceive(bodyData)
                     urlSchemeTask.didFinish()
@@ -190,11 +196,11 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler {
             }
         } else {
             // Null response = pass-through via URLSession
-            executePassThrough(requestId: requestId, urlSchemeTask: urlSchemeTask, bufferedBody: bufferedBody, webView: webView)
+            executePassThrough(requestId: requestId, urlSchemeTask: urlSchemeTask, bufferedBody: bufferedBody)
         }
     }
 
-    private func executePassThrough(requestId: String, urlSchemeTask: WKURLSchemeTask, bufferedBody: Data?, webView: WKWebView?) {
+    private func executePassThrough(requestId: String, urlSchemeTask: WKURLSchemeTask, bufferedBody: Data?) {
         var request = urlSchemeTask.request
         // Restore body if it was consumed from httpBodyStream during interception
         if request.httpBody == nil, let body = bufferedBody {
@@ -217,7 +223,9 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler {
 
     /// Sync Set-Cookie headers from an HTTP response into WKWebView's cookie store.
     /// Calls completion after all cookies have been stored.
-    private func syncCookies(from response: HTTPURLResponse, to webView: WKWebView, completion: @escaping () -> Void) {
+    /// Accepts WKHTTPCookieStore directly so callers never touch WKWebView.configuration
+    /// from a background thread.
+    private func syncCookies(from response: HTTPURLResponse, to cookieStore: WKHTTPCookieStore, completion: @escaping () -> Void) {
         guard let url = response.url else {
             completion()
             return
@@ -228,7 +236,6 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler {
             completion()
             return
         }
-        let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
         let group = DispatchGroup()
         for cookie in cookies {
             group.enter()
@@ -251,7 +258,7 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler {
         pendingTasks.removeAll()
         pendingBodies.removeAll()
         pendingNetworkTasks.removeAll()
-        pendingWebViews.removeAll()
+        pendingCookieStores.removeAll()
         networkTaskRequestIds.removeAll()
         passThroughResponseData.removeAll()
         passThroughHTTPResponses.removeAll()
@@ -285,22 +292,22 @@ extension ProxySchemeHandler: URLSessionDataDelegate {
     ) {
         taskLock.lock()
         let requestId = networkTaskRequestIds[task.taskIdentifier]
-        let webView = requestId.flatMap { pendingWebViews[$0] }
+        let cookieStore = requestId.flatMap { pendingCookieStores[$0] }
         taskLock.unlock()
 
-        guard let webView = webView else {
+        guard let cookieStore = cookieStore else {
             completionHandler(request)
             return
         }
 
         // 1. Sync Set-Cookie from the redirect response into WKWebView
-        syncCookies(from: response, to: webView) {
+        syncCookies(from: response, to: cookieStore) {
             // 2. Inject WKWebView cookies for the redirect target domain
             guard let redirectURL = request.url else {
                 completionHandler(request)
                 return
             }
-            webView.configuration.websiteDataStore.httpCookieStore.getAllCookies { allCookies in
+            cookieStore.getAllCookies { allCookies in
                 var modifiedRequest = request
                 modifiedRequest.httpShouldHandleCookies = false
 
@@ -380,7 +387,7 @@ extension ProxySchemeHandler: URLSessionDataDelegate {
         let urlSchemeTask = pendingTasks.removeValue(forKey: requestId)
         let response = passThroughHTTPResponses.removeValue(forKey: requestId)
         let data = passThroughResponseData.removeValue(forKey: requestId) ?? Data()
-        let webView = pendingWebViews.removeValue(forKey: requestId)
+        let cookieStore = pendingCookieStores.removeValue(forKey: requestId)
         pendingNetworkTasks.removeValue(forKey: requestId)
         let wasStopped = stoppedRequests.remove(requestId) != nil
         taskLock.unlock()
@@ -403,8 +410,8 @@ extension ProxySchemeHandler: URLSessionDataDelegate {
         }
 
         // Sync Set-Cookie from final response to WKWebView, then deliver to scheme task
-        if let webView = webView {
-            syncCookies(from: httpResponse, to: webView) {
+        if let cookieStore = cookieStore {
+            syncCookies(from: httpResponse, to: cookieStore) {
                 urlSchemeTask.didReceive(httpResponse)
                 if !data.isEmpty {
                     urlSchemeTask.didReceive(data)


### PR DESCRIPTION
## Summary

- Fixes cookie store mismatch between WKWebView and URLSession in the proxy pass-through path
- Prevents `httpShouldHandleCookies` duplicate/conflict issues by disabling URLSession's cookie management
- Syncs `Set-Cookie` headers from pass-through responses back to `WKHTTPCookieStore`
- Handles redirect cookie chains via delegate-based URLSession with cookie injection per redirect step

## Root cause

WKWebView has its own cookie store (`WKHTTPCookieStore`), separate from URLSession's `HTTPCookieStorage.shared`. When `executePassThrough` proxied requests through `URLSession.shared`:

1. URLSession could add duplicate cookies from its own jar
2. `Set-Cookie` headers from responses were never synced back to WKWebView
3. Redirect responses that set cookies were lost — the redirect target never received them

This broke any site relying on session cookies through pass-through (e.g., Google reCAPTCHA).

## Changes

| Fix | What it does |
|-----|-------------|
| `httpShouldHandleCookies = false` | Prevents URLSession from adding its own cookies — WKWebView already put them in request headers |
| `syncCookies()` helper | Extracts `Set-Cookie` from `HTTPURLResponse` and stores them in `WKHTTPCookieStore` with async completion |
| Delegate-based `URLSession` | Replaces completion-handler `dataTask` so `willPerformHTTPRedirection` fires |
| Redirect cookie handling | At each redirect: sync Set-Cookie to WKWebView, then inject WKWebView cookies for the redirect target domain |
| `pendingWebViews` tracking | Stores WKWebView reference per request for cookie sync access |
| `invalidateSession()` | Breaks the URLSession ↔ delegate retain cycle when handler is disposed |

## Test plan

- [ ] Open in-app browser with proxy pass-through to a site that sets cookies (e.g., Google)
- [ ] Verify session cookies persist across page loads
- [ ] Verify redirect chains (e.g., Google sign-in flow) maintain cookies between domains
- [ ] Verify reCAPTCHA loads and functions correctly
- [ ] Verify existing proxy interception (non-pass-through) still works