### PR TITLE
[codex] fix iOS window close handling

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -1185,6 +1185,19 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
                                 window.webkit.messageHandlers.close.postMessage(null);
                         }\(extraControls)\(screenshotControls)
                 });
+                if (!window.__capgoInAppBrowserWindowCloseInstalled) {
+                        window.__capgoInAppBrowserWindowCloseInstalled = true;
+                        window.__capgoInAppBrowserOriginalClose = window.close;
+                        window.close = function() {
+                                if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.close) {
+                                        window.webkit.messageHandlers.close.postMessage(null);
+                                        return;
+                                }
+                                if (typeof window.__capgoInAppBrowserOriginalClose === 'function') {
+                                        return window.__capgoInAppBrowserOriginalClose.apply(window, arguments);
+                                }
+                        };
+                }
                 """
     }
 
@@ -2422,6 +2435,31 @@ extension WKWebViewController: WKUIDelegate {
                 print("[InAppBrowser] Error presenting alert: \(error)")
                 strongCompletionHandler()
             }
+        }
+    }
+
+    public func webView(_ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (Bool) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                completionHandler(false)
+                return
+            }
+
+            guard self.view.window != nil, !self.isBeingDismissed, !self.isMovingFromParent else {
+                print("[InAppBrowser] Cannot present confirm - view not in window hierarchy or being dismissed")
+                completionHandler(false)
+                return
+            }
+
+            let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+            alertController.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { _ in
+                completionHandler(false)
+            }))
+            alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
+                completionHandler(true)
+            }))
+
+            self.present(alertController, animated: true, completion: nil)
         }
     }
 

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -2438,7 +2438,7 @@ extension WKWebViewController: WKUIDelegate {
         }
     }
 
-    public func webView(_ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (Bool) -> Void) {
+    public func webView(_: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame _: WKFrameInfo, completionHandler: @escaping (Bool) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else {
                 completionHandler(false)
@@ -2447,6 +2447,12 @@ extension WKWebViewController: WKUIDelegate {
 
             guard self.view.window != nil, !self.isBeingDismissed, !self.isMovingFromParent else {
                 print("[InAppBrowser] Cannot present confirm - view not in window hierarchy or being dismissed")
+                completionHandler(false)
+                return
+            }
+
+            guard self.presentedViewController == nil else {
+                print("[InAppBrowser] Cannot present confirm - another controller is already presented")
                 completionHandler(false)
                 return
             }


### PR DESCRIPTION
## What
- Add iOS support for page-driven `window.close()` calls inside `openWebView`.
- Add native handling for JavaScript `confirm()` dialogs in the iOS WKWebView controller.

## Why
- Fixes #531, where hosted payment pages could close correctly on Android but remained open on iOS after their completion flow.

## How
- The injected iOS bridge now wraps `window.close()` once and routes it through the existing native close message handler.
- `WKUIDelegate` now presents a native confirm dialog and returns the selected boolean result to JavaScript.

## Testing
- `bun run verify:ios`
- `bun run verify:web`
- `bun run swiftlint -- lint ios/Sources/InAppBrowserPlugin/WKWebViewController.swift`

## Not Tested
- Full local `bun run verify` could not complete because Android verification needs a Java runtime and this machine has none installed. CI should cover Android.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JavaScript confirmation dialogs now appear as native iOS alerts with Cancel and OK, matching system UI and behavior.

* **Bug Fixes**
  * Improved handling for window close requests with a guarded fallback to ensure reliable and safe close behavior across contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-inappbrowser/pull/534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->