### PR TITLE
fix(ios): two redirect bugs in ProxySchemeHandler — dual-fire race + Accept-Encoding blocking auto-decompression

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
+++ b/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
@@ -619,6 +619,19 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
             }
 
             let httpResponse = response as? HTTPURLResponse
+            // 3xx responses are the exclusive responsibility of
+            // urlSession(_:task:willPerformHTTPRedirection:newRequest:completionHandler:).
+            // When that delegate calls completionHandler(nil) to suppress URLSession's
+            // automatic redirect-following, URLSession still surfaces the 3xx body to
+            // this completion handler as a normal response. Without this guard, the
+            // willPerformHTTPRedirection path and this completion handler both race to
+            // mutate pendingTask.responseData and call executeInboundDecision; the late-
+            // firing one overwrites the redirect-target state and ends up handing the
+            // empty 3xx body to the WKURLSchemeTask via finish(), short-circuiting the
+            // actual redirect-target fetch.
+            if let httpResponse, (300...399).contains(httpResponse.statusCode) {
+                return
+            }
             let responseHeaders = ProxySchemeRequestSupport.normalizedResponseHeaders(from: httpResponse)
             pendingTask.requestContext.url = ProxySchemeRequestSupport.resolvedResponseURL(
                 response,
@@ -925,7 +938,18 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
         }
         var request = URLRequest(url: url)
         request.httpMethod = context.method
