### PR TITLE
[codex] Emit custom scheme intercept events

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ The W3C Payment Request API (used by Google Pay) requires Android WebView 120+. 
 * [`addListener('screenshotTaken', ...)`](#addlistenerscreenshottaken-)
 * [`addListener('browserPageLoaded', ...)`](#addlistenerbrowserpageloaded-)
 * [`addListener('pageLoadError', ...)`](#addlistenerpageloaderror-)
+* [`addListener('customSchemeIntercepted', ...)`](#addlistenercustomschemeintercepted-)
 * [`addListener('downloadCompleted', ...)`](#addlistenerdownloadcompleted-)
 * [`addListener('downloadFailed', ...)`](#addlistenerdownloadfailed-)
 * [`addListener('popupWindowOpened', ...)`](#addlistenerpopupwindowopened-)
@@ -868,6 +869,29 @@ Will be triggered when page load error
 | **`listenerFunc`** | <code>(event: { id?: string; }) =&gt; void</code> |
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+--------------------
+
+
+### addListener('customSchemeIntercepted', ...)
+
+```typescript
+addListener(eventName: 'customSchemeIntercepted', listenerFunc: CustomSchemeInterceptedListener) => Promise<PluginListenerHandle>
+```
+
+Will be triggered when the webview intercepts a non-standard custom scheme
+and hands it to the operating system.
+
+Standard OS-handled schemes such as `tel:`, `mailto:`, and `sms:` are excluded.
+
+| Param              | Type                                                                                        |
+| ------------------ | ------------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code>'customSchemeIntercepted'</code>                                                      |
+| **`listenerFunc`** | <code><a href="#customschemeinterceptedlistener">CustomSchemeInterceptedListener</a></code> |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+**Since:** 8.6.7
 
 --------------------
 
@@ -1326,6 +1350,20 @@ Any regex property that is omitted is treated as a wildcard.
 | **`url`** | <code>string</code> | Emit when a button is clicked. | 0.0.1 |
 
 
+#### CustomSchemeInterceptedEvent
+
+Event emitted when the managed webview intercepts a non-standard custom scheme
+and hands it to the operating system.
+
+Standard OS-handled schemes such as `tel:`, `mailto:`, and `sms:` are excluded.
+
+| Prop         | Type                 | Description                                            |
+| ------------ | -------------------- | ------------------------------------------------------ |
+| **`id`**     | <code>string</code>  | Webview instance id.                                   |
+| **`url`**    | <code>string</code>  | Intercepted URL.                                       |
+| **`opened`** | <code>boolean</code> | Whether the operating system accepted the URL handoff. |
+
+
 #### DownloadCompletedEvent
 
 Event emitted after a managed download is saved locally.
@@ -1522,6 +1560,11 @@ Construct a type with a set of properties K of type T
 #### ConfirmBtnListener
 
 <code>(state: <a href="#btnevent">BtnEvent</a>): void</code>
+
+
+#### CustomSchemeInterceptedListener
+
+<code>(state: <a href="#customschemeinterceptedevent">CustomSchemeInterceptedEvent</a>): void</code>
 
 
 #### DownloadHandledBy

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CustomSchemeInterceptSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CustomSchemeInterceptSupport.java
@@ -1,0 +1,51 @@
+package ee.forgr.capacitor_inappbrowser;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+final class CustomSchemeInterceptSupport {
+
+    private static final Set<String> EXCLUDED_SCHEMES = new HashSet<>(Arrays.asList("http", "https", "file", "tel", "mailto", "sms"));
+
+    private CustomSchemeInterceptSupport() {}
+
+    static boolean shouldEmitInterceptEvent(String rawUrl) {
+        String scheme = extractScheme(rawUrl);
+        return scheme != null && !EXCLUDED_SCHEMES.contains(scheme);
+    }
+
+    private static String extractScheme(String rawUrl) {
+        if (rawUrl == null || rawUrl.isBlank()) {
+            return null;
+        }
+
+        int separatorIndex = rawUrl.indexOf(':');
+        if (separatorIndex <= 0) {
+            return null;
+        }
+
+        String scheme = rawUrl.substring(0, separatorIndex);
+        if (!isAsciiLetter(scheme.charAt(0))) {
+            return null;
+        }
+
+        for (int index = 1; index < scheme.length(); index++) {
+            char character = scheme.charAt(index);
+            if (!isAsciiLetter(character) && !isAsciiDigit(character) && character != '+' && character != '-' && character != '.') {
+                return null;
+            }
+        }
+
+        return scheme.toLowerCase(Locale.ROOT);
+    }
+
+    private static boolean isAsciiLetter(char character) {
+        return (character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z');
+    }
+
+    private static boolean isAsciiDigit(char character) {
+        return character >= '0' && character <= '9';
+    }
+}

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -150,6 +150,11 @@ public class InAppBrowserPlugin extends Plugin implements WebViewDialog.Permissi
             }
 
             @Override
+            public void customSchemeIntercepted(String url, boolean opened) {
+                notifyListeners("customSchemeIntercepted", new JSObject().put("id", webViewId).put("url", url).put("opened", opened));
+            }
+
+            @Override
             public void buttonNearDoneClicked() {
                 notifyListeners("buttonNearDoneClick", new JSObject().put("id", webViewId));
             }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCallbacks.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCallbacks.java
@@ -11,6 +11,8 @@ public interface WebViewCallbacks {
 
     public void pageLoadError();
 
+    public void customSchemeIntercepted(String url, boolean opened);
+
     public void javascriptCallback(String message);
 
     public void consoleMessage(String level, String message, String source, Integer line, Integer column);

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -4105,6 +4105,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                     }
 
                     if (isNotHttpOrHttps) {
+                        boolean shouldEmitCustomSchemeEvent = CustomSchemeInterceptSupport.shouldEmitInterceptEvent(url);
                         try {
                             Intent intent;
                             if (url.startsWith("intent:")) {
@@ -4114,9 +4115,15 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                             }
                             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                             context.startActivity(intent);
+                            if (shouldEmitCustomSchemeEvent && _options.getCallbacks() != null) {
+                                _options.getCallbacks().customSchemeIntercepted(url, true);
+                            }
                             return true;
                         } catch (ActivityNotFoundException | URISyntaxException e) {
                             Log.w("InAppBrowser", "No handler for external URL: " + url, e);
+                            if (shouldEmitCustomSchemeEvent && _options.getCallbacks() != null) {
+                                _options.getCallbacks().customSchemeIntercepted(url, false);
+                            }
                             // Notify that a page load error occurred
                             if (_options.getCallbacks() != null && request.isForMainFrame()) {
                                 _options.getCallbacks().pageLoadError();

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -4119,11 +4119,19 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                                 _options.getCallbacks().customSchemeIntercepted(url, true);
                             }
                             return true;
-                        } catch (ActivityNotFoundException | URISyntaxException e) {
+                        } catch (ActivityNotFoundException e) {
                             Log.w("InAppBrowser", "No handler for external URL: " + url, e);
                             if (shouldEmitCustomSchemeEvent && _options.getCallbacks() != null) {
                                 _options.getCallbacks().customSchemeIntercepted(url, false);
                             }
+                            // Notify that a page load error occurred
+                            if (_options.getCallbacks() != null && request.isForMainFrame()) {
+                                _options.getCallbacks().pageLoadError();
+                                rejectOpenWebViewIfNeeded("No handler available for external URL: " + url);
+                            }
+                            return true; // prevent WebView from attempting to load the custom scheme
+                        } catch (URISyntaxException e) {
+                            Log.w("InAppBrowser", "No handler for external URL: " + url, e);
                             // Notify that a page load error occurred
                             if (_options.getCallbacks() != null && request.isForMainFrame()) {
                                 _options.getCallbacks().pageLoadError();

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/CustomSchemeInterceptSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/CustomSchemeInterceptSupportTest.java
@@ -1,0 +1,33 @@
+package ee.forgr.capacitor_inappbrowser;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class CustomSchemeInterceptSupportTest {
+
+    @Test
+    public void emitsForNonStandardCustomSchemes() {
+        assertTrue(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("myapp://callback/success"));
+        assertTrue(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("com.example.app://oauth/callback"));
+        assertTrue(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("intent://scan/#Intent;scheme=zxing;end"));
+    }
+
+    @Test
+    public void skipsWebFileAndStandardOsSchemes() {
+        assertFalse(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("https://example.com"));
+        assertFalse(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("http://example.com"));
+        assertFalse(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("file:///android_asset/index.html"));
+        assertFalse(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("tel:+15555550123"));
+        assertFalse(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("MAILTO:test@example.com"));
+        assertFalse(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("sms:+15555550123"));
+    }
+
+    @Test
+    public void skipsUrlsWithoutValidSchemes() {
+        assertFalse(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("/callback/success"));
+        assertFalse(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("1app://callback/success"));
+        assertFalse(CustomSchemeInterceptSupport.shouldEmitInterceptEvent(null));
+    }
+}

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -14,9 +14,21 @@ private let estimatedProgressKeyPath = "estimatedProgress"
 private let titleKeyPath = "title"
 private let cookieKey = "Cookie"
 
+enum CustomSchemeInterceptSupport {
+    static let standardHandledSchemes = ["tel", "mailto", "sms"]
+    private static let webSchemes = ["http", "https", "file"]
+
+    static func shouldEmitInterceptEvent(for url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased(), !scheme.isEmpty else {
+            return false
+        }
+        return !webSchemes.contains(scheme) && !standardHandledSchemes.contains(scheme)
+    }
+}
+
 private struct UrlsHandledByApp {
     static var hosts = ["itunes.apple.com"]
-    static var schemes = ["tel", "mailto", "sms"]
+    static var schemes = CustomSchemeInterceptSupport.standardHandledSchemes
 }
 
 private struct WKDownloadState {
@@ -2056,13 +2068,20 @@ fileprivate extension WKWebViewController {
 
     private func tryOpenCustomScheme(_ url: URL) -> Bool {
         let app = UIApplication.shared
+        let shouldEmitCustomSchemeEvent = CustomSchemeInterceptSupport.shouldEmitInterceptEvent(for: url)
 
         if app.canOpenURL(url) {
             app.open(url, options: [:], completionHandler: nil)
+            if shouldEmitCustomSchemeEvent {
+                emit("customSchemeIntercepted", data: ["url": url.absoluteString, "opened": true])
+            }
             return true // external app opened -> cancel WebView load
         }
 
         // Cannot open scheme: notify and still block WebView (avoid rendering garbage / errors)
+        if shouldEmitCustomSchemeEvent {
+            emit("customSchemeIntercepted", data: ["url": url.absoluteString, "opened": false])
+        }
         emit("pageLoadError")
         return true
     }

--- a/ios/Tests/InAppBrowserPluginTests/ConsoleMessageSupportTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/ConsoleMessageSupportTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import InappbrowserPlugin
+
+final class ConsoleMessageSupportTests: XCTestCase {
+    func testConsoleMessagePayloadNormalizesFields() {
+        let payload = ConsoleMessageSupport.normalizePayload(
+            from: [
+                "level": "WARN",
+                "message": "popup blocked",
+                "source": "https://example.com/app.js",
+                "line": NSNumber(value: 42),
+                "column": "7",
+                "kind": "console"
+            ]
+        )
+
+        XCTAssertEqual(payload["level"] as? String, "warn")
+        XCTAssertEqual(payload["message"] as? String, "popup blocked")
+        XCTAssertEqual(payload["source"] as? String, "https://example.com/app.js")
+        XCTAssertEqual(payload["line"] as? Int, 42)
+        XCTAssertEqual(payload["column"] as? Int, 7)
+        XCTAssertEqual(payload["kind"] as? String, "console")
+    }
+
+    func testConsoleMessagePayloadDefaultsInvalidValues() {
+        let payload = ConsoleMessageSupport.normalizePayload(
+            from: [
+                "level": "unexpected",
+                "message": NSNumber(value: 15)
+            ]
+        )
+
+        XCTAssertEqual(payload["level"] as? String, "log")
+        XCTAssertEqual(payload["message"] as? String, "15")
+        XCTAssertNil(payload["source"])
+        XCTAssertNil(payload["line"])
+    }
+
+    func testConsoleCaptureScriptContainsExpectedHooks() {
+        let script = ConsoleMessageSupport.captureScriptSource()
+
+        XCTAssertTrue(script.contains("consoleMessageHandler"))
+        XCTAssertTrue(script.contains("unhandledrejection"))
+        XCTAssertTrue(script.contains("console.assert"))
+    }
+}

--- a/ios/Tests/InAppBrowserPluginTests/CustomSchemeInterceptSupportTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/CustomSchemeInterceptSupportTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import InappbrowserPlugin
+
+final class CustomSchemeInterceptSupportTests: XCTestCase {
+    func testEmitsForNonStandardCustomSchemes() throws {
+        XCTAssertTrue(
+            CustomSchemeInterceptSupport.shouldEmitInterceptEvent(for: try XCTUnwrap(URL(string: "myapp://callback/success")))
+        )
+        XCTAssertTrue(
+            CustomSchemeInterceptSupport.shouldEmitInterceptEvent(for: try XCTUnwrap(URL(string: "com.example.app://oauth/callback")))
+        )
+    }
+
+    func testSkipsWebFileAndStandardOsSchemes() throws {
+        XCTAssertFalse(
+            CustomSchemeInterceptSupport.shouldEmitInterceptEvent(for: try XCTUnwrap(URL(string: "https://example.com")))
+        )
+        XCTAssertFalse(
+            CustomSchemeInterceptSupport.shouldEmitInterceptEvent(for: try XCTUnwrap(URL(string: "http://example.com")))
+        )
+        XCTAssertFalse(
+            CustomSchemeInterceptSupport.shouldEmitInterceptEvent(for: try XCTUnwrap(URL(string: "file:///tmp/index.html")))
+        )
+        XCTAssertFalse(
+            CustomSchemeInterceptSupport.shouldEmitInterceptEvent(for: try XCTUnwrap(URL(string: "tel:+15555550123")))
+        )
+        XCTAssertFalse(
+            CustomSchemeInterceptSupport.shouldEmitInterceptEvent(for: try XCTUnwrap(URL(string: "mailto:test@example.com")))
+        )
+        XCTAssertFalse(
+            CustomSchemeInterceptSupport.shouldEmitInterceptEvent(for: try XCTUnwrap(URL(string: "sms:+15555550123")))
+        )
+    }
+}

--- a/ios/Tests/InAppBrowserPluginTests/InAppBrowserPluginTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/InAppBrowserPluginTests.swift
@@ -2,48 +2,6 @@ import XCTest
 @testable import InappbrowserPlugin
 
 final class InAppBrowserPluginTests: XCTestCase {
-    func testConsoleMessagePayloadNormalizesFields() {
-        let payload = ConsoleMessageSupport.normalizePayload(
-            from: [
-                "level": "WARN",
-                "message": "popup blocked",
-                "source": "https://example.com/app.js",
-                "line": NSNumber(value: 42),
-                "column": "7",
-                "kind": "console"
-            ]
-        )
-
-        XCTAssertEqual(payload["level"] as? String, "warn")
-        XCTAssertEqual(payload["message"] as? String, "popup blocked")
-        XCTAssertEqual(payload["source"] as? String, "https://example.com/app.js")
-        XCTAssertEqual(payload["line"] as? Int, 42)
-        XCTAssertEqual(payload["column"] as? Int, 7)
-        XCTAssertEqual(payload["kind"] as? String, "console")
-    }
-
-    func testConsoleMessagePayloadDefaultsInvalidValues() {
-        let payload = ConsoleMessageSupport.normalizePayload(
-            from: [
-                "level": "unexpected",
-                "message": NSNumber(value: 15)
-            ]
-        )
-
-        XCTAssertEqual(payload["level"] as? String, "log")
-        XCTAssertEqual(payload["message"] as? String, "15")
-        XCTAssertNil(payload["source"])
-        XCTAssertNil(payload["line"])
-    }
-
-    func testConsoleCaptureScriptContainsExpectedHooks() {
-        let script = ConsoleMessageSupport.captureScriptSource()
-
-        XCTAssertTrue(script.contains("consoleMessageHandler"))
-        XCTAssertTrue(script.contains("unhandledrejection"))
-        XCTAssertTrue(script.contains("console.assert"))
-    }
-
     func testLegacyProxyRequestsConfigurationSupportsBooleanValues() {
         let enabled = ProxySchemeRequestSupport.legacyProxyRequestsConfiguration(from: true)
         XCTAssertTrue(enabled.isEnabled)

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -12,6 +12,29 @@ export interface UrlEvent {
    */
   url: string;
 }
+
+/**
+ * Event emitted when the managed webview intercepts a non-standard custom scheme
+ * and hands it to the operating system.
+ *
+ * Standard OS-handled schemes such as `tel:`, `mailto:`, and `sms:` are excluded.
+ *
+ * @since 8.6.7
+ */
+export interface CustomSchemeInterceptedEvent {
+  /**
+   * Webview instance id.
+   */
+  id?: string;
+  /**
+   * Intercepted URL.
+   */
+  url: string;
+  /**
+   * Whether the operating system accepted the URL handoff.
+   */
+  opened: boolean;
+}
 export interface BtnEvent {
   /**
    * Webview instance id.
@@ -28,6 +51,7 @@ export interface BtnEvent {
 export type UrlChangeListener = (state: UrlEvent) => void;
 export type ConfirmBtnListener = (state: BtnEvent) => void;
 export type ButtonNearListener = (state: object) => void;
+export type CustomSchemeInterceptedListener = (state: CustomSchemeInterceptedEvent) => void;
 
 export enum BackgroundColor {
   WHITE = 'white',
@@ -1295,6 +1319,18 @@ export interface InAppBrowserPlugin {
   addListener(
     eventName: 'pageLoadError',
     listenerFunc: (event: { id?: string }) => void,
+  ): Promise<PluginListenerHandle>;
+  /**
+   * Will be triggered when the webview intercepts a non-standard custom scheme
+   * and hands it to the operating system.
+   *
+   * Standard OS-handled schemes such as `tel:`, `mailto:`, and `sms:` are excluded.
+   *
+   * @since 8.6.7
+   */
+  addListener(
+    eventName: 'customSchemeIntercepted',
+    listenerFunc: CustomSchemeInterceptedListener,
   ): Promise<PluginListenerHandle>;
   /**
    * Will be triggered after native download handling saves a file locally.


### PR DESCRIPTION
## What
- Add a new `customSchemeIntercepted` listener event with `{ id?, url, opened }` payload.
- Emit the event from iOS and Android when a managed WebView intercepts a non-standard custom scheme and hands it to the OS.
- Keep standard OS-handled schemes (`tel:`, `mailto:`, `sms:`), file URLs, HTTP(S), and authorized app/universal link behavior unchanged.
- Add Android and iOS tests for the custom-scheme event filtering.

## Why
- Fixes #516.
- Apps migrating from `cordova-plugin-inappbrowser` need a JS-side signal when backend-rendered flows finish through a custom deeplink redirect, even when the WebView URL itself does not change.

## How
- Added a typed `CustomSchemeInterceptedEvent` and generated README docs.
- Added shared native filtering helpers so only non-standard custom schemes emit the new event.
- Wired native event callbacks after successful external handoff and in the no-handler failure path.

## Testing
- `JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/Users/martindonadieu/Library/Android/sdk bun run verify`
- `xcodebuild test -scheme CapgoInappbrowser -destination 'id=F688C88A-C182-41FF-995F-A90ADE5056A0'`

## Not Tested
- Manual deeplink handoff against a real third-party app registration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `customSchemeIntercepted` event that notifies when a managed webview intercepts non-standard custom schemes, including the intercepted URL, whether the OS opened it, and an optional webview id.

* **Documentation**
  * API docs updated with the new listener and event type details.

* **Tests**
  * Added cross-platform tests for custom-scheme interception and introduced a dedicated console-message test suite (console-related tests reorganized).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-inappbrowser/pull/536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->