### PR TITLE
Fix Android WebView URL lookup threading

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -4276,7 +4276,6 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                             Log.e("InAppBrowserProxy", "Failed to parse stored proxy headers", error);
                             return createCanceledResponse();
                         }
-                        
                         String initiatorUrl = request.getRequestHeaders().get("Referer");
                         if (initiatorUrl == null || initiatorUrl.isBlank()) {
                             // FIX: Safely fetch the WebView URL on the Main Thread
@@ -4295,7 +4294,6 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                                 initiatorUrl = originalUrl; 
                             }
                         }
-                        
                         String targetCookies = CookieManager.getInstance().getCookie(originalUrl);
                         if (
                             targetCookies != null &&

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -4276,10 +4276,26 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                             Log.e("InAppBrowserProxy", "Failed to parse stored proxy headers", error);
                             return createCanceledResponse();
                         }
+                        
                         String initiatorUrl = request.getRequestHeaders().get("Referer");
                         if (initiatorUrl == null || initiatorUrl.isBlank()) {
-                            initiatorUrl = _webView.getUrl();
+                            // FIX: Safely fetch the WebView URL on the Main Thread
+                            try {
+                                java.util.concurrent.FutureTask<String> task = new java.util.concurrent.FutureTask<>(new java.util.concurrent.Callable<String>() {
+                                    @Override
+                                    public String call() {
+                                        return _webView.getUrl();
+                                    }
+                                });
+                                new android.os.Handler(android.os.Looper.getMainLooper()).post(task);
+                                // Wait up to 1 second for the UI thread to return the URL
+                                initiatorUrl = task.get(1, java.util.concurrent.TimeUnit.SECONDS); 
+                            } catch (Exception e) {
+                                // Fallback to the original requested URL if the UI thread times out
+                                initiatorUrl = originalUrl; 
+                            }
                         }
+                        
                         String targetCookies = CookieManager.getInstance().getCookie(originalUrl);
                         if (
                             targetCookies != null &&

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -106,6 +106,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -3313,6 +3314,28 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         }
     }
 
+    private String getWebViewUrlOnMainThread(String fallbackUrl) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            return getWebViewUrlOrFallback(fallbackUrl);
+        }
+
+        FutureTask<String> task = new FutureTask<>(() -> getWebViewUrlOrFallback(fallbackUrl));
+        mainHandler.post(task);
+        try {
+            return task.get(1, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return fallbackUrl;
+        } catch (Exception e) {
+            return fallbackUrl;
+        }
+    }
+
+    private String getWebViewUrlOrFallback(String fallbackUrl) {
+        String url = _webView != null ? _webView.getUrl() : null;
+        return TextUtils.isEmpty(url) ? fallbackUrl : url;
+    }
+
     public String getUrl() {
         try {
             WebView webView = _webView;
@@ -4278,21 +4301,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                         }
                         String initiatorUrl = request.getRequestHeaders().get("Referer");
                         if (initiatorUrl == null || initiatorUrl.isBlank()) {
-                            // FIX: Safely fetch the WebView URL on the Main Thread
-                            try {
-                                java.util.concurrent.FutureTask<String> task = new java.util.concurrent.FutureTask<>(new java.util.concurrent.Callable<String>() {
-                                    @Override
-                                    public String call() {
-                                        return _webView.getUrl();
-                                    }
-                                });
-                                new android.os.Handler(android.os.Looper.getMainLooper()).post(task);
-                                // Wait up to 1 second for the UI thread to return the URL
-                                initiatorUrl = task.get(1, java.util.concurrent.TimeUnit.SECONDS); 
-                            } catch (Exception e) {
-                                // Fallback to the original requested URL if the UI thread times out
-                                initiatorUrl = originalUrl; 
-                            }
+                            initiatorUrl = getWebViewUrlOnMainThread(originalUrl);
                         }
                         String targetCookies = CookieManager.getInstance().getCookie(originalUrl);
                         if (

--- a/ios/Tests/InAppBrowserPluginTests/InAppBrowserPluginTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/InAppBrowserPluginTests.swift
@@ -348,6 +348,9 @@ final class InAppBrowserPluginTests: XCTestCase {
         XCTAssertEqual(headers["Cache-Control"], "no-cache")
     }
 
+}
+
+final class ProxySchemeTimeoutSupportTests: XCTestCase {
     func testProxySchemeTimeoutResolutionActionPrefersNativeFallbackForOutbound() {
         XCTAssertEqual(
             ProxySchemeRequestSupport.timeoutResolutionAction(


### PR DESCRIPTION
## What
- Recreates the fix from #524 on a Cap-go branch.
- Reads the WebView URL on the main thread when proxy requests have no Referer header.
- Splits timeout-related iOS tests into a separate test class so SwiftLint has no serious violations.

## Why
- #524 fixed the WebView threading crash but failed CI on Java formatting.
- The replacement branch lets CI run from this repository while preserving the original PR commits.

## How
- Cherry-picked the two commits from #524.
- Replaced the inline FutureTask block with a helper that uses the existing main handler, times out after 1 second, falls back to the original URL, and preserves interrupt state.
- Moved the timeout tests into their own XCTestCase class to satisfy the current SwiftLint type body limit.

## Testing
- bun run fmt
- bun run lint
- JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/martindonadieu/Library/Android/sdk" ANDROID_SDK_ROOT="/Users/martindonadieu/Library/Android/sdk" bun run verify

## Not Tested
- Manual Android device reproduction of the original WebView threading crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety for WebView URL operations to enhance stability when handling concurrent requests across different execution contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-inappbrowser/pull/532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->