-        request.allHTTPHeaderFields = context.headers
+        // URLSession will auto-decompress gzip/br/zstd responses only when
+        // Accept-Encoding is NOT present in the request headers (URLSession
+        // adds its own and owns the decompression in that case). If we forward
+        // an Accept-Encoding value supplied by the JS handler (or carried over
+        // by URLSession's own redirect-rewriting), URLSession assumes the
+        // caller will handle decompression and passes the raw compressed bytes
+        // through, which the WKURLSchemeTask then renders as gibberish in the
+        // WebView. Strip it so URLSession's transparent decompression kicks in.
+        let filteredHeaders = context.headers.filter { key, _ in
+            key.caseInsensitiveCompare("Accept-Encoding") != .orderedSame
+        }
+        request.allHTTPHeaderFields = filteredHeaders
         if
             ProxySchemeRequestSupport.supportsRequestBody(method: context.method),
             let bodyData = try ProxySchemeRequestSupport.decodedRequestBody(from: context.base64Body) {

--- a/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
+++ b/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
@@ -421,6 +421,13 @@ final class PendingProxyTask {
 
 // swiftlint:disable type_body_length
 public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDelegate {
+    /// HTTP status codes for which URLSession actually triggers
+    /// `urlSession(_:task:willPerformHTTPRedirection:newRequest:completionHandler:)`.
+    /// Scoped narrowly so other 3xx responses (300, 304, 305, 306) flow through the
+    /// dataTask completion handler normally — 304 Not Modified in particular must
+    /// still reach finish() or the scheme task strands.
+    static let redirectStatusCodes: Set<Int> = [301, 302, 303, 307, 308]
+
     weak var plugin: InAppBrowserPlugin?
     private var pendingTasks: [String: PendingProxyTask] = [:]
     private var stoppedRequests: [String: UUID] = [:]
@@ -619,17 +626,23 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
             }
 
             let httpResponse = response as? HTTPURLResponse
-            // 3xx responses are the exclusive responsibility of
+            // Actual HTTP redirect status codes are the exclusive responsibility of
             // urlSession(_:task:willPerformHTTPRedirection:newRequest:completionHandler:).
             // When that delegate calls completionHandler(nil) to suppress URLSession's
-            // automatic redirect-following, URLSession still surfaces the 3xx body to
-            // this completion handler as a normal response. Without this guard, the
+            // automatic redirect-following, URLSession still surfaces the redirect body
+            // to this completion handler as a normal response. Without this guard, the
             // willPerformHTTPRedirection path and this completion handler both race to
             // mutate pendingTask.responseData and call executeInboundDecision; the late-
             // firing one overwrites the redirect-target state and ends up handing the
-            // empty 3xx body to the WKURLSchemeTask via finish(), short-circuiting the
-            // actual redirect-target fetch.
-            if let httpResponse, (300...399).contains(httpResponse.statusCode) {
+            // empty redirect body to the WKURLSchemeTask via finish(), short-circuiting
+            // the actual redirect-target fetch.
+            //
+            // Scoped narrowly to the codes that actually trigger willPerformHTTPRedirection
+            // (301, 302, 303, 307, 308). Other 3xx — 300, 304 Not Modified, 305, 306 — are
+            // NOT redirects and the delegate doesn't fire for them, so they must flow
+            // through this completion handler normally (a 304 in particular needs the
+            // scheme task to be didFinish()'d with the cached/empty body, not stranded).
+            if let httpResponse, ProxySchemeHandler.redirectStatusCodes.contains(httpResponse.statusCode) {
                 return
             }
             let responseHeaders = ProxySchemeRequestSupport.normalizedResponseHeaders(from: httpResponse)


### PR DESCRIPTION
## Summary

Two independent bugs in `ProxySchemeHandler` that both surface when a proxied request is redirected (3xx). Either one alone causes user-visible breakage on `delegateToJs` flows that involve redirects (e.g. `facebook.com/marketplace/create` → 302 → `/marketplace/`).

Diagnosed on iOS 17 via a real-device debug session 2026-05-13. Five-line fix per bug, both in the same file, hence one PR.

## Bug 1 — `willPerformHTTPRedirection` and the dataTask completion handler race for `pendingTask.responseData`

`urlSession(_:task:willPerformHTTPRedirection:newRequest:completionHandler:)` calls `completionHandler(nil)` to suppress URLSession's automatic redirect-following so the plugin can route the redirect target back through the proxy pipeline (`followPendingRedirect` → `routeCurrentRequest` → JS handler → fresh URLSession dataTask).

Per [Apple's docs](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411626-urlsession), passing `nil` makes URLSession **"use the body of the current response as the body of the response"** — meaning the dataTask's completion handler also fires with the 3xx response. Both delegate paths then race on the same `pendingTask`:

```
willPerformHTTPRedirection                  dataTask completion (for the 302)
  ├─ pendingTask.responseData = 302         ├─ (waits behind delegate queue)
  ├─ pendingTask.redirectRequest = newReq
  ├─ completionHandler(nil)
  └─ syncResponseCookies { executeInboundDecision }
       └─ main: followPendingRedirect → routeCurrentRequest
                  → emit second outbound event for redirect target
                  → JS handler responds → executeNativePipeline
                     → second dataTask resumes for the redirect target
                                              └─ main: pendingTask.responseData = 302  ◄ overwrite
                                                      executeInboundDecision
                                                      → no inbound rule, redirectRequest is nil
                                                      → finish(task, with: 302-empty-body)
                                                      → WKURLSchemeTask is done before the second
                                                        dataTask ever completes
```

Debug run from 2026-05-13 caught this: probe shows `bodyLength: 0`, `pathname: /marketplace/create`, `title: ""` on the WebView — the 302 body served as the final response. The second dataTask for `/marketplace/` was orphaned, hence HTTP Toolkit only ever saw the first wire request.

**Fix:** in the dataTask completion handler, if the response status is 3xx, return without touching state. `willPerformHTTPRedirection` is authoritative for redirects.

## Bug 2 — explicit `Accept-Encoding` disables URLSession's automatic response decompression

`URLSession` only auto-decompresses gzip/brotli/zstd responses when `Accept-Encoding` is NOT present on the `URLRequest`. If it is, URLSession assumes the caller owns decompression and passes raw compressed bytes through. The `WKURLSchemeTask` then forwards those bytes to the WebView, which renders them as gibberish text.

Two paths feed `Accept-Encoding` into the override:
- JS handlers commonly spread `request.headers` into their override (`{ ...request.headers, ... }`) without knowing this gotcha. `request.headers` often contains an `Accept-Encoding` value the WebView attached.
- URLSession's own redirect handling preserves headers across the synthesized redirect request, so even when the JS handler doesn't add it, `Accept-Encoding` rides through.

Debug run from 2026-05-13 caught this too: when Bug 1's race resolved in favor of the redirect-follow path completing, the resulting response landed in the WebView with `bodyLength: 101850`, `bodyPreview` showing binary bytes starting `(�/�Xtz�O�p/...` — gzip-shaped. Title and body text all unreadable.

**Fix:** strip `Accept-Encoding` (case-insensitive) from the header map in `makeURLRequest` before assigning `allHTTPHeaderFields`. URLSession then re-adds its own and the response is delivered decompressed.

## Test plan

- [ ] Open a proxied flow that triggers an HTTP redirect on iOS (e.g. the Facebook marketplace login flow at `https://www.facebook.com/marketplace/create` with an outbound `delegateToJs` proxy rule).
- [ ] Confirm the WebView renders the redirect target's actual content, not a blank page (Bug 1) or binary gibberish (Bug 2).
- [ ] Confirm two outbound `proxyRequest` events fire with the same `requestId` — one for the source URL, one for the redirect target.
- [ ] Confirm HTTP Toolkit (or any external proxy) sees BOTH requests on the wire — not just the first one.
- [ ] Smoke-test a non-redirect proxied request (e.g. `https://example.com`) to confirm no regression on the happy path.
- [ ] No Android impact — diff is `ios/` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate processing of HTTP redirects so redirected requests are handled reliably and only once.
  * Ensured HTTP response decompression is performed correctly so compressed content is decoded before delivery to the browser, avoiding corrupted or unreadable responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-inappbrowser/pull/528)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->