### PR TITLE
fix(android): use JSObject.has() not get() for proxy response status check

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -5547,7 +5547,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                 }
 
                 JSObject responseOverride = response.getJSObject("response");
-                if (responseOverride == null && response.get("status") != null) {
+                if (responseOverride == null && response.has("status")) {
                     responseOverride = response;
                 }
 


### PR DESCRIPTION
## Summary

`WebViewDialog.java:5550` checks for a flat-response shape using
`response.get("status") != null`, but `JSObject.get()` (inherited
from `org.json.JSONObject`) **throws `JSONException: No value for
status`** when the key is missing. This fires on every
`ProxyRequestOverride` decision and every `null`/`cancel` decision —
i.e. anything that isn't a response — producing `Error building
proxy response` noise in logcat:

```
E InAppBrowserProxy  Error building proxy response
  org.json.JSONException: No value for status
      at org.json.JSONObject.get(JSONObject.java:398)
      at WebViewDialog.handleProxyResponse(WebViewDialog.java:5550)
      at InAppBrowserPlugin.handleProxyRequestInternal(InAppBrowserPlugin.java:1391)
```

The exception is caught at line 5592 (`catch (Exception e)`) and the
semaphore is still released at 5600, so the override technically
applies — but the log noise masks any real failures and is hit by
every modern user of `addProxyHandler` whose handler returns a
request override (a very common shape).

The intent of the short-circuit is clearly "accept a legacy flat
response where `status` is at the top level instead of nested under
`response`". `has()` is the right semantic — "is the key present?" —
without throwing.

This matches the iOS path's null-safe lookup at
[ProxySchemeHandler.swift:537-547](https://github.com/Cap-go/capacitor-inappbrowser/blob/main/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift#L537-L547):

```swift
let directResponse = (responseData["response"] as? [String: Any]) ?? responseData
let hasDirectResponse = directResponse["status"] != nil
```

## The fix

```diff
  JSObject responseOverride = response.getJSObject("response");
- if (responseOverride == null && response.get("status") != null) {
+ if (responseOverride == null && response.has("status")) {
      responseOverride = response;
  }
```

One character changed (well, swapping `get(...) != null` for `has(...)`).

## Test plan

- [ ] Open an `outboundProxyRules: [{ action: 'delegateToJs' }]` flow on Android.
- [ ] In `addProxyHandler`, return a `ProxyRequestOverride` shape (`{ request: { url, headers, ... } }`).
- [ ] Confirm `adb logcat -s InAppBrowserProxy` no longer prints `Error building proxy response` / `No value for status`.
- [ ] Confirm the override (URL/headers/body) still applies — this codepath was previously surviving the throw because the request override branch ran before the buggy line.
- [ ] Regression: pass an inline flat response `{ status: 200, body: '...', headers: {...} }` (legacy compat shape) and confirm it's still accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a stability issue in proxy response handling that could cause exceptions when certain response fields are absent.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-inappbrowser/pull/525)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->