### PR TITLE
test: add Maestro feature smoke coverage

### DIFF
--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -1,6 +1,10 @@
 ## Maestro
 
-This folder contains Android regression coverage for the example app.
+This folder contains Maestro coverage for the example app.
+
+### Example app smoke test
+
+`android/example-app-smoke.yaml` runs the broader example app smoke test. It uses a self-contained feature harness in the app to exercise managed WebView APIs, proxy handling, JavaScript messaging, screenshots, visibility controls, dimensions, cookies, navigation, reload, popup handling, close events, and then runs the native download handling smoke test.
 
 ### Download handling smoke test
 

--- a/.maestro/android/example-app-smoke.yaml
+++ b/.maestro/android/example-app-smoke.yaml
@@ -1,0 +1,3 @@
+appId: app.capgo.inappbrowser
+---
+- runFlow: ../example-app-api-smoke-android.yaml

--- a/.maestro/download-handling-android.yaml
+++ b/.maestro/download-handling-android.yaml
@@ -1,14 +1,16 @@
 appId: app.capgo.inappbrowser
 ---
 - extendedWaitUntil:
-    visible: "InAppBrowser Test App"
+    visible: 'InAppBrowser Test App'
     timeout: 20000
 - extendedWaitUntil:
-    visible: "Open Auto Download Demo \\+ Close On Event"
+    visible: "Run Download Event \\(Maestro\\)"
     timeout: 20000
-- tapOn: "Open Auto Download Demo + Close On Event"
+- tapOn:
+    id: 'maestro-run-download'
+    retryTapIfNoChange: true
 - extendedWaitUntil:
     visible: "Event OK: capgo-download-demo(-\\d+)?\\.txt"
     timeout: 30000
-- assertVisible: "InAppBrowser Test App"
+- assertVisible: 'InAppBrowser Test App'
 - assertVisible: "Event OK: capgo-download-demo(-\\d+)?\\.txt"

--- a/.maestro/example-app-api-smoke-android.yaml
+++ b/.maestro/example-app-api-smoke-android.yaml
@@ -1,0 +1,31 @@
+appId: app.capgo.inappbrowser
+androidWebViewHierarchy: devtools
+---
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "Wait"
+    optional: true
+    label: "Dismiss the transient Pixel Launcher ANR dialog before waiting for the harness"
+- extendedWaitUntil:
+    visible: "Feature smoke ready"
+    timeout: 240000
+- tapOn:
+    id: "maestro-run-feature-smoke"
+    retryTapIfNoChange: true
+- extendedWaitUntil:
+    visible: "Feature smoke passed"
+    timeout: 240000
+- scrollUntilVisible:
+    element: "Open Auto Download Demo \\+ Close On Event"
+    direction: DOWN
+    timeout: 30000
+    centerElement: true
+- tapOn:
+    text: "Open Auto Download Demo \\+ Close On Event"
+    retryTapIfNoChange: true
+- extendedWaitUntil:
+    visible: "Event OK: capgo-download-demo(-\\d+)?\\.txt"
+    timeout: 30000
+- assertVisible: "Feature smoke passed"
+- assertVisible: "Event OK: capgo-download-demo(-\\d+)?\\.txt"

--- a/.maestro/example-app-api-smoke-android.yaml
+++ b/.maestro/example-app-api-smoke-android.yaml
@@ -22,7 +22,7 @@ androidWebViewHierarchy: devtools
     timeout: 30000
     centerElement: true
 - tapOn:
-    text: "Open Auto Download Demo \\+ Close On Event"
+    id: "open-download-demo-listener"
     retryTapIfNoChange: true
 - extendedWaitUntil:
     visible: "Event OK: capgo-download-demo(-\\d+)?\\.txt"

--- a/.maestro/example-app-api-smoke-android.yaml
+++ b/.maestro/example-app-api-smoke-android.yaml
@@ -4,28 +4,23 @@ androidWebViewHierarchy: devtools
 - launchApp:
     clearState: true
 - tapOn:
-    text: "Wait"
+    text: 'Wait'
     optional: true
-    label: "Dismiss the transient Pixel Launcher ANR dialog before waiting for the harness"
+    label: 'Dismiss the transient Pixel Launcher ANR dialog before waiting for the harness'
 - extendedWaitUntil:
-    visible: "Feature smoke ready"
+    visible: 'Feature smoke ready'
     timeout: 240000
 - tapOn:
-    id: "maestro-run-feature-smoke"
+    id: 'maestro-run-feature-smoke'
     retryTapIfNoChange: true
 - extendedWaitUntil:
-    visible: "Feature smoke passed"
+    visible: 'Feature smoke passed'
     timeout: 240000
-- scrollUntilVisible:
-    element: "Open Auto Download Demo \\+ Close On Event"
-    direction: DOWN
-    timeout: 30000
-    centerElement: true
 - tapOn:
-    id: "open-download-demo-listener"
+    id: 'maestro-run-download'
     retryTapIfNoChange: true
 - extendedWaitUntil:
     visible: "Event OK: capgo-download-demo(-\\d+)?\\.txt"
     timeout: 30000
-- assertVisible: "Feature smoke passed"
+- assertVisible: 'Feature smoke passed'
 - assertVisible: "Event OK: capgo-download-demo(-\\d+)?\\.txt"

--- a/example-app/.maestro/blank-target-http-stays-in-webview.yaml
+++ b/example-app/.maestro/blank-target-http-stays-in-webview.yaml
@@ -10,13 +10,17 @@ androidWebViewHierarchy: devtools
     label: "Dismiss the transient Pixel Launcher ANR dialog before waiting for the harness"
 - launchApp:
     clearState: false
-- extendedWaitUntil:
-    visible: "Maestro Ready"
-    timeout: 240000
-- tapOn:
-    text: "Wait"
-    optional: true
-    label: "Dismiss the transient Pixel Launcher ANR dialog when it appears"
+- retry:
+    maxRetries: 3
+    commands:
+      - runFlow:
+          when:
+            visible: "Wait"
+          commands:
+            - tapOn: "Wait"
+      - extendedWaitUntil:
+          visible: "Maestro Ready"
+          timeout: 60000
 - tapOn:
     id: "maestro-run-blank-target"
     retryTapIfNoChange: true

--- a/example-app/.maestro/blank-target-http-stays-in-webview.yaml
+++ b/example-app/.maestro/blank-target-http-stays-in-webview.yaml
@@ -10,17 +10,22 @@ androidWebViewHierarchy: devtools
     label: "Dismiss the transient Pixel Launcher ANR dialog before waiting for the harness"
 - launchApp:
     clearState: false
-- retry:
-    maxRetries: 3
+- repeat:
+    times: 16
+    while:
+      notVisible: "Maestro Ready"
     commands:
-      - runFlow:
-          when:
-            visible: "Wait"
-          commands:
-            - tapOn: "Wait"
+      - tapOn:
+          text: "Wait"
+          optional: true
+          label: "Dismiss the transient Pixel Launcher ANR dialog while waiting for the harness"
       - extendedWaitUntil:
           visible: "Maestro Ready"
-          timeout: 60000
+          timeout: 15000
+          optional: true
+- extendedWaitUntil:
+    visible: "Maestro Ready"
+    timeout: 15000
 - tapOn:
     id: "maestro-run-blank-target"
     retryTapIfNoChange: true

--- a/example-app/src/index.html
+++ b/example-app/src/index.html
@@ -64,6 +64,13 @@
         >
           Run Feature Smoke (Maestro)
         </button>
+        <button
+          id="maestro-run-download"
+          disabled
+          style="padding: 10px 12px; border: 0; border-radius: 6px; background: #0ea5e9; color: #fff; font-size: 14px;"
+        >
+          Run Download Event (Maestro)
+        </button>
       </div>
       <div id="maestro-proxy-status" style="margin-top: 8px; font-size: 14px;">Not started</div>
       <div id="maestro-proxy-details" style="margin-top: 4px; font-size: 13px; white-space: pre-wrap;"></div>
@@ -73,6 +80,7 @@
       <div id="maestro-blank-target-details" style="margin-top: 4px; font-size: 13px; white-space: pre-wrap;"></div>
       <div id="maestro-feature-smoke-status" style="margin-top: 8px; font-size: 14px;">Feature smoke booting</div>
       <div id="maestro-feature-smoke-details" style="margin-top: 4px; font-size: 13px; white-space: pre-wrap;"></div>
+      <div id="maestro-download-status" style="margin-top: 8px; font-size: 14px;">Download not started</div>
     </div>
     <capacitor-welcome></capacitor-welcome>
 

--- a/example-app/src/index.html
+++ b/example-app/src/index.html
@@ -57,6 +57,13 @@
         >
           Run Blank Target Regression (Maestro)
         </button>
+        <button
+          id="maestro-run-feature-smoke"
+          disabled
+          style="padding: 10px 12px; border: 0; border-radius: 6px; background: #854d0e; color: #fff; font-size: 14px;"
+        >
+          Run Feature Smoke (Maestro)
+        </button>
       </div>
       <div id="maestro-proxy-status" style="margin-top: 8px; font-size: 14px;">Not started</div>
       <div id="maestro-proxy-details" style="margin-top: 4px; font-size: 13px; white-space: pre-wrap;"></div>
@@ -64,6 +71,8 @@
       <div id="maestro-keyboard-details" style="margin-top: 4px; font-size: 13px; white-space: pre-wrap;"></div>
       <div id="maestro-blank-target-status" style="margin-top: 8px; font-size: 14px;">Not started</div>
       <div id="maestro-blank-target-details" style="margin-top: 4px; font-size: 13px; white-space: pre-wrap;"></div>
+      <div id="maestro-feature-smoke-status" style="margin-top: 8px; font-size: 14px;">Feature smoke booting</div>
+      <div id="maestro-feature-smoke-details" style="margin-top: 4px; font-size: 13px; white-space: pre-wrap;"></div>
     </div>
     <capacitor-welcome></capacitor-welcome>
 

--- a/example-app/src/js/capacitor-welcome.js
+++ b/example-app/src/js/capacitor-welcome.js
@@ -9,6 +9,7 @@ import {
 import { setupProxyDemoButtons } from "./proxy-demo.js";
 import { setupProxyRegression } from "./proxy-regression.js";
 import { attachKeyboardRegressionHarness } from "./keyboard-regression.js";
+import { attachFeatureSmokeHarness } from "./feature-smoke.js";
 import { url as configuredTestWebappUrl } from "./url.js";
 
 // Default URL configuration
@@ -286,6 +287,7 @@ window.customElements.define(
       const self = this;
 
       attachKeyboardRegressionHarness();
+      attachFeatureSmokeHarness();
 
       // Helper function to validate URL
       function isValidUrl(string) {

--- a/example-app/src/js/capacitor-welcome.js
+++ b/example-app/src/js/capacitor-welcome.js
@@ -364,6 +364,14 @@ window.customElements.define(
       let closeOnNextDownloadEvent = false;
       const downloadStatusElement = () => self.shadowRoot.querySelector("#download-event-status");
       const downloadListenerButtonElement = () => self.shadowRoot.querySelector("#open-download-demo-listener");
+      const maestroRunDownloadButton = document.getElementById("maestro-run-download");
+      const maestroDownloadStatus = document.getElementById("maestro-download-status");
+
+      function setMaestroDownloadStatus(message) {
+        if (maestroDownloadStatus) {
+          maestroDownloadStatus.textContent = message;
+        }
+      }
 
       function setDownloadStatus(message, { backgroundColor = "#f8f9fa", color = "#495057" } = {}) {
         const statusElement = downloadStatusElement();
@@ -401,7 +409,12 @@ window.customElements.define(
 
         downloadListenerHandles = await Promise.all([
           InAppBrowser.addListener("downloadCompleted", (event) => {
-            setDownloadListenerButtonLabel(`Event OK: ${event.fileName}`);
+            const successLabel = `Event OK: ${event.fileName}`;
+            setDownloadListenerButtonLabel(successLabel);
+            setMaestroDownloadStatus(successLabel);
+            if (maestroRunDownloadButton) {
+              maestroRunDownloadButton.disabled = false;
+            }
             setDownloadStatus(
               `Download completed: ${event.fileName} via ${event.handledBy}`,
               { backgroundColor: "#dcfce7", color: "#166534" },
@@ -417,6 +430,10 @@ window.customElements.define(
           InAppBrowser.addListener("downloadFailed", (event) => {
             closeOnNextDownloadEvent = false;
             setDownloadListenerButtonLabel("Event Failed");
+            setMaestroDownloadStatus("Event Failed");
+            if (maestroRunDownloadButton) {
+              maestroRunDownloadButton.disabled = false;
+            }
             const fileLabel = event.fileName ? ` for ${event.fileName}` : "";
             setDownloadStatus(
               `Download failed${fileLabel}: ${event.error}`,
@@ -431,22 +448,24 @@ window.customElements.define(
       async function openAutoDownloadDemo({ closeOnEvent = false } = {}) {
         const handleDownloadsToggle = self.shadowRoot.querySelector("#handle-downloads-toggle");
         closeOnNextDownloadEvent = closeOnEvent && handleDownloadsToggle.checked;
+        if (maestroRunDownloadButton) {
+          maestroRunDownloadButton.disabled = true;
+        }
         setDownloadListenerButtonLabel(
           closeOnEvent && handleDownloadsToggle.checked
             ? "Waiting For Download Event..."
             : "Open Auto Download Demo + Close On Event",
         );
-        setDownloadStatus(
-          handleDownloadsToggle.checked
-            ? closeOnEvent
-              ? "Waiting for native download event, then closing the webview..."
-              : "Waiting for native download event..."
-            : "Native download handling disabled for this run.",
-          {
-            backgroundColor: handleDownloadsToggle.checked ? "#e0f2fe" : "#f8f9fa",
-            color: handleDownloadsToggle.checked ? "#075985" : "#495057",
-          },
-        );
+        const downloadMessage = handleDownloadsToggle.checked
+          ? closeOnEvent
+            ? "Waiting for native download event, then closing the webview..."
+            : "Waiting for native download event..."
+          : "Native download handling disabled for this run.";
+        setMaestroDownloadStatus(downloadMessage);
+        setDownloadStatus(downloadMessage, {
+          backgroundColor: handleDownloadsToggle.checked ? "#e0f2fe" : "#f8f9fa",
+          color: handleDownloadsToggle.checked ? "#075985" : "#495057",
+        });
 
         try {
           await createDownloadListeners();
@@ -463,6 +482,10 @@ window.customElements.define(
           });
         } catch (error) {
           closeOnNextDownloadEvent = false;
+          if (maestroRunDownloadButton) {
+            maestroRunDownloadButton.disabled = false;
+          }
+          setMaestroDownloadStatus("Download open failed");
           console.error("Error opening auto download demo:", error);
         }
       }
@@ -1094,6 +1117,13 @@ window.customElements.define(
         .addEventListener("click", async function () {
           await openAutoDownloadDemo({ closeOnEvent: true });
         });
+
+      if (maestroRunDownloadButton) {
+        maestroRunDownloadButton.addEventListener("click", async function () {
+          await openAutoDownloadDemo({ closeOnEvent: true });
+        });
+        maestroRunDownloadButton.disabled = false;
+      }
 
       self.shadowRoot
         .querySelector("#system-bars-show-all")

--- a/example-app/src/js/feature-smoke.js
+++ b/example-app/src/js/feature-smoke.js
@@ -134,7 +134,461 @@ function withMaestroNativeHarness(callback) {
 
   try {
     callback(harness);
-  } catch (_error) {}
+  } catch (error) {
+    console.warn("Unable to update Maestro native harness", error);
+  }
+}
+
+async function waitUntil(label, predicate, timeout = TIMEOUT_MS) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeout) {
+    const result = await predicate();
+    if (result) {
+      return result;
+    }
+    await sleep(100);
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+function featureSmokeProxyResponse(request) {
+  if (request.url === ENTRY_URL || request.url === HISTORY_ENTRY_URL || request.url === SECOND_URL) {
+    return textResponse(ENTRY_HTML, "text/html");
+  }
+  if (request.url === POPUP_URL) {
+    return textResponse(POPUP_HTML, "text/html");
+  }
+  if (request.url === SCRIPT_URL) {
+    return textResponse(SMOKE_SCRIPT, "application/javascript");
+  }
+  return null;
+}
+
+function createSmokeContext(setStatus) {
+  const ctx = {
+    closeEvents: [],
+    consoleMessages: [],
+    handles: [],
+    messages: [],
+    pageLoads: [],
+    popupEvents: [],
+    popupId: null,
+    screenshots: [],
+    setStatus,
+    steps: [],
+    urlChanges: [],
+    webviewId: null,
+  };
+
+  ctx.markStep = (step) => {
+    ctx.steps.push(step);
+    ctx.setStatus(`Feature smoke running: ${step}`, ctx.steps.join("\n"));
+  };
+  ctx.waitForMessage = (step, timeout) =>
+    waitUntil(step, () => ctx.messages.find((message) => message.step === step), timeout);
+
+  return ctx;
+}
+
+function recordFeatureMessage(ctx, event) {
+  const detail = event.detail || {};
+  if (detail.type !== "featureSmoke") {
+    return;
+  }
+  ctx.messages.push({
+    id: event.id,
+    ...detail,
+  });
+}
+
+function recordPageLoadError(ctx, event) {
+  ctx.messages.push({
+    id: event.id,
+    step: "page-load-error",
+  });
+}
+
+async function setupSmokeHarness(ctx) {
+  await InAppBrowser.removeAllListeners();
+  await InAppBrowser.clearAllCookies();
+  await InAppBrowser.clearCache();
+
+  const listenerHandles = await Promise.all([
+    InAppBrowser.addListener("messageFromWebview", (event) => recordFeatureMessage(ctx, event)),
+    InAppBrowser.addListener("consoleMessage", (event) => ctx.consoleMessages.push(event)),
+    InAppBrowser.addListener("screenshotTaken", (event) => ctx.screenshots.push(event)),
+    InAppBrowser.addListener("popupWindowOpened", (event) => ctx.popupEvents.push(event)),
+    InAppBrowser.addListener("browserPageLoaded", (event) => ctx.pageLoads.push(event)),
+    InAppBrowser.addListener("urlChangeEvent", (event) => ctx.urlChanges.push(event)),
+    InAppBrowser.addListener("closeEvent", (event) => ctx.closeEvents.push(event)),
+    InAppBrowser.addListener("pageLoadError", (event) => recordPageLoadError(ctx, event)),
+  ]);
+  const proxyHandle = await addProxyHandler(featureSmokeProxyResponse);
+  ctx.handles.push(...listenerHandles, proxyHandle);
+}
+
+async function openSmokeWebview(ctx) {
+  ctx.markStep("open hidden proxied webview");
+  const openResult = await InAppBrowser.openWebView({
+    url: ENTRY_URL,
+    proxyRequests: true,
+    toolbarType: ToolBarType.BLANK,
+    backgroundColor: BackgroundColor.WHITE,
+    hidden: true,
+    invisibilityMode: InvisibilityMode.FAKE_VISIBLE,
+    captureConsoleLogs: true,
+    allowScreenshotsFromWebPage: true,
+    hiddenPopupWindow: true,
+    enableGooglePaySupport: true,
+    activeNativeNavigationForWebview: true,
+    enabledSafeBottomMargin: true,
+    enabledSafeTopMargin: true,
+    isPresentAfterPageLoad: true,
+    preShowScript: "window.__featureSmokePreShow = true;",
+    preShowScriptInjectionTime: "documentStart",
+    width: 360,
+    height: 640,
+    x: 0,
+    y: 0,
+  });
+  ctx.webviewId = openResult.id;
+}
+
+async function verifyStartup(ctx) {
+  const entryReady = await ctx.waitForMessage("entry-ready");
+  if (!entryReady.preShowFlag) {
+    throw new Error("preShowScript did not run before entry script");
+  }
+  await waitUntil("consoleMessage", () =>
+    ctx.consoleMessages.some((event) => String(event.message).includes("feature-smoke-console-ok")),
+  );
+  ctx.markStep("page load, proxy, console, preShowScript");
+}
+
+async function verifyCookies(ctx) {
+  const cookies = await InAppBrowser.getCookies({ url: SMOKE_ORIGIN });
+  if (cookies.featureSmokeCookie !== "enabled") {
+    throw new Error("featureSmokeCookie was not available through getCookies()");
+  }
+  ctx.markStep("getCookies");
+}
+
+async function verifyPostMessage(ctx) {
+  await InAppBrowser.postMessage({
+    id: ctx.webviewId,
+    detail: {
+      action: "native-ping",
+      marker: "post-message-ok",
+    },
+  });
+  const postMessage = await ctx.waitForMessage("post-message");
+  if (postMessage.payload?.marker !== "post-message-ok") {
+    throw new Error("postMessage payload was not echoed by the webview");
+  }
+  ctx.markStep("postMessage");
+}
+
+async function verifyExecuteScript(ctx) {
+  await InAppBrowser.executeScript({
+    id: ctx.webviewId,
+    code: `
+      window.mobileApp.postMessage({
+        detail: {
+          type: "featureSmoke",
+          step: "execute-script",
+          title: document.title
+        }
+      });
+    `,
+  });
+  const scriptMessage = await ctx.waitForMessage("execute-script");
+  if (scriptMessage.title !== "Feature Smoke Entry") {
+    throw new Error("executeScript returned the wrong document title");
+  }
+  ctx.markStep("executeScript");
+}
+
+async function verifySizingAndNativeScreenshot(ctx) {
+  await InAppBrowser.updateDimensions({ id: ctx.webviewId, width: 320, height: 560, x: 0, y: 0 });
+  await InAppBrowser.setEnabledSafeTopMargin({ id: ctx.webviewId, enabled: false });
+  await InAppBrowser.setEnabledSafeBottomMargin({ id: ctx.webviewId, enabled: true });
+  ctx.markStep("dimensions and safe margins");
+
+  await InAppBrowser.show({ id: ctx.webviewId });
+  await sleep(500);
+  const screenshot = await InAppBrowser.takeScreenshot({ id: ctx.webviewId });
+  if (!screenshot.base64 || !screenshot.width || !screenshot.height) {
+    throw new Error("takeScreenshot returned an empty result");
+  }
+  await waitUntil("screenshotTaken", () => ctx.screenshots.length > 0);
+  await InAppBrowser.hide({ id: ctx.webviewId });
+  ctx.markStep("show, takeScreenshot, hide");
+}
+
+async function verifyBridgeScreenshot(ctx) {
+  await InAppBrowser.executeScript({
+    id: ctx.webviewId,
+    code: `
+      window.mobileApp.takeScreenshot()
+        .then(function(result) {
+          window.mobileApp.postMessage({
+            detail: {
+              type: "featureSmoke",
+              step: "bridge-screenshot",
+              hasData: Boolean(result && result.base64),
+              width: result ? result.width : 0,
+              height: result ? result.height : 0
+            }
+          });
+        })
+        .catch(function(error) {
+          window.mobileApp.postMessage({
+            detail: {
+              type: "featureSmoke",
+              step: "bridge-screenshot-error",
+              error: error && error.message ? error.message : String(error)
+            }
+          });
+        });
+    `,
+  });
+  const result = await waitUntil("bridge screenshot result", () =>
+    ctx.messages.find(
+      (message) => message.step === "bridge-screenshot" || message.step === "bridge-screenshot-error",
+    ),
+  );
+  if (result.step === "bridge-screenshot-error") {
+    throw new Error(`window.mobileApp.takeScreenshot() failed: ${result.error || "unknown error"}`);
+  }
+  if (!result.hasData || !result.width || !result.height) {
+    throw new Error("window.mobileApp.takeScreenshot() returned an empty result");
+  }
+  ctx.markStep("webview screenshot bridge");
+}
+
+async function verifySetUrl(ctx) {
+  await InAppBrowser.setUrl({ id: ctx.webviewId, url: HISTORY_ENTRY_URL });
+  await waitUntil("setUrl history entry", () =>
+    ctx.messages.some((message) => message.step === "entry-ready" && message.href === HISTORY_ENTRY_URL),
+  );
+  await waitUntil("setUrl urlChangeEvent", () =>
+    ctx.urlChanges.some((event) => event.id === ctx.webviewId && event.url === HISTORY_ENTRY_URL),
+  );
+  ctx.markStep("setUrl");
+}
+
+async function navigateToSecondPage(ctx) {
+  await InAppBrowser.executeScript({
+    id: ctx.webviewId,
+    code: `
+      window.location.assign(${JSON.stringify(SECOND_URL)});
+    `,
+  });
+  const secondReady = await ctx.waitForMessage("second-ready");
+  if (secondReady.href !== SECOND_URL) {
+    throw new Error("Navigation did not reach the expected URL");
+  }
+  await waitUntil("second urlChangeEvent", () =>
+    ctx.urlChanges.some((event) => event.id === ctx.webviewId && event.url === SECOND_URL),
+  );
+}
+
+async function verifyBackNavigation(ctx) {
+  const entryHistoryCountBeforeBack = ctx.messages.filter(
+    (message) => message.step === "entry-history-ready" && isEntrySmokeUrl(message.href),
+  ).length;
+  const historyUrlChangeCountBeforeBack = ctx.urlChanges.filter(
+    (event) => event.id === ctx.webviewId && isEntrySmokeUrl(event.url),
+  ).length;
+
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const backResult = await InAppBrowser.goBack({ id: ctx.webviewId });
+    if (backResult.canGoBack) {
+      break;
+    }
+    await sleep(500);
+  }
+
+  try {
+    await waitUntil("entry page after goBack", () =>
+      hasBackNavigationSignal(ctx, entryHistoryCountBeforeBack, historyUrlChangeCountBeforeBack),
+    );
+  } catch (_error) {
+    throw new Error(backNavigationTimeoutMessage(ctx));
+  }
+  ctx.markStep("urlChangeEvent and goBack");
+}
+
+async function hasBackNavigationSignal(ctx, entryHistoryCountBeforeBack, historyUrlChangeCountBeforeBack) {
+  const hasPassiveBackSignal =
+    ctx.messages.filter((message) => message.step === "entry-history-ready" && isEntrySmokeUrl(message.href)).length >
+      entryHistoryCountBeforeBack ||
+    ctx.urlChanges.filter((event) => event.id === ctx.webviewId && isEntrySmokeUrl(event.url)).length >
+      historyUrlChangeCountBeforeBack;
+  if (hasPassiveBackSignal) {
+    return true;
+  }
+
+  await postCurrentLocation(ctx);
+  return ctx.messages.some((message) => message.step === "go-back-location" && isEntrySmokeUrl(message.href));
+}
+
+async function postCurrentLocation(ctx) {
+  try {
+    await InAppBrowser.executeScript({
+      id: ctx.webviewId,
+      code: `
+        window.mobileApp.postMessage({
+          detail: {
+            type: "featureSmoke",
+            step: "go-back-location",
+            href: window.location.href
+          }
+        });
+      `,
+    });
+  } catch (error) {
+    console.warn("Unable to probe webview location after goBack", error);
+  }
+}
+
+function backNavigationTimeoutMessage(ctx) {
+  const observedBackLocations = [
+    ...new Set(
+      ctx.messages
+        .filter((message) => message.step === "go-back-location" && message.href)
+        .map((message) => message.href),
+    ),
+  ];
+  return `Timed out waiting for entry page after goBack${
+    observedBackLocations.length ? `; observed ${observedBackLocations.join(", ")}` : ""
+  }`;
+}
+
+async function verifyReload(ctx) {
+  const pageLoadCountBeforeReload = ctx.pageLoads.filter((event) => event.id === ctx.webviewId).length;
+  await InAppBrowser.reload({ id: ctx.webviewId });
+  await waitUntil(
+    "reload page load",
+    () => ctx.pageLoads.filter((event) => event.id === ctx.webviewId).length > pageLoadCountBeforeReload,
+  );
+  ctx.markStep("reload");
+}
+
+async function verifyNavigationAndReload(ctx) {
+  await verifySetUrl(ctx);
+  await navigateToSecondPage(ctx);
+  await verifyBackNavigation(ctx);
+  await verifyReload(ctx);
+}
+
+async function verifyHiddenPopup(ctx) {
+  await InAppBrowser.executeScript({
+    id: ctx.webviewId,
+    code: `window.open(${JSON.stringify(POPUP_URL)}, "_blank");`,
+  });
+  const popupEvent = await waitUntil("popupWindowOpened", () =>
+    ctx.popupEvents.find((event) => event.parentId === ctx.webviewId || event.url === POPUP_URL),
+  );
+  if (!popupEvent?.id) {
+    throw new Error("popupWindowOpened did not include a popup id");
+  }
+  ctx.popupId = popupEvent.id;
+  await closeSmokeTarget(ctx, "popupId");
+  ctx.markStep("hidden popup window");
+}
+
+async function verifyPluginVersion(ctx) {
+  const version = await InAppBrowser.getPluginVersion();
+  if (!version.version) {
+    throw new Error("getPluginVersion() returned an empty version");
+  }
+  ctx.markStep(`getPluginVersion ${version.version}`);
+}
+
+async function verifyCookieClearing(ctx) {
+  await InAppBrowser.clearCookies({ id: ctx.webviewId, url: SMOKE_ORIGIN });
+  await InAppBrowser.clearAllCookies({ id: ctx.webviewId });
+  ctx.markStep("clearCookies and clearAllCookies");
+}
+
+async function closePrimaryWebview(ctx) {
+  const closingId = ctx.webviewId;
+  await InAppBrowser.close({ id: closingId });
+  await waitUntil("closeEvent", () => ctx.closeEvents.some((event) => event.id === closingId));
+  ctx.webviewId = null;
+}
+
+async function runFeatureSmokeFlow(ctx) {
+  await setupSmokeHarness(ctx);
+  await openSmokeWebview(ctx);
+  await verifyStartup(ctx);
+  await verifyCookies(ctx);
+  await verifyPostMessage(ctx);
+  await verifyExecuteScript(ctx);
+  await verifySizingAndNativeScreenshot(ctx);
+  await verifyBridgeScreenshot(ctx);
+  await verifyNavigationAndReload(ctx);
+  await verifyHiddenPopup(ctx);
+  await verifyPluginVersion(ctx);
+  await verifyCookieClearing(ctx);
+  await closePrimaryWebview(ctx);
+}
+
+async function closeSmokeTarget(ctx, targetKey) {
+  const targetId = ctx[targetKey];
+  if (!targetId) {
+    return;
+  }
+  try {
+    await InAppBrowser.close({ id: targetId });
+  } catch (error) {
+    console.warn(`Unable to close smoke target ${targetId}`, error);
+  }
+  ctx[targetKey] = null;
+}
+
+async function closeOpenSmokeTargets(ctx) {
+  await closeSmokeTarget(ctx, "popupId");
+  await closeSmokeTarget(ctx, "webviewId");
+}
+
+async function removeSmokeHandles(ctx) {
+  const handles = [...ctx.handles].reverse();
+  for (const handle of handles) {
+    await removeSmokeHandle(handle);
+  }
+  ctx.handles.length = 0;
+}
+
+async function removeSmokeHandle(handle) {
+  if (!handle || typeof handle.remove !== "function") {
+    return;
+  }
+  try {
+    await handle.remove();
+  } catch (error) {
+    console.warn("Unable to remove smoke test listener", error);
+  }
+}
+
+async function runFeatureSmokeClick(runButton, setRunning, setStatus) {
+  if (runButton.disabled) {
+    return;
+  }
+
+  setRunning(true);
+  const ctx = createSmokeContext(setStatus);
+  try {
+    await runFeatureSmokeFlow(ctx);
+    setStatus("Feature smoke passed", `Passed steps:\n${ctx.steps.join("\n")}`);
+  } catch (error) {
+    setStatus("Feature smoke failed", normalizeError(error));
+    await closeOpenSmokeTargets(ctx);
+  } finally {
+    await removeSmokeHandles(ctx);
+    setRunning(false);
+  }
 }
 
 export function attachFeatureSmokeHarness() {
@@ -165,408 +619,10 @@ export function attachFeatureSmokeHarness() {
     });
   };
 
-  const markReady = () => {
-    runButton.disabled = false;
-    setStatus("Feature smoke ready");
-  };
-
-  const markStep = (steps, step) => {
-    steps.push(step);
-    setStatus(`Feature smoke running: ${step}`, steps.join("\n"));
-  };
-
-  const waitUntil = async (label, predicate, timeout = TIMEOUT_MS) => {
-    const startedAt = Date.now();
-    while (Date.now() - startedAt < timeout) {
-      const result = await predicate();
-      if (result) {
-        return result;
-      }
-      await sleep(100);
-    }
-    throw new Error(`Timed out waiting for ${label}`);
-  };
-
-  runButton.addEventListener("click", async () => {
-    if (runButton.disabled) {
-      return;
-    }
-
-    setRunning(true);
-
-    const handles = [];
-    const messages = [];
-    const consoleMessages = [];
-    const screenshots = [];
-    const closeEvents = [];
-    const popupEvents = [];
-    const pageLoads = [];
-    const urlChanges = [];
-    const steps = [];
-    let webviewId = null;
-    let popupId = null;
-
-    const waitForMessage = (step, timeout) =>
-      waitUntil(
-        step,
-        () => messages.find((message) => message.step === step),
-        timeout,
-      );
-
-    try {
-      await InAppBrowser.removeAllListeners();
-      await InAppBrowser.clearAllCookies();
-      await InAppBrowser.clearCache();
-
-      handles.push(
-        await InAppBrowser.addListener("messageFromWebview", (event) => {
-          const detail = event.detail || {};
-          if (detail.type !== "featureSmoke") {
-            return;
-          }
-          messages.push({
-            id: event.id,
-            ...detail,
-          });
-        }),
-      );
-      handles.push(
-        await InAppBrowser.addListener("consoleMessage", (event) => {
-          consoleMessages.push(event);
-        }),
-      );
-      handles.push(
-        await InAppBrowser.addListener("screenshotTaken", (event) => {
-          screenshots.push(event);
-        }),
-      );
-      handles.push(
-        await InAppBrowser.addListener("popupWindowOpened", (event) => {
-          popupEvents.push(event);
-        }),
-      );
-      handles.push(
-        await InAppBrowser.addListener("browserPageLoaded", (event) => {
-          pageLoads.push(event);
-        }),
-      );
-      handles.push(
-        await InAppBrowser.addListener("urlChangeEvent", (event) => {
-          urlChanges.push(event);
-        }),
-      );
-      handles.push(
-        await InAppBrowser.addListener("closeEvent", (event) => {
-          closeEvents.push(event);
-        }),
-      );
-      handles.push(
-        await InAppBrowser.addListener("pageLoadError", (event) => {
-          messages.push({
-            id: event.id,
-            step: "page-load-error",
-          });
-        }),
-      );
-
-      handles.push(
-        await addProxyHandler((request) => {
-          if (request.url === ENTRY_URL || request.url === HISTORY_ENTRY_URL || request.url === SECOND_URL) {
-            return textResponse(ENTRY_HTML, "text/html");
-          }
-          if (request.url === POPUP_URL) {
-            return textResponse(POPUP_HTML, "text/html");
-          }
-          if (request.url === SCRIPT_URL) {
-            return textResponse(SMOKE_SCRIPT, "application/javascript");
-          }
-          return null;
-        }),
-      );
-
-      markStep(steps, "open hidden proxied webview");
-      const openResult = await InAppBrowser.openWebView({
-        url: ENTRY_URL,
-        proxyRequests: true,
-        toolbarType: ToolBarType.BLANK,
-        backgroundColor: BackgroundColor.WHITE,
-        hidden: true,
-        invisibilityMode: InvisibilityMode.FAKE_VISIBLE,
-        captureConsoleLogs: true,
-        allowScreenshotsFromWebPage: true,
-        hiddenPopupWindow: true,
-        enableGooglePaySupport: true,
-        activeNativeNavigationForWebview: true,
-        enabledSafeBottomMargin: true,
-        enabledSafeTopMargin: true,
-        isPresentAfterPageLoad: true,
-        preShowScript: "window.__featureSmokePreShow = true;",
-        preShowScriptInjectionTime: "documentStart",
-        width: 360,
-        height: 640,
-        x: 0,
-        y: 0,
-      });
-      webviewId = openResult.id;
-
-      const entryReady = await waitForMessage("entry-ready");
-      if (!entryReady.preShowFlag) {
-        throw new Error("preShowScript did not run before entry script");
-      }
-      await waitUntil("consoleMessage", () =>
-        consoleMessages.some((event) => String(event.message).includes("feature-smoke-console-ok")),
-      );
-      markStep(steps, "page load, proxy, console, preShowScript");
-
-      const cookies = await InAppBrowser.getCookies({ url: SMOKE_ORIGIN });
-      if (cookies.featureSmokeCookie !== "enabled") {
-        throw new Error("featureSmokeCookie was not available through getCookies()");
-      }
-      markStep(steps, "getCookies");
-
-      await InAppBrowser.postMessage({
-        id: webviewId,
-        detail: {
-          action: "native-ping",
-          marker: "post-message-ok",
-        },
-      });
-      const postMessage = await waitForMessage("post-message");
-      if (postMessage.payload?.marker !== "post-message-ok") {
-        throw new Error("postMessage payload was not echoed by the webview");
-      }
-      markStep(steps, "postMessage");
-
-      await InAppBrowser.executeScript({
-        id: webviewId,
-        code: `
-          window.mobileApp.postMessage({
-            detail: {
-              type: "featureSmoke",
-              step: "execute-script",
-              title: document.title
-            }
-          });
-        `,
-      });
-      const scriptMessage = await waitForMessage("execute-script");
-      if (scriptMessage.title !== "Feature Smoke Entry") {
-        throw new Error("executeScript returned the wrong document title");
-      }
-      markStep(steps, "executeScript");
-
-      await InAppBrowser.updateDimensions({ id: webviewId, width: 320, height: 560, x: 0, y: 0 });
-      await InAppBrowser.setEnabledSafeTopMargin({ id: webviewId, enabled: false });
-      await InAppBrowser.setEnabledSafeBottomMargin({ id: webviewId, enabled: true });
-      markStep(steps, "dimensions and safe margins");
-
-      await InAppBrowser.show({ id: webviewId });
-      await sleep(500);
-      const screenshot = await InAppBrowser.takeScreenshot({ id: webviewId });
-      if (!screenshot.base64 || !screenshot.width || !screenshot.height) {
-        throw new Error("takeScreenshot returned an empty result");
-      }
-      await waitUntil("screenshotTaken", () => screenshots.length > 0);
-      await InAppBrowser.hide({ id: webviewId });
-      markStep(steps, "show, takeScreenshot, hide");
-
-      await InAppBrowser.executeScript({
-        id: webviewId,
-        code: `
-          window.mobileApp.takeScreenshot()
-            .then(function(result) {
-              window.mobileApp.postMessage({
-                detail: {
-                  type: "featureSmoke",
-                  step: "bridge-screenshot",
-                  hasData: Boolean(result && result.base64),
-                  width: result ? result.width : 0,
-                  height: result ? result.height : 0
-                }
-              });
-            })
-            .catch(function(error) {
-              window.mobileApp.postMessage({
-                detail: {
-                  type: "featureSmoke",
-                  step: "bridge-screenshot-error",
-                  error: error && error.message ? error.message : String(error)
-                }
-              });
-            });
-        `,
-      });
-      const bridgeScreenshotResult = await waitUntil("bridge screenshot result", () =>
-        messages.find(
-          (message) =>
-            message.step === "bridge-screenshot" || message.step === "bridge-screenshot-error",
-        ),
-      );
-      if (bridgeScreenshotResult.step === "bridge-screenshot-error") {
-        throw new Error(
-          `window.mobileApp.takeScreenshot() failed: ${bridgeScreenshotResult.error || "unknown error"}`,
-        );
-      }
-      if (
-        !bridgeScreenshotResult.hasData ||
-        !bridgeScreenshotResult.width ||
-        !bridgeScreenshotResult.height
-      ) {
-        throw new Error("window.mobileApp.takeScreenshot() returned an empty result");
-      }
-      markStep(steps, "webview screenshot bridge");
-
-      await InAppBrowser.setUrl({ id: webviewId, url: HISTORY_ENTRY_URL });
-      await waitUntil("setUrl history entry", () =>
-        messages.some((message) => message.step === "entry-ready" && message.href === HISTORY_ENTRY_URL),
-      );
-      await waitUntil("setUrl urlChangeEvent", () =>
-        urlChanges.some((event) => event.id === webviewId && event.url === HISTORY_ENTRY_URL),
-      );
-      markStep(steps, "setUrl");
-
-      await InAppBrowser.executeScript({
-        id: webviewId,
-        code: `
-          window.location.assign(${JSON.stringify(SECOND_URL)});
-        `,
-      });
-      const secondReady = await waitForMessage("second-ready");
-      if (secondReady.href !== SECOND_URL) {
-        throw new Error("Navigation did not reach the expected URL");
-      }
-      await waitUntil("second urlChangeEvent", () =>
-        urlChanges.some((event) => event.id === webviewId && event.url === SECOND_URL),
-      );
-      const entryHistoryCountBeforeBack = messages.filter(
-        (message) => message.step === "entry-history-ready" && isEntrySmokeUrl(message.href),
-      ).length;
-      const historyUrlChangeCountBeforeBack = urlChanges.filter(
-        (event) => event.id === webviewId && isEntrySmokeUrl(event.url),
-      ).length;
-      let backResult = { canGoBack: false };
-      for (let attempt = 0; attempt < 8; attempt += 1) {
-        backResult = await InAppBrowser.goBack({ id: webviewId });
-        if (backResult.canGoBack) {
-          break;
-        }
-        await sleep(500);
-      }
-      if (!backResult.canGoBack) {
-        throw new Error("goBack() reported that history was unavailable");
-      }
-      try {
-        await waitUntil(
-          "entry page after goBack",
-          async () => {
-            const hasPassiveBackSignal =
-              messages.filter((message) => message.step === "entry-history-ready" && isEntrySmokeUrl(message.href))
-                .length > entryHistoryCountBeforeBack ||
-              urlChanges.filter((event) => event.id === webviewId && isEntrySmokeUrl(event.url)).length >
-                historyUrlChangeCountBeforeBack;
-            if (hasPassiveBackSignal) {
-              return true;
-            }
-
-            try {
-              await InAppBrowser.executeScript({
-                id: webviewId,
-                code: `
-                  window.mobileApp.postMessage({
-                    detail: {
-                      type: "featureSmoke",
-                      step: "go-back-location",
-                      href: window.location.href
-                    }
-                  });
-                `,
-              });
-            } catch (_error) {}
-
-            return messages.some((message) => message.step === "go-back-location" && isEntrySmokeUrl(message.href));
-          },
-          30000,
-        );
-      } catch (_error) {
-        const observedBackLocations = [
-          ...new Set(
-            messages
-              .filter((message) => message.step === "go-back-location" && message.href)
-              .map((message) => message.href),
-          ),
-        ];
-        throw new Error(
-          `Timed out waiting for entry page after goBack${
-            observedBackLocations.length ? `; observed ${observedBackLocations.join(", ")}` : ""
-          }`,
-        );
-      }
-      markStep(steps, "urlChangeEvent and goBack");
-
-      const pageLoadCountBeforeReload = pageLoads.filter((event) => event.id === webviewId).length;
-      await InAppBrowser.reload({ id: webviewId });
-      await waitUntil(
-        "reload page load",
-        () => pageLoads.filter((event) => event.id === webviewId).length > pageLoadCountBeforeReload,
-      );
-      markStep(steps, "reload");
-
-      await InAppBrowser.executeScript({
-        id: webviewId,
-        code: `window.open(${JSON.stringify(POPUP_URL)}, "_blank");`,
-      });
-      const popupEvent = await waitUntil("popupWindowOpened", () =>
-        popupEvents.find((event) => event.parentId === webviewId || event.url === POPUP_URL),
-      );
-      if (!popupEvent?.id) {
-        throw new Error("popupWindowOpened did not include a popup id");
-      }
-      popupId = popupEvent.id;
-      if (popupId) {
-        await InAppBrowser.close({ id: popupId });
-        popupId = null;
-      }
-      markStep(steps, "hidden popup window");
-
-      const version = await InAppBrowser.getPluginVersion();
-      if (!version.version) {
-        throw new Error("getPluginVersion() returned an empty version");
-      }
-      markStep(steps, `getPluginVersion ${version.version}`);
-
-      await InAppBrowser.clearCookies({ id: webviewId, url: SMOKE_ORIGIN });
-      await InAppBrowser.clearAllCookies({ id: webviewId });
-      markStep(steps, "clearCookies and clearAllCookies");
-
-      await InAppBrowser.close({ id: webviewId });
-      await waitUntil("closeEvent", () => closeEvents.some((event) => event.id === webviewId));
-      webviewId = null;
-
-      setStatus("Feature smoke passed", `Passed steps:\n${steps.join("\n")}`);
-    } catch (error) {
-      setStatus("Feature smoke failed", normalizeError(error));
-      if (popupId) {
-        try {
-          await InAppBrowser.close({ id: popupId });
-        } catch (_cleanupError) {}
-      }
-      if (webviewId) {
-        try {
-          await InAppBrowser.close({ id: webviewId });
-        } catch (_cleanupError) {}
-      }
-    } finally {
-      for (const handle of handles.reverse()) {
-        if (!handle || typeof handle.remove !== "function") {
-          continue;
-        }
-        try {
-          await handle.remove();
-        } catch (_error) {}
-      }
-      setRunning(false);
-    }
+  runButton.addEventListener("click", () => {
+    void runFeatureSmokeClick(runButton, setRunning, setStatus);
   });
 
-  markReady();
+  runButton.disabled = false;
+  setStatus("Feature smoke ready");
 }

--- a/example-app/src/js/feature-smoke.js
+++ b/example-app/src/js/feature-smoke.js
@@ -1,0 +1,572 @@
+import {
+  InAppBrowser,
+  ToolBarType,
+  BackgroundColor,
+  InvisibilityMode,
+  addProxyHandler,
+} from "@capgo/inappbrowser";
+
+const SMOKE_ORIGIN = "https://feature-smoke.capgo.test";
+const ENTRY_URL = `${SMOKE_ORIGIN}/entry`;
+const HISTORY_ENTRY_URL = `${SMOKE_ORIGIN}/history-entry`;
+const SECOND_URL = `${SMOKE_ORIGIN}/second`;
+const POPUP_URL = `${SMOKE_ORIGIN}/popup`;
+const SCRIPT_URL = `${SMOKE_ORIGIN}/smoke.js`;
+const TIMEOUT_MS = 180000;
+
+const ENTRY_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Feature Smoke Entry</title>
+    <link rel="icon" href="data:," />
+  </head>
+  <body>
+    <main>
+      <h1>Feature Smoke Entry</h1>
+      <p id="status">Waiting for plugin bridge.</p>
+      <script src="${SCRIPT_URL}"></script>
+    </main>
+  </body>
+</html>`;
+
+const POPUP_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Feature Smoke Popup</title>
+    <link rel="icon" href="data:," />
+  </head>
+  <body>
+    <main>
+      <h1>Feature Smoke Popup</h1>
+    </main>
+  </body>
+</html>`;
+
+const SMOKE_SCRIPT = `(() => {
+  const post = (step, extra = {}) => {
+    if (!window.mobileApp || typeof window.mobileApp.postMessage !== "function") {
+      return;
+    }
+
+    window.mobileApp.postMessage({
+      detail: {
+        type: "featureSmoke",
+        step,
+        ...extra,
+      },
+    });
+  };
+
+  console.log("feature-smoke-console-ok");
+  document.cookie = "featureSmokeCookie=enabled; path=/; SameSite=Lax";
+
+  window.addEventListener("messageFromNative", (event) => {
+    post("post-message", {
+      payload: event.detail || null,
+    });
+  });
+
+  const postNavigationState = () => {
+    if (window.location.href === "${SECOND_URL}") {
+      post("second-ready", {
+        href: window.location.href,
+        title: document.title,
+      });
+      return;
+    }
+    post("entry-history-ready", {
+      href: window.location.href,
+    });
+  };
+
+  window.addEventListener("popstate", postNavigationState);
+  window.addEventListener("pageshow", postNavigationState);
+
+  window.setTimeout(() => {
+    const status = document.getElementById("status");
+    if (status) {
+      status.textContent = "Plugin bridge ready.";
+    }
+    post("entry-ready", {
+      cookie: document.cookie,
+      href: window.location.href,
+      preShowFlag: window.__featureSmokePreShow === true,
+      title: document.title,
+    });
+    postNavigationState();
+  }, 50);
+})();`;
+
+function textResponse(body, contentType) {
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Cache-Control": "no-store",
+      "Content-Type": contentType,
+    },
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+function normalizeError(error) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function isEntrySmokeUrl(url) {
+  return url === ENTRY_URL || url === HISTORY_ENTRY_URL;
+}
+
+function withMaestroNativeHarness(callback) {
+  const harness = window.MaestroNativeHarness;
+  if (!harness || typeof callback !== "function") {
+    return;
+  }
+
+  try {
+    callback(harness);
+  } catch (_error) {}
+}
+
+export function attachFeatureSmokeHarness() {
+  const runButton = document.getElementById("maestro-run-feature-smoke");
+  const status = document.getElementById("maestro-feature-smoke-status");
+  const details = document.getElementById("maestro-feature-smoke-details");
+
+  if (!runButton || !status || !details) {
+    return;
+  }
+
+  const setStatus = (message, detailText = "") => {
+    status.textContent = message;
+    details.textContent = detailText;
+    withMaestroNativeHarness((harness) => {
+      if (typeof harness.setStatus === "function") {
+        harness.setStatus(message, detailText);
+      }
+    });
+  };
+
+  const setRunning = (running) => {
+    runButton.disabled = running;
+    withMaestroNativeHarness((harness) => {
+      if (typeof harness.setRunning === "function") {
+        harness.setRunning(Boolean(running));
+      }
+    });
+  };
+
+  const markReady = () => {
+    runButton.disabled = false;
+    setStatus("Feature smoke ready");
+  };
+
+  const markStep = (steps, step) => {
+    steps.push(step);
+    setStatus(`Feature smoke running: ${step}`, steps.join("\n"));
+  };
+
+  const waitUntil = async (label, predicate, timeout = TIMEOUT_MS) => {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < timeout) {
+      const result = await predicate();
+      if (result) {
+        return result;
+      }
+      await sleep(100);
+    }
+    throw new Error(`Timed out waiting for ${label}`);
+  };
+
+  runButton.addEventListener("click", async () => {
+    if (runButton.disabled) {
+      return;
+    }
+
+    setRunning(true);
+
+    const handles = [];
+    const messages = [];
+    const consoleMessages = [];
+    const screenshots = [];
+    const closeEvents = [];
+    const popupEvents = [];
+    const pageLoads = [];
+    const urlChanges = [];
+    const steps = [];
+    let webviewId = null;
+    let popupId = null;
+
+    const waitForMessage = (step, timeout) =>
+      waitUntil(
+        step,
+        () => messages.find((message) => message.step === step),
+        timeout,
+      );
+
+    try {
+      await InAppBrowser.removeAllListeners();
+      await InAppBrowser.clearAllCookies();
+      await InAppBrowser.clearCache();
+
+      handles.push(
+        await InAppBrowser.addListener("messageFromWebview", (event) => {
+          const detail = event.detail || {};
+          if (detail.type !== "featureSmoke") {
+            return;
+          }
+          messages.push({
+            id: event.id,
+            ...detail,
+          });
+        }),
+      );
+      handles.push(
+        await InAppBrowser.addListener("consoleMessage", (event) => {
+          consoleMessages.push(event);
+        }),
+      );
+      handles.push(
+        await InAppBrowser.addListener("screenshotTaken", (event) => {
+          screenshots.push(event);
+        }),
+      );
+      handles.push(
+        await InAppBrowser.addListener("popupWindowOpened", (event) => {
+          popupEvents.push(event);
+        }),
+      );
+      handles.push(
+        await InAppBrowser.addListener("browserPageLoaded", (event) => {
+          pageLoads.push(event);
+        }),
+      );
+      handles.push(
+        await InAppBrowser.addListener("urlChangeEvent", (event) => {
+          urlChanges.push(event);
+        }),
+      );
+      handles.push(
+        await InAppBrowser.addListener("closeEvent", (event) => {
+          closeEvents.push(event);
+        }),
+      );
+      handles.push(
+        await InAppBrowser.addListener("pageLoadError", (event) => {
+          messages.push({
+            id: event.id,
+            step: "page-load-error",
+          });
+        }),
+      );
+
+      handles.push(
+        await addProxyHandler((request) => {
+          if (request.url === ENTRY_URL || request.url === HISTORY_ENTRY_URL || request.url === SECOND_URL) {
+            return textResponse(ENTRY_HTML, "text/html");
+          }
+          if (request.url === POPUP_URL) {
+            return textResponse(POPUP_HTML, "text/html");
+          }
+          if (request.url === SCRIPT_URL) {
+            return textResponse(SMOKE_SCRIPT, "application/javascript");
+          }
+          return null;
+        }),
+      );
+
+      markStep(steps, "open hidden proxied webview");
+      const openResult = await InAppBrowser.openWebView({
+        url: ENTRY_URL,
+        proxyRequests: true,
+        toolbarType: ToolBarType.BLANK,
+        backgroundColor: BackgroundColor.WHITE,
+        hidden: true,
+        invisibilityMode: InvisibilityMode.FAKE_VISIBLE,
+        captureConsoleLogs: true,
+        allowScreenshotsFromWebPage: true,
+        hiddenPopupWindow: true,
+        enableGooglePaySupport: true,
+        activeNativeNavigationForWebview: true,
+        enabledSafeBottomMargin: true,
+        enabledSafeTopMargin: true,
+        isPresentAfterPageLoad: true,
+        preShowScript: "window.__featureSmokePreShow = true;",
+        preShowScriptInjectionTime: "documentStart",
+        width: 360,
+        height: 640,
+        x: 0,
+        y: 0,
+      });
+      webviewId = openResult.id;
+
+      const entryReady = await waitForMessage("entry-ready");
+      if (!entryReady.preShowFlag) {
+        throw new Error("preShowScript did not run before entry script");
+      }
+      await waitUntil("consoleMessage", () =>
+        consoleMessages.some((event) => String(event.message).includes("feature-smoke-console-ok")),
+      );
+      markStep(steps, "page load, proxy, console, preShowScript");
+
+      const cookies = await InAppBrowser.getCookies({ url: SMOKE_ORIGIN });
+      if (cookies.featureSmokeCookie !== "enabled") {
+        throw new Error("featureSmokeCookie was not available through getCookies()");
+      }
+      markStep(steps, "getCookies");
+
+      await InAppBrowser.postMessage({
+        id: webviewId,
+        detail: {
+          action: "native-ping",
+          marker: "post-message-ok",
+        },
+      });
+      const postMessage = await waitForMessage("post-message");
+      if (postMessage.payload?.marker !== "post-message-ok") {
+        throw new Error("postMessage payload was not echoed by the webview");
+      }
+      markStep(steps, "postMessage");
+
+      await InAppBrowser.executeScript({
+        id: webviewId,
+        code: `
+          window.mobileApp.postMessage({
+            detail: {
+              type: "featureSmoke",
+              step: "execute-script",
+              title: document.title
+            }
+          });
+        `,
+      });
+      const scriptMessage = await waitForMessage("execute-script");
+      if (scriptMessage.title !== "Feature Smoke Entry") {
+        throw new Error("executeScript returned the wrong document title");
+      }
+      markStep(steps, "executeScript");
+
+      await InAppBrowser.updateDimensions({ id: webviewId, width: 320, height: 560, x: 0, y: 0 });
+      await InAppBrowser.setEnabledSafeTopMargin({ id: webviewId, enabled: false });
+      await InAppBrowser.setEnabledSafeBottomMargin({ id: webviewId, enabled: true });
+      markStep(steps, "dimensions and safe margins");
+
+      await InAppBrowser.show({ id: webviewId });
+      await sleep(500);
+      const screenshot = await InAppBrowser.takeScreenshot({ id: webviewId });
+      if (!screenshot.base64 || !screenshot.width || !screenshot.height) {
+        throw new Error("takeScreenshot returned an empty result");
+      }
+      await waitUntil("screenshotTaken", () => screenshots.length > 0);
+      await InAppBrowser.hide({ id: webviewId });
+      markStep(steps, "show, takeScreenshot, hide");
+
+      await InAppBrowser.executeScript({
+        id: webviewId,
+        code: `
+          window.mobileApp.takeScreenshot()
+            .then(function(result) {
+              window.mobileApp.postMessage({
+                detail: {
+                  type: "featureSmoke",
+                  step: "bridge-screenshot",
+                  hasData: Boolean(result && result.base64),
+                  width: result ? result.width : 0,
+                  height: result ? result.height : 0
+                }
+              });
+            })
+            .catch(function(error) {
+              window.mobileApp.postMessage({
+                detail: {
+                  type: "featureSmoke",
+                  step: "bridge-screenshot-error",
+                  error: error && error.message ? error.message : String(error)
+                }
+              });
+            });
+        `,
+      });
+      const bridgeScreenshotResult = await waitUntil("bridge screenshot result", () =>
+        messages.find(
+          (message) =>
+            message.step === "bridge-screenshot" || message.step === "bridge-screenshot-error",
+        ),
+      );
+      if (bridgeScreenshotResult.step === "bridge-screenshot-error") {
+        throw new Error(
+          `window.mobileApp.takeScreenshot() failed: ${bridgeScreenshotResult.error || "unknown error"}`,
+        );
+      }
+      if (
+        !bridgeScreenshotResult.hasData ||
+        !bridgeScreenshotResult.width ||
+        !bridgeScreenshotResult.height
+      ) {
+        throw new Error("window.mobileApp.takeScreenshot() returned an empty result");
+      }
+      markStep(steps, "webview screenshot bridge");
+
+      await InAppBrowser.setUrl({ id: webviewId, url: HISTORY_ENTRY_URL });
+      await waitUntil("setUrl history entry", () =>
+        messages.some((message) => message.step === "entry-ready" && message.href === HISTORY_ENTRY_URL),
+      );
+      await waitUntil("setUrl urlChangeEvent", () =>
+        urlChanges.some((event) => event.id === webviewId && event.url === HISTORY_ENTRY_URL),
+      );
+      markStep(steps, "setUrl");
+
+      await InAppBrowser.executeScript({
+        id: webviewId,
+        code: `
+          window.location.assign(${JSON.stringify(SECOND_URL)});
+        `,
+      });
+      const secondReady = await waitForMessage("second-ready");
+      if (secondReady.href !== SECOND_URL) {
+        throw new Error("Navigation did not reach the expected URL");
+      }
+      await waitUntil("second urlChangeEvent", () =>
+        urlChanges.some((event) => event.id === webviewId && event.url === SECOND_URL),
+      );
+      const entryHistoryCountBeforeBack = messages.filter(
+        (message) => message.step === "entry-history-ready" && isEntrySmokeUrl(message.href),
+      ).length;
+      const historyUrlChangeCountBeforeBack = urlChanges.filter(
+        (event) => event.id === webviewId && isEntrySmokeUrl(event.url),
+      ).length;
+      let backResult = { canGoBack: false };
+      for (let attempt = 0; attempt < 8; attempt += 1) {
+        backResult = await InAppBrowser.goBack({ id: webviewId });
+        if (backResult.canGoBack) {
+          break;
+        }
+        await sleep(500);
+      }
+      if (!backResult.canGoBack) {
+        throw new Error("goBack() reported that history was unavailable");
+      }
+      try {
+        await waitUntil(
+          "entry page after goBack",
+          async () => {
+            const hasPassiveBackSignal =
+              messages.filter((message) => message.step === "entry-history-ready" && isEntrySmokeUrl(message.href))
+                .length > entryHistoryCountBeforeBack ||
+              urlChanges.filter((event) => event.id === webviewId && isEntrySmokeUrl(event.url)).length >
+                historyUrlChangeCountBeforeBack;
+            if (hasPassiveBackSignal) {
+              return true;
+            }
+
+            try {
+              await InAppBrowser.executeScript({
+                id: webviewId,
+                code: `
+                  window.mobileApp.postMessage({
+                    detail: {
+                      type: "featureSmoke",
+                      step: "go-back-location",
+                      href: window.location.href
+                    }
+                  });
+                `,
+              });
+            } catch (_error) {}
+
+            return messages.some((message) => message.step === "go-back-location" && isEntrySmokeUrl(message.href));
+          },
+          30000,
+        );
+      } catch (_error) {
+        const observedBackLocations = [
+          ...new Set(
+            messages
+              .filter((message) => message.step === "go-back-location" && message.href)
+              .map((message) => message.href),
+          ),
+        ];
+        throw new Error(
+          `Timed out waiting for entry page after goBack${
+            observedBackLocations.length ? `; observed ${observedBackLocations.join(", ")}` : ""
+          }`,
+        );
+      }
+      markStep(steps, "urlChangeEvent and goBack");
+
+      const pageLoadCountBeforeReload = pageLoads.filter((event) => event.id === webviewId).length;
+      await InAppBrowser.reload({ id: webviewId });
+      await waitUntil(
+        "reload page load",
+        () => pageLoads.filter((event) => event.id === webviewId).length > pageLoadCountBeforeReload,
+      );
+      markStep(steps, "reload");
+
+      await InAppBrowser.executeScript({
+        id: webviewId,
+        code: `window.open(${JSON.stringify(POPUP_URL)}, "_blank");`,
+      });
+      const popupEvent = await waitUntil("popupWindowOpened", () =>
+        popupEvents.find((event) => event.parentId === webviewId || event.url === POPUP_URL),
+      );
+      if (!popupEvent?.id) {
+        throw new Error("popupWindowOpened did not include a popup id");
+      }
+      popupId = popupEvent.id;
+      if (popupId) {
+        await InAppBrowser.close({ id: popupId });
+        popupId = null;
+      }
+      markStep(steps, "hidden popup window");
+
+      const version = await InAppBrowser.getPluginVersion();
+      if (!version.version) {
+        throw new Error("getPluginVersion() returned an empty version");
+      }
+      markStep(steps, `getPluginVersion ${version.version}`);
+
+      await InAppBrowser.clearCookies({ id: webviewId, url: SMOKE_ORIGIN });
+      await InAppBrowser.clearAllCookies({ id: webviewId });
+      markStep(steps, "clearCookies and clearAllCookies");
+
+      await InAppBrowser.close({ id: webviewId });
+      await waitUntil("closeEvent", () => closeEvents.some((event) => event.id === webviewId));
+      webviewId = null;
+
+      setStatus("Feature smoke passed", `Passed steps:\n${steps.join("\n")}`);
+    } catch (error) {
+      setStatus("Feature smoke failed", normalizeError(error));
+      if (popupId) {
+        try {
+          await InAppBrowser.close({ id: popupId });
+        } catch (_cleanupError) {}
+      }
+      if (webviewId) {
+        try {
+          await InAppBrowser.close({ id: webviewId });
+        } catch (_cleanupError) {}
+      }
+    } finally {
+      for (const handle of handles.reverse()) {
+        if (!handle || typeof handle.remove !== "function") {
+          continue;
+        }
+        try {
+          await handle.remove();
+        } catch (_error) {}
+      }
+      setRunning(false);
+    }
+  });
+
+  markReady();
+}

--- a/example-app/src/js/feature-smoke.js
+++ b/example-app/src/js/feature-smoke.js
@@ -112,7 +112,7 @@ function textResponse(body, contentType) {
 }
 
 function sleep(ms) {
-  return new Promise((resolve) => window.setTimeout(resolve, ms));
+  return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
 }
 
 function normalizeError(error) {
@@ -127,7 +127,7 @@ function isEntrySmokeUrl(url) {
 }
 
 function withMaestroNativeHarness(callback) {
-  const harness = window.MaestroNativeHarness;
+  const harness = globalThis.MaestroNativeHarness;
   if (!harness || typeof callback !== "function") {
     return;
   }
@@ -139,7 +139,7 @@ function withMaestroNativeHarness(callback) {
   }
 }
 
-async function waitUntil(label, predicate, timeout = TIMEOUT_MS) {
+async function waitUntil(label, predicate, timeout = TIMEOUT_MS, getTimeoutMessage) {
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeout) {
     const result = await predicate();
@@ -148,7 +148,8 @@ async function waitUntil(label, predicate, timeout = TIMEOUT_MS) {
     }
     await sleep(100);
   }
-  throw new Error(`Timed out waiting for ${label}`);
+  const timeoutMessage = typeof getTimeoutMessage === "function" ? getTimeoutMessage() : `Timed out waiting for ${label}`;
+  throw new Error(timeoutMessage);
 }
 
 function featureSmokeProxyResponse(request) {
@@ -409,13 +410,13 @@ async function verifyBackNavigation(ctx) {
     await sleep(500);
   }
 
-  try {
-    await waitUntil("entry page after goBack", () =>
+  await waitUntil(
+    "entry page after goBack",
+    () =>
       hasBackNavigationSignal(ctx, entryHistoryCountBeforeBack, historyUrlChangeCountBeforeBack),
-    );
-  } catch (_error) {
-    throw new Error(backNavigationTimeoutMessage(ctx));
-  }
+    TIMEOUT_MS,
+    () => backNavigationTimeoutMessage(ctx),
+  );
   ctx.markStep("urlChangeEvent and goBack");
 }
 

--- a/scripts/test-maestro-android.sh
+++ b/scripts/test-maestro-android.sh
@@ -5,9 +5,15 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 EXAMPLE_DIR="$ROOT_DIR/example-app"
 APK_PATH="$EXAMPLE_DIR/android/app/build/outputs/apk/debug/app-debug.apk"
 RESULTS_DIR="$ROOT_DIR/maestro-results"
-FLOW_PATH="$ROOT_DIR/.maestro/download-handling-android.yaml"
+FLOW_PATH="${CAPGO_MAESTRO_FLOW_PATH:-$ROOT_DIR/.maestro/android/example-app-smoke.yaml}"
 APP_ID="app.capgo.inappbrowser"
 SKIP_BUILD="${CAPGO_MAESTRO_SKIP_BUILD:-0}"
+
+if [[ ! -f "$FLOW_PATH" ]]; then
+  echo "Maestro flow file not found: $FLOW_PATH" >&2
+  echo "Check CAPGO_MAESTRO_FLOW_PATH or use the default flow path." >&2
+  exit 1
+fi
 
 if ! command -v adb >/dev/null 2>&1; then
   echo "adb is required to run Android Maestro tests." >&2


### PR DESCRIPTION
## What
- Add a broader Maestro smoke harness to the InAppBrowser example app.
- Add updater-style root Maestro flow wrappers for Android.
- Make the default Android Maestro script run the broader smoke flow before the existing download handling check.

## Why
- The existing Maestro coverage focused on a few regressions. This adds one self-contained flow that exercises most managed WebView plugin features through the example app.

## How
- Added a feature smoke harness that serves deterministic pages through `addProxyHandler()` and validates plugin APIs from the host app.
- Covered proxy handling, hidden WebView, pre-show script, console capture, cookies, native/webview messaging, script execution, dimensions, safe margins, show/hide, screenshots, navigation, reload, hidden popup handling, plugin version, close events, and cookie clearing.
- Added `.maestro/android/example-app-smoke.yaml` and `.maestro/example-app-api-smoke-android.yaml` following the updater plugin layout.

## Testing
- `bun run build`
- `bun run verify:web`
- `cd example-app && bun run build`
- `bun run verify:ios`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH="/opt/homebrew/opt/openjdk@21/bin:$PATH" bun run verify:android`
- `git diff --check`
- `bun run lint` reached SwiftLint after ESLint and Prettier passed; SwiftLint fails on existing file length/complexity violations unrelated to this PR.

## Not Tested
- Local Maestro device flow was not completed because no Android device/emulator is attached in this environment.
- CI should run the Android/Maestro coverage in the configured environment.

AI-assisted PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive "feature smoke" harness to validate WebView and plugin behaviors (proxy, messaging, screenshots, visibility, cookies, navigation, popups, downloads).
  * Added a UI control (disabled by default) plus status/detail areas to run and monitor the feature smoke test.

* **Documentation**
  * Maestro docs relabeled and expanded to describe broader "Maestro coverage" and the expanded smoke test scope.

* **Chores**
  * Test script now reads a configurable Maestro flow path and verifies the flow file exists before running.

* **Configuration**
  * Android smoke test set to target the in-app browser app and invoke a chained smoke flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-inappbrowser/pull/538?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->