### PR TITLE
fix: preserve proxied Content-Type headers on Android

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupport.java
@@ -390,6 +390,16 @@ final class ProxyRequestSupport {
         return new WebResourceResponseMetadata(mimeType, encoding);
     }
 
+    static WebResourceResponseMetadata resolveWebResourceResponseConstructorMetadata(
+        String contentType,
+        Map<String, String> responseHeaders
+    ) {
+        if (hasHeaderIgnoreCase(responseHeaders, "Content-Type")) {
+            return new WebResourceResponseMetadata(null, null);
+        }
+        return resolveWebResourceResponseMetadata(contentType, responseHeaders);
+    }
+
     static ParsedResponseHeaders splitResponseHeaders(Map<String, List<String>> rawHeaders) {
         Map<String, String> responseHeaders = new HashMap<>();
         List<String> cookieHeaders = new java.util.ArrayList<>();
@@ -733,6 +743,10 @@ final class ProxyRequestSupport {
     private static String findHeaderIgnoreCase(Map<String, String> headers, String expectedKey) {
         String resolvedKey = findHeaderKeyIgnoreCase(headers, expectedKey);
         return resolvedKey != null ? headers.get(resolvedKey) : null;
+    }
+
+    private static boolean hasHeaderIgnoreCase(Map<String, String> headers, String expectedKey) {
+        return findHeaderKeyIgnoreCase(headers, expectedKey) != null;
     }
 
     private static String findHeaderKeyIgnoreCase(Map<String, String> headers, String expectedKey) {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -5478,7 +5478,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
     }
 
     private WebResourceResponse buildWebResourceResponse(NativeResponseData responseData) {
-        ProxyRequestSupport.WebResourceResponseMetadata metadata = ProxyRequestSupport.resolveWebResourceResponseMetadata(
+        ProxyRequestSupport.WebResourceResponseMetadata metadata = ProxyRequestSupport.resolveWebResourceResponseConstructorMetadata(
             responseData.contentType,
             responseData.headers
         );

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupportTest.java
@@ -367,6 +367,23 @@ public class ProxyRequestSupportTest {
     }
 
     @Test
+    public void resolveWebResourceResponseConstructorMetadataDefersToExistingContentTypeHeader() {
+        ProxyRequestSupport.WebResourceResponseMetadata metadata = ProxyRequestSupport.resolveWebResourceResponseConstructorMetadata(
+            "multipart/mixed; boundary=fallback",
+            Map.of("content-type", "multipart/mixed; boundary=someboundary")
+        );
+
+        assertNull(metadata.mimeType());
+        assertNull(metadata.encoding());
+
+        ProxyRequestSupport.WebResourceResponseMetadata fallbackMetadata =
+            ProxyRequestSupport.resolveWebResourceResponseConstructorMetadata("text/html; charset=utf-8", Map.of());
+
+        assertEquals("text/html", fallbackMetadata.mimeType());
+        assertEquals("utf-8", fallbackMetadata.encoding());
+    }
+
+    @Test
     public void splitResponseHeadersPreservesAllCookieValuesSeparately() {
         ProxyRequestSupport.ParsedResponseHeaders parsedHeaders = ProxyRequestSupport.splitResponseHeaders(
             Map.of(


### PR DESCRIPTION
## What
- Preserve existing Android proxy `Content-Type` response headers when constructing `WebResourceResponse`.
- Add a unit test covering `multipart/mixed; boundary=...` passthrough behavior.

## Why
- Android rewrites `Content-Type` when `WebResourceResponse` receives MIME type and encoding constructor arguments, which can duplicate the header and drop parameters such as multipart boundaries.
- Fixes #537.

## How
- Added constructor-specific metadata resolution that returns `null` MIME/encoding when a response already has a `Content-Type` header.
- Kept the existing parsed MIME fallback for responses without the header and for bootstrap HTML handling.

## Testing
- `bun run fmt`
- `bun run verify:android`
- `bun run verify`

## Not Tested
- Manual Android WebView reproduction with a live multipart proxy response.

AI-assisted PR authored with Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Content-Type headers in web resource responses within the in-app browser.

* **Tests**
  * Added test coverage for web resource response header processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-inappbrowser/pull/541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->