### PR TITLE
[codex] fix Android preventDeeplink blank target links

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -2990,6 +2990,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                 if (_webView != null) {
                     try {
                         _webView.evaluateJavascript(script, null);
+                        injectBlankTargetInCurrentWebViewScript();
                     } catch (Exception e) {
                         Log.e("InAppBrowser", "Error injecting JavaScript interface: " + e.getMessage());
                     }
@@ -3893,12 +3894,120 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         return false;
     }
 
+    private String buildAuthorizedHostsJson(List<String> authorizedLinks) {
+        if (authorizedLinks == null || authorizedLinks.isEmpty()) {
+            return "[]";
+        }
+
+        StringBuilder hostsJson = new StringBuilder("[");
+        boolean hasHost = false;
+        for (String authorized : authorizedLinks) {
+            if (authorized == null) {
+                continue;
+            }
+
+            try {
+                URI authUri = new URI(authorized);
+                String host = authUri.getHost();
+                if (host == null) {
+                    continue;
+                }
+
+                if (host.startsWith("www.")) {
+                    host = host.substring(4);
+                }
+
+                if (hasHost) {
+                    hostsJson.append(",");
+                }
+                hostsJson.append(JSONObject.quote(host.toLowerCase(Locale.ROOT)));
+                hasHost = true;
+            } catch (URISyntaxException e) {
+                Log.e("InAppBrowser", "Skipping invalid authorized app link: " + authorized, e);
+            }
+        }
+
+        hostsJson.append("]");
+        return hostsJson.toString();
+    }
+
+    private void injectBlankTargetInCurrentWebViewScript() {
+        if (_webView == null || _options == null || (!_options.getPreventDeeplink() && !_options.getOpenBlankTargetInWebView())) {
+            return;
+        }
+
+        String authorizedHostsJson = buildAuthorizedHostsJson(_options.getAuthorizedAppLinks());
+        String preventDeeplink = _options.getPreventDeeplink() ? "true" : "false";
+        String script = String.format(
+            Locale.US,
+            """
+            (function() {
+              if (window.__capgoInAppBrowserBlankTargetInCurrentWebView) {
+                return;
+              }
+              window.__capgoInAppBrowserBlankTargetInCurrentWebView = true;
+
+              var authorizedHosts = new Set(%s);
+              var preventDeeplink = %s;
+              var normalizeHost = function(host) {
+                return (host || '').replace(/^www\\./i, '').toLowerCase();
+              };
+
+              document.addEventListener('click', function(event) {
+                var element = event.target;
+                if (!element || typeof element.closest !== 'function') {
+                  return;
+                }
+
+                var anchor = element.closest('a[target][href]');
+                if (!anchor || (anchor.getAttribute('target') || '').toLowerCase() !== '_blank') {
+                  return;
+                }
+
+                var nextUrl;
+                try {
+                  nextUrl = new URL(anchor.getAttribute('href'), window.location.href);
+                } catch (_) {
+                  return;
+                }
+
+                var protocol = nextUrl.protocol.toLowerCase();
+                if (protocol !== 'http:' && protocol !== 'https:') {
+                  return;
+                }
+
+                if (!preventDeeplink && authorizedHosts.has(normalizeHost(nextUrl.hostname))) {
+                  return;
+                }
+
+                event.preventDefault();
+                setTimeout(function() {
+                  window.location.assign(nextUrl.toString());
+                }, 0);
+              }, true);
+            })();
+            """,
+            authorizedHostsJson,
+            preventDeeplink
+        );
+
+        _webView.post(() -> {
+            if (_webView != null) {
+                try {
+                    _webView.evaluateJavascript(script, null);
+                } catch (Exception e) {
+                    Log.e("InAppBrowser", "Error injecting blank target handler: " + e.getMessage());
+                }
+            }
+        });
+    }
+
     private boolean shouldLoadBlankTargetInCurrentWebView(String url) {
         if (!isHttpOrHttpsUrl(url)) {
             return false;
         }
 
-        if (isAuthorizedAppLink(url, _options.getAuthorizedAppLinks())) {
+        if (!_options.getPreventDeeplink() && isAuthorizedAppLink(url, _options.getAuthorizedAppLinks())) {
             return false;
         }
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -3954,6 +3954,10 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
               };
 
               document.addEventListener('click', function(event) {
+                if (event.defaultPrevented) {
+                  return;
+                }
+
                 var element = event.target;
                 if (!element || typeof element.closest !== 'function') {
                   return;
@@ -3966,7 +3970,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
 
                 var nextUrl;
                 try {
-                  nextUrl = new URL(anchor.getAttribute('href'), window.location.href);
+                  nextUrl = new URL(anchor.href);
                 } catch (_) {
                   return;
                 }
@@ -3984,7 +3988,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                 setTimeout(function() {
                   window.location.assign(nextUrl.toString());
                 }, 0);
-              }, true);
+              });
             })();
             """,
             authorizedHostsJson,

--- a/example-app/.maestro/blank-target-http-stays-in-webview.yaml
+++ b/example-app/.maestro/blank-target-http-stays-in-webview.yaml
@@ -34,11 +34,8 @@ androidWebViewHierarchy: devtools
     id: "app.capgo.inappbrowser:id/closeButton"
     label: "Close the plugin webview"
 - extendedWaitUntil:
-    visible: "internal navigation confirmed"
+    visible: ".*internal navigation confirmed.*"
     timeout: 15000
-- assertVisible: "Blank target test status:"
-- assertVisible: "Closed"
-- assertVisible: "Blank target test result:"
-- assertVisible: "internal navigation confirmed"
-- assertVisible: "Blank target last URL:"
-- assertVisible: "https://example.com/#blank-target-webview"
+- assertVisible: ".*Closed.*"
+- assertVisible: ".*internal navigation confirmed.*"
+- assertVisible: ".*https://example.com/#blank-target-webview.*"

--- a/example-app/.maestro/blank-target-http-stays-in-webview.yaml
+++ b/example-app/.maestro/blank-target-http-stays-in-webview.yaml
@@ -30,14 +30,15 @@ androidWebViewHierarchy: devtools
 - extendedWaitUntil:
     visible: "Example Domain"
     timeout: 15000
-- back
 - tapOn:
-    text: "Navigate up"
-    optional: true
-    label: "Close the plugin webview if an external browser opened first"
+    id: "app.capgo.inappbrowser:id/closeButton"
+    label: "Close the plugin webview"
 - extendedWaitUntil:
-    visible: "Blank target test result: internal navigation confirmed"
+    visible: "internal navigation confirmed"
     timeout: 15000
-- assertVisible: "Blank target test status: Closed"
-- assertVisible: "Blank target test result: internal navigation confirmed"
-- assertVisible: "Blank target last URL: https://example.com/#blank-target-webview"
+- assertVisible: "Blank target test status:"
+- assertVisible: "Closed"
+- assertVisible: "Blank target test result:"
+- assertVisible: "internal navigation confirmed"
+- assertVisible: "Blank target last URL:"
+- assertVisible: "https://example.com/#blank-target-webview"

--- a/example-app/src/js/capacitor-welcome.js
+++ b/example-app/src/js/capacitor-welcome.js
@@ -515,7 +515,20 @@ window.customElements.define(
       }
 
       function isBlankTargetEvent(result) {
-        return blankTargetTestActive && result?.id === blankTargetWebViewId;
+        if (!blankTargetTestActive) {
+          return false;
+        }
+
+        if (!result?.id) {
+          return blankTargetWebViewId === null;
+        }
+
+        if (blankTargetWebViewId === null) {
+          blankTargetWebViewId = result.id;
+          return true;
+        }
+
+        return result.id === blankTargetWebViewId;
       }
 
       async function clearBlankTargetListeners() {
@@ -931,7 +944,9 @@ window.customElements.define(
               enabledSafeBottomMargin: true,
               preventDeeplink: true,
             });
-            blankTargetWebViewId = id;
+            if (blankTargetTestActive) {
+              blankTargetWebViewId = id;
+            }
           } catch (e) {
             blankTargetTestActive = false;
             blankTargetWebViewId = null;

--- a/example-app/src/js/capacitor-welcome.js
+++ b/example-app/src/js/capacitor-welcome.js
@@ -929,7 +929,7 @@ window.customElements.define(
               showReloadButton: false,
               activeNativeNavigationForWebview: false,
               enabledSafeBottomMargin: true,
-              openBlankTargetInWebView: true,
+              preventDeeplink: true,
             });
             blankTargetWebViewId = id;
           } catch (e) {

--- a/scripts/start-android-maestro-app.sh
+++ b/scripts/start-android-maestro-app.sh
@@ -6,5 +6,6 @@ package_id="${1:-app.capgo.inappbrowser}"
 activity_name="${2:-app.capgo.inappbrowser/.MainActivity}"
 
 adb wait-for-device >/dev/null
+adb shell am force-stop "$package_id" >/dev/null 2>&1 || true
 adb shell pm clear "$package_id" >/dev/null
 adb shell am start -W -n "$activity_name" >/dev/null


### PR DESCRIPTION
## What
- Fix Android `target="_blank"` HTTP(S) links being swallowed when `preventDeeplink: true` is set.
- Add DOM-level blank-target handling so qualifying links load in the current plugin WebView.
- Update the example blank-target regression harness to exercise `preventDeeplink: true`.

## Why
- Issue #515 reports that Android silently drops blank-target HTTPS links under `preventDeeplink`, making the option unusable for preserving WebView session cookies.

## How
- Inject a click-capture handler when `preventDeeplink` or `openBlankTargetInWebView` is active.
- Resolve blank-target anchor URLs relative to the current page and route HTTP(S) URLs through `window.location.assign`.
- Preserve authorized app-link behavior unless `preventDeeplink` is enabled, where external handling should remain blocked.

## Testing
- `bun run verify`
- `git diff --check`

## Not Tested
- Android emulator Maestro flow was not run locally.
- `bun run lint` still fails on an existing unrelated SwiftLint `type_body_length` violation in `ios/Tests/InAppBrowserPluginTests/InAppBrowserPluginTests.swift`.

## AI
- Prepared with Codex assistance.

Fixes #515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app browser injects a click handler to intercept `target="_blank"` links and (when enabled) open them in the current WebView for smoother navigation.

* **Bug Fixes**
  * Allowlisted app links now bypass interception only when deeplink prevention is disabled.

* **Tests**
  * Automated scenario and event-matching updated to reliably verify `_blank` interception and navigation; explicit close flow asserted.

* **Chores**
  * Android startup script now force-stops the app before reset for consistent test setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-inappbrowser/pull/533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->