### PR TITLE
fix(ci): install Node 22+ and reset native dirs in packed example verification

### DIFF
--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -34,6 +34,8 @@ fi
 plugin_name="$(bun -e 'console.log(require("./package.json").name)')"
 cp -R example-app/. "$test_app/"
 cd "$test_app"
+# Remove pre-existing native platform directories so `cap add` can recreate them fresh.
+rm -rf android ios
 bun remove "$plugin_name"
 bun add "${packed_packages[0]}"
 bun run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v4
+        with:
+          node-version: 24
       - name: Install dependencies
         id: install_code
         run: bun i
@@ -293,6 +297,10 @@ jobs:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v4
+        with:
+          node-version: 24
       - name: Install dependencies
         id: install_code
         run: bun i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
       - name: Install dependencies
@@ -298,7 +298,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
       - name: Install dependencies


### PR DESCRIPTION
## Summary

CI was failing on `build_android` (and `build_ios`) with:

```
[fatal] The Capacitor CLI requires NodeJS >=22.0.0
        Please install the latest LTS version.
```

…and on `build_ios` with:

```
[error] ios platform already exists.
        To re-add this platform, first remove ./ios, then run this command again.
```

Failing run: https://github.com/Cap-go/capacitor-inappbrowser/actions/runs/25784903162/job/75735849474

### Root causes

1. The `build_android` and `build_ios` jobs only run `oven-sh/setup-bun` — they never set up Node. The `verify-packed-example.sh` step then calls `bunx cap …`, which is the Capacitor CLI, a Node program. Ubuntu 24.04 runners ship an older default Node, so the CLI bails out demanding Node ≥ 22.
2. The example app has `ios/` and `android/` committed. `verify-packed-example.sh` copies the whole `example-app/` tree (including those native dirs) into a tmp test app, then runs `bunx cap add ios|android`, which refuses to overwrite existing platform folders.

### Fix

- `.github/workflows/test.yml`: add `actions/setup-node@v4` (node-version `24`) to `build_android` and `build_ios`, matching the rest of the file.
- `.github/scripts/verify-packed-example.sh`: `rm -rf android ios` in the copied example app before `bun add` so `cap add` can scaffold the platforms fresh.

## Test plan

- [ ] `test / build_android` passes on this PR
- [ ] `test / build_ios` passes on this PR
- [ ] `test / web` continues to pass (unchanged behavior — no `cap add` for web)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed platform setup to ensure clean state during native platform configuration.

* **Chores**
  * Enhanced build reliability with explicit Node.js version configuration in build workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-inappbrowser/pull/527)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->