### PR TITLE
fix(ios): write cookies on main thread in ProxySchemeHandler

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
+++ b/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
@@ -1014,15 +1014,10 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
     }
 
     private func syncResponseCookies(from response: URLResponse?, fallbackURL: String, completion: @escaping () -> Void) {
-        guard
-            let plugin,
-            let cookieStore = plugin.cookieStore(for: webviewId),
-            !fallbackURL.isEmpty
-        else {
+        guard !fallbackURL.isEmpty else {
             completion()
             return
         }
-
         let cookies = ProxySchemeRequestSupport.responseCookies(
             response: response,
             fallback: fallbackURL
@@ -1031,44 +1026,51 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
             completion()
             return
         }
-
-        let group = DispatchGroup()
-        for cookie in cookies {
-            group.enter()
-            cookieStore.setCookie(cookie) {
-                group.leave()
-            }
-        }
-        group.notify(queue: .main) {
-            completion()
-        }
+        writeCookiesOnMain(cookies, completion: completion)
     }
 
     private func syncResponseCookies(from responseData: NativeResponseData, fallbackURL: String, completion: @escaping () -> Void) {
-        guard
-            let plugin,
-            let cookieStore = plugin.cookieStore(for: webviewId),
-            !fallbackURL.isEmpty
-        else {
+        guard !fallbackURL.isEmpty else {
             completion()
             return
         }
-
         let cookies = ProxySchemeRequestSupport.responseCookies(from: responseData.headers, fallback: fallbackURL)
         guard !cookies.isEmpty else {
             completion()
             return
         }
+        writeCookiesOnMain(cookies, completion: completion)
+    }
 
-        let group = DispatchGroup()
-        for cookie in cookies {
-            group.enter()
-            cookieStore.setCookie(cookie) {
-                group.leave()
+    /// Writes cookies into the WebView cookie store on the main thread.
+    ///
+    /// `WKWebsiteDataStore.httpCookieStore` and `WKHTTPCookieStore.setCookie` are both
+    /// `@MainActor`-only on iOS 17+. URLSession delegate callbacks (including
+    /// `urlSession(_:task:willPerformHTTPRedirection:newRequest:)`) and the timeout
+    /// closure dispatched via `DispatchQueue.global().asyncAfter` run on background
+    /// queues, so reaching the cookie store from there triggers Main Thread Checker
+    /// warnings and risks runtime crashes in release builds. Hop to main here so all
+    /// `syncResponseCookies` callers stay correct regardless of their own thread context.
+    private func writeCookiesOnMain(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard
+                let self,
+                let plugin = self.plugin,
+                let cookieStore = plugin.cookieStore(for: self.webviewId)
+            else {
+                completion()
+                return
             }
-        }
-        group.notify(queue: .main) {
-            completion()
+            let group = DispatchGroup()
+            for cookie in cookies {
+                group.enter()
+                cookieStore.setCookie(cookie) {
+                    group.leave()
+                }
+            }
+            group.notify(queue: .main) {
+                completion()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

`WKWebsiteDataStore.httpCookieStore` and `WKHTTPCookieStore.setCookie(_:completionHandler:)` are `@MainActor`-only on iOS 17+. `ProxySchemeHandler.syncResponseCookies` was reaching the cookie store from background queues, triggering Main Thread Checker warnings and risking intermittent release-build crashes.

## The warning

```
Main Thread Checker: UI API called on a background thread: -[WKWebsiteDataStore httpCookieStore]
Queue name: com.apple.NSURLSession-delegate, QoS: 0
Backtrace:
5  InappbrowserPlugin.cookieStore(for:)
6  ProxySchemeHandler.syncResponseCookies(from:fallbackURL:completion:)
7  ProxySchemeHandler.urlSession(_:task:willPerformHTTPRedirection:newRequest:completionHandler:)
```

The reported path is the URLSession redirect handler, but the same bug exists on **two more code paths** that happen to be less common and not yet caught by Main Thread Checker:

- The dataTask completion callback after `executeNativePipeline` ([`ProxySchemeHandler.swift:633`](https://github.com/Cap-go/capacitor-inappbrowser/blob/main/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift#L633)) — also runs on `NSURLSession-delegate`.
- The proxy timeout closure dispatched via `DispatchQueue.global().asyncAfter` ([`:739`](https://github.com/Cap-go/capacitor-inappbrowser/blob/main/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift#L739)) — runs on a global background queue.

All three reach `plugin.cookieStore(for:)` → `WKWebsiteDataStore.httpCookieStore` from off-main.

## The fix

Extract the cookie-store-touching work into a `writeCookiesOnMain(_:completion:)` helper and `DispatchQueue.main.async` into it. Cookie parsing (`ProxySchemeRequestSupport.responseCookies`) stays off-main — it's pure Foundation cookie parsing, no UI APIs, thread-safe.

Fast-fails (empty `fallbackURL`, empty `cookies`) return synchronously on the calling queue exactly as before, so the no-op path keeps its zero overhead. Only the cookie-present path hops to main.

Both overloads of `syncResponseCookies` (URLResponse and NativeResponseData) share the same helper, so the four known call sites are all fixed in one go.

## Why callee-side dispatch instead of fixing call sites

- Single point of correctness for all current and future callers.
- Two of the four call sites are on URLSession delegate queues by design (the `URLSession(delegate:delegateQueue: nil)` config at [`:436`](https://github.com/Cap-go/capacitor-inappbrowser/blob/main/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift#L436) means delegate methods run on the system serial OperationQueue) — moving them to `OperationQueue.main` would put response decoding and header serialization on main too, a measurable regression.
- Matches the file's existing style: `group.notify(queue: .main)` is already used for adjacent work.

## Test plan

- [ ] Build the example app on iOS simulator (Xcode debug, Main Thread Checker on by default).
- [ ] Trigger a proxied flow with a redirect — e.g., Facebook login POST → 302 → `/marketplace/`.
- [ ] Confirm Xcode console shows no `Main Thread Checker: UI API called on a background thread` warnings from `WKWebsiteDataStore.httpCookieStore` or `WKHTTPCookieStore.setCookie`.
- [ ] Confirm `InAppBrowser.getCookies({ url: 'https://www.facebook.com' })` returns cookies set by the redirected response.
- [ ] Smoke test a non-redirect proxied request to verify the dataTask completion path also no longer warns and still writes cookies.
- [ ] No Android regression — diff touches `ios/` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved cookie synchronization handling in the in-app browser to enhance consistency and reliability during cookie operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-inappbrowser/pull/526)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->