### PR TITLE
Fix for error "All WebView methods must be called on the same thread"

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -4276,7 +4276,6 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                             Log.e("InAppBrowserProxy", "Failed to parse stored proxy headers", error);
                             return createCanceledResponse();
                         }
-                        
                         String initiatorUrl = request.getRequestHeaders().get("Referer");
                         if (initiatorUrl == null || initiatorUrl.isBlank()) {
                             // FIX: Safely fetch the WebView URL on the Main Thread
@@ -4295,7 +4294,6 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                                 initiatorUrl = originalUrl; 
                             }
                         }
-                        
                         String targetCookies = CookieManager.getInstance().getCookie(originalUrl);
                         if (
                             targetCookies != null &&

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -4276,10 +4276,26 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                             Log.e("InAppBrowserProxy", "Failed to parse stored proxy headers", error);
                             return createCanceledResponse();
                         }
+                        
                         String initiatorUrl = request.getRequestHeaders().get("Referer");
                         if (initiatorUrl == null || initiatorUrl.isBlank()) {
-                            initiatorUrl = _webView.getUrl();
+                            // FIX: Safely fetch the WebView URL on the Main Thread
+                            try {
+                                java.util.concurrent.FutureTask<String> task = new java.util.concurrent.FutureTask<>(new java.util.concurrent.Callable<String>() {
+                                    @Override
+                                    public String call() {
+                                        return _webView.getUrl();
+                                    }
+                                });
+                                new android.os.Handler(android.os.Looper.getMainLooper()).post(task);
+                                // Wait up to 1 second for the UI thread to return the URL
+                                initiatorUrl = task.get(1, java.util.concurrent.TimeUnit.SECONDS); 
+                            } catch (Exception e) {
+                                // Fallback to the original requested URL if the UI thread times out
+                                initiatorUrl = originalUrl; 
+                            }
                         }
+                        
                         String targetCookies = CookieManager.getInstance().getCookie(originalUrl);
                         if (
                             targetCookies != null &&


### PR DESCRIPTION
## Issue
When request interceptor is used during authentication flows with rapid 302 redirects, it can happen that the entire app crashes with the following error:


```txt
Fatal Exception: java.lang.RuntimeException
java.lang.Throwable: A WebView method was called on thread 'ThreadPoolForeg'. All WebView methods must be called on the same thread. (Expected Looper Looper (main, tid 2) {a4a8fe} called on null, FYI main Looper is Looper (main, tid 2) {a4a8fe})
```

## Fix
This PR fixes the issue by executing `_webView.getUrl()` on the main thread.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of referrer handling for proxied requests in the in-app browser, ensuring more robust cookie injection when referrer information is unavailable or inaccessible from the current page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->