### PR TITLE
Add support for Chrome Tabs ephemeral browsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1470,7 +1470,7 @@ The body must be base64-encoded.
 | **`authEndpoint`**                      | <code>string</code>  | The endpoint to open                                                                                                                                                                                                                                                                                                  |                    |       |
 | **`redirectUri`**                       | <code>string</code>  | The redirect URI to use for the openSecureWindow call. This will be checked to make sure it matches the redirect URI after the window finishes the redirection.                                                                                                                                                       |                    |       |
 | **`broadcastChannelName`**              | <code>string</code>  | The name of the broadcast channel to listen to, relevant only for web                                                                                                                                                                                                                                                 |                    |       |
-| **`prefersEphemeralWebBrowserSession`** | <code>boolean</code> | If true, the browser session will be ephemeral (no cookies or browsing data are shared with the system browser). On iOS, this sets `prefersEphemeralWebBrowserSession = true` on `ASWebAuthenticationSession`. On Android, ephemeral mode is always enabled via `FLAG_ACTIVITY_NO_HISTORY` regardless of this option. | <code>false</code> | 6.6.0 |
+| **`prefersEphemeralWebBrowserSession`** | <code>boolean</code> | If true, the browser session will be ephemeral (no cookies or browsing data are shared with the system browser). On iOS, this sets `prefersEphemeralWebBrowserSession = true` on `ASWebAuthenticationSession`. On Android, this enables Custom Tabs ephemeral browsing via `setEphemeralBrowsingEnabled(true)`. | <code>false</code> | 6.6.0 |
 
 
 ### Type Aliases
@@ -1492,7 +1492,9 @@ Construct a type with the properties of T except for those in type K.
 
 From T, pick a set of properties whose keys are in the union K
 
-<code>{ [P in K]: T[P]; }</code>
+<code>{
+ [P in K]: T[P];
+ }</code>
 
 
 #### Exclude
@@ -1506,7 +1508,9 @@ From T, pick a set of properties whose keys are in the union K
 
 Construct a type with a set of properties K of type T
 
-<code>{ [P in K]: T; }</code>
+<code>{
+ [P in K]: T;
+ }</code>
 
 
 #### GetCookieOptions

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -1648,6 +1648,7 @@ public class InAppBrowserPlugin extends Plugin implements WebViewDialog.Permissi
         CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
         builder.enableUrlBarHiding();
         builder.setShareState(CustomTabsIntent.SHARE_STATE_OFF);
+        builder.setEphemeralBrowsingEnabled(Boolean.TRUE.equals(call.getBoolean("prefersEphemeralWebBrowserSession", false)));
         CustomTabsIntent customTabsIntent = builder.build();
         customTabsIntent.intent.setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY | Intent.FLAG_ACTIVITY_CLEAR_TOP);
         customTabsIntent.intent.putExtra(CustomTabsIntent.EXTRA_ENABLE_INSTANT_APPS, false);

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -412,7 +412,7 @@ export interface OpenSecureWindowOptions {
   /**
    * If true, the browser session will be ephemeral (no cookies or browsing data are shared with the system browser).
    * On iOS, this sets `prefersEphemeralWebBrowserSession = true` on `ASWebAuthenticationSession`.
-   * On Android, ephemeral mode is always enabled via `FLAG_ACTIVITY_NO_HISTORY` regardless of this option.
+   * On Android, this enables Custom Tabs ephemeral browsing via `setEphemeralBrowsingEnabled(true)`.
    * @default false
    * @since 6.6.0
    */


### PR DESCRIPTION
This change enables [Chrome Ephemeral Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs/guide-ephemeral-tab) support for `openSecureWindow` call when `prefersEphemeralWebBrowserSession` is set to `true`.

This allows to keep cookies separated from main Chrome which is very beneficial to cover Login/Logout scenarios as current approach using `FLAG_ACTIVITY_NO_HISTORY` doesn't seem to actually enable ephemeral mode and only handles history.

The API is supported from Chrome version 137.0.7141.0, on older versions it will just make no change to current functionality.
Tested it on both new and old Chrome versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected ephemeral browsing behavior on Android for secure web windows to properly respect the ephemeral session preference setting.

* **Documentation**
  * Updated documentation for ephemeral session preferences and improved formatting of code examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->