### PR TITLE
[codex] fix Android safe area insets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,6 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
-          token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -66,7 +65,6 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: 1.3.11
-          token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -109,7 +107,6 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
-          token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -164,7 +161,6 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: 1.3.11
-          token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -216,7 +212,6 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: 1.3.11
-          token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -257,7 +252,6 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: 1.3.11
-          token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -321,7 +315,6 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
-          token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -350,7 +343,6 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
-          token: ''
       - name: Install dependencies
         id: install_code
         run: bun i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -61,6 +63,8 @@ jobs:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -101,6 +105,8 @@ jobs:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -153,6 +159,8 @@ jobs:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -202,6 +210,8 @@ jobs:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -240,6 +250,8 @@ jobs:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -301,6 +313,8 @@ jobs:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -327,6 +341,8 @@ jobs:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          token: ''
       - name: Install dependencies
         id: install_code
         run: bun i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
+          bun-version: 1.3.11
           token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -64,6 +65,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
+          bun-version: 1.3.11
           token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -106,6 +108,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
+          bun-version: 1.3.11
           token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -160,6 +163,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
+          bun-version: 1.3.11
           token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -211,6 +215,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
+          bun-version: 1.3.11
           token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -251,6 +256,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
+          bun-version: 1.3.11
           token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -314,6 +320,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
+          bun-version: 1.3.11
           token: ''
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -342,6 +349,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
+          bun-version: 1.3.11
           token: ''
       - name: Install dependencies
         id: install_code

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
@@ -1,0 +1,28 @@
+package ee.forgr.capacitor_inappbrowser;
+
+final class SafeAreaInsetsSupport {
+
+    private SafeAreaInsetsSupport() {}
+
+    static int resolveSafeBottomInset(
+        int systemBarsBottom,
+        int navigationBarsBottom,
+        int systemGesturesBottom,
+        int mandatoryGesturesBottom
+    ) {
+        return Math.max(systemBarsBottom, Math.max(navigationBarsBottom, Math.max(systemGesturesBottom, mandatoryGesturesBottom)));
+    }
+
+    static int resolveBottomMargin(boolean enabledSafeBottomMargin, int safeBottomInset, int imeBottom) {
+        int bottomInset = enabledSafeBottomMargin ? safeBottomInset : 0;
+        return Math.max(bottomInset, imeBottom);
+    }
+
+    static int resolveTopMargin(boolean enabledSafeTopMargin, boolean useTopInset, int systemBarsTop, boolean appBarHandlesTopInset) {
+        if (!enabledSafeTopMargin || !useTopInset || appBarHandlesTopInset) {
+            return 0;
+        }
+
+        return systemBarsTop;
+    }
+}

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -2568,9 +2568,6 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         // Check if we need Android 15+ specific fixes
         boolean isAndroid15Plus = Build.VERSION.SDK_INT >= 35;
 
-        // Get parent view
-        ViewGroup parent = (ViewGroup) _webView.getParent();
-
         // Find status bar color view and toolbar for Android 15+ specific handling
         View statusBarColorView = findViewById(R.id.status_bar_color_view);
         View toolbarView = findViewById(R.id.tool_bar);
@@ -2639,42 +2636,23 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             }
         }
 
-        // Apply system insets to WebView content view (compatible with all Android versions)
-        ViewCompat.setOnApplyWindowInsetsListener(_webView, (v, windowInsets) -> {
+        View coordinatorView = findViewById(R.id.coordinator_layout);
+        final View insetsSourceView = coordinatorView != null ? coordinatorView : _webView;
+
+        // Resolve insets from the dialog root; child WebViews can receive already-fitted zero insets.
+        ViewCompat.setOnApplyWindowInsetsListener(insetsSourceView, (v, windowInsets) -> {
             Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
             Insets navigationBars = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars());
             Insets systemGestures = windowInsets.getInsets(WindowInsetsCompat.Type.systemGestures());
             Insets mandatoryGestures = windowInsets.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures());
             Insets ime = windowInsets.getInsets(WindowInsetsCompat.Type.ime());
-            Boolean keyboardVisible = windowInsets.isVisible(WindowInsetsCompat.Type.ime());
+            boolean keyboardVisible = windowInsets.isVisible(WindowInsetsCompat.Type.ime());
 
-            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+            applySafeAreaMargins(bars, navigationBars, systemGestures, mandatoryGestures, ime, keyboardVisible, isAndroid15Plus);
 
-            // Apply safe margin inset to bottom margin if enabled in options or fallback to 0px
-            int safeBottomInset = Math.max(
-                bars.bottom,
-                Math.max(navigationBars.bottom, Math.max(systemGestures.bottom, mandatoryGestures.bottom))
-            );
-            int navBottom = _options.getEnabledSafeMargin() ? safeBottomInset : 0;
-
-            // Apply top inset based on enabledSafeTopMargin and useTopInset options
-            // If enabledSafeTopMargin is false, force full screen (no top margin)
-            // Otherwise, use useTopInset to determine if system inset should be applied
-            int navTop = _options.getEnabledSafeTopMargin() && _options.getUseTopInset() ? bars.top : 0;
-
-            // Avoid double-applying top inset; AppBar/status bar handled above on Android 15+
-            mlp.topMargin = isAndroid15Plus ? 0 : navTop;
-
-            // Apply larger of navigation bar or keyboard inset to bottom margin
-            mlp.bottomMargin = Math.max(navBottom, ime.bottom);
-
-            mlp.leftMargin = bars.left;
-            mlp.rightMargin = bars.right;
-            v.setLayoutParams(mlp);
-
-            return WindowInsetsCompat.CONSUMED;
+            return windowInsets;
         });
-        ViewCompat.requestApplyInsets(_webView);
+        requestSafeAreaInsets();
 
         // Handle window decoration - version-specific handling
         if (getWindow() != null) {
@@ -2742,6 +2720,58 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                 }
             }
         }
+
+        requestSafeAreaInsets();
+    }
+
+    private void applySafeAreaMargins(
+        Insets bars,
+        Insets navigationBars,
+        Insets systemGestures,
+        Insets mandatoryGestures,
+        Insets ime,
+        boolean keyboardVisible,
+        boolean appBarHandlesTopInset
+    ) {
+        if (_webView == null || _options == null) {
+            return;
+        }
+
+        ViewGroup.LayoutParams layoutParams = _webView.getLayoutParams();
+        if (!(layoutParams instanceof ViewGroup.MarginLayoutParams mlp)) {
+            return;
+        }
+
+        int safeBottomInset = SafeAreaInsetsSupport.resolveSafeBottomInset(
+            bars.bottom,
+            navigationBars.bottom,
+            systemGestures.bottom,
+            mandatoryGestures.bottom
+        );
+        int imeBottom = keyboardVisible ? ime.bottom : 0;
+        int navTop = SafeAreaInsetsSupport.resolveTopMargin(
+            _options.getEnabledSafeTopMargin(),
+            _options.getUseTopInset(),
+            bars.top,
+            appBarHandlesTopInset
+        );
+
+        mlp.topMargin = navTop;
+        mlp.bottomMargin = SafeAreaInsetsSupport.resolveBottomMargin(_options.getEnabledSafeMargin(), safeBottomInset, imeBottom);
+        mlp.leftMargin = bars.left;
+        mlp.rightMargin = bars.right;
+        _webView.setLayoutParams(mlp);
+    }
+
+    private void requestSafeAreaInsets() {
+        View coordinatorView = findViewById(R.id.coordinator_layout);
+        View insetsSourceView = coordinatorView != null ? coordinatorView : _webView;
+        if (insetsSourceView == null) {
+            return;
+        }
+
+        ViewCompat.requestApplyInsets(insetsSourceView);
+        insetsSourceView.post(() -> ViewCompat.requestApplyInsets(insetsSourceView));
     }
 
     public void postMessageToJS(Object detail) {
@@ -5961,17 +5991,13 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
     public void setEnabledSafeTopMargin(boolean enabled) {
         if (_options.getEnabledSafeTopMargin() == enabled) return;
         _options.setEnabledSafeTopMargin(enabled);
-        if (_webView != null) {
-            ViewCompat.requestApplyInsets(_webView);
-        }
+        requestSafeAreaInsets();
     }
 
     public void setEnabledSafeBottomMargin(boolean enabled) {
         if (_options.getEnabledSafeMargin() == enabled) return;
         _options.setEnabledSafeMargin(enabled);
-        if (_webView != null) {
-            ViewCompat.requestApplyInsets(_webView);
-        }
+        requestSafeAreaInsets();
     }
 
     /**

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -2648,7 +2648,13 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             Insets ime = windowInsets.getInsets(WindowInsetsCompat.Type.ime());
             boolean keyboardVisible = windowInsets.isVisible(WindowInsetsCompat.Type.ime());
 
-            applySafeAreaMargins(bars, navigationBars, systemGestures, mandatoryGestures, ime, keyboardVisible, isAndroid15Plus);
+            boolean appBarHandlesTopInset =
+                isAndroid15Plus &&
+                !TextUtils.equals(_options.getToolbarType(), "blank") &&
+                toolbarView != null &&
+                toolbarView.getVisibility() == View.VISIBLE &&
+                toolbarView.getParent() instanceof com.google.android.material.appbar.AppBarLayout;
+            applySafeAreaMargins(bars, navigationBars, systemGestures, mandatoryGestures, ime, keyboardVisible, appBarHandlesTopInset);
 
             return windowInsets;
         });

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupportTest.java
@@ -1,0 +1,29 @@
+package ee.forgr.capacitor_inappbrowser;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class SafeAreaInsetsSupportTest {
+
+    @Test
+    public void safeBottomInsetUsesLargestSystemOrGestureInset() {
+        assertEquals(24, SafeAreaInsetsSupport.resolveSafeBottomInset(0, 16, 24, 8));
+    }
+
+    @Test
+    public void bottomMarginFollowsSafeBottomOptionAndKeyboardInset() {
+        assertEquals(16, SafeAreaInsetsSupport.resolveBottomMargin(true, 16, 0));
+        assertEquals(0, SafeAreaInsetsSupport.resolveBottomMargin(false, 16, 0));
+        assertEquals(280, SafeAreaInsetsSupport.resolveBottomMargin(false, 16, 280));
+        assertEquals(280, SafeAreaInsetsSupport.resolveBottomMargin(true, 16, 280));
+    }
+
+    @Test
+    public void topMarginRequiresSafeTopAndExplicitTopInsetWithoutAppBarHandling() {
+        assertEquals(48, SafeAreaInsetsSupport.resolveTopMargin(true, true, 48, false));
+        assertEquals(0, SafeAreaInsetsSupport.resolveTopMargin(false, true, 48, false));
+        assertEquals(0, SafeAreaInsetsSupport.resolveTopMargin(true, false, 48, false));
+        assertEquals(0, SafeAreaInsetsSupport.resolveTopMargin(true, true, 48, true));
+    }
+}

--- a/example-app/.maestro/blank-target-http-stays-in-webview.yaml
+++ b/example-app/.maestro/blank-target-http-stays-in-webview.yaml
@@ -41,6 +41,7 @@ androidWebViewHierarchy: devtools
     id: "maestro-run-blank-target"
     retryTapIfNoChange: true
 - assertVisible: "Target Blank Test Page"
+# CI can show a transient Pixel Launcher ANR after opening this WebView; poll briefly instead of blocking for long waits.
 - repeat:
     times: 8
     commands:
@@ -55,6 +56,7 @@ androidWebViewHierarchy: devtools
 - tapOn:
     text: "Open Example Domain"
     retryTapIfNoChange: true
+# Keep post-click ANR dismissal bounded: ten 5s polls cover delayed dialogs without adding the long 15s harness wait each time.
 - repeat:
     times: 10
     while:

--- a/example-app/.maestro/blank-target-http-stays-in-webview.yaml
+++ b/example-app/.maestro/blank-target-http-stays-in-webview.yaml
@@ -10,6 +10,10 @@ androidWebViewHierarchy: devtools
     label: "Dismiss the transient Pixel Launcher ANR dialog before waiting for the harness"
 - launchApp:
     clearState: false
+- tapOn:
+    text: "Wait"
+    optional: true
+    label: "Dismiss the transient Pixel Launcher ANR dialog after relaunching the harness"
 - repeat:
     times: 16
     while:
@@ -23,6 +27,13 @@ androidWebViewHierarchy: devtools
           visible: "Maestro Ready"
           timeout: 15000
           optional: true
+- repeat:
+    times: 4
+    commands:
+      - tapOn:
+          text: "Wait"
+          optional: true
+          label: "Dismiss the transient Pixel Launcher ANR dialog after the harness is ready"
 - extendedWaitUntil:
     visible: "Maestro Ready"
     timeout: 15000

--- a/example-app/.maestro/blank-target-http-stays-in-webview.yaml
+++ b/example-app/.maestro/blank-target-http-stays-in-webview.yaml
@@ -41,13 +41,33 @@ androidWebViewHierarchy: devtools
     id: "maestro-run-blank-target"
     retryTapIfNoChange: true
 - assertVisible: "Target Blank Test Page"
+- repeat:
+    times: 8
+    commands:
+      - tapOn:
+          text: "Wait"
+          optional: true
+          label: "Dismiss the transient Pixel Launcher ANR dialog before tapping the blank target link"
+      - extendedWaitUntil:
+          visible: "Open Example Domain"
+          timeout: 5000
+          optional: true
 - tapOn:
     text: "Open Example Domain"
     retryTapIfNoChange: true
-- tapOn:
-    text: "Wait"
-    optional: true
-    label: "Dismiss the transient Pixel Launcher ANR dialog after opening the blank target link"
+- repeat:
+    times: 10
+    while:
+      notVisible: "Example Domain"
+    commands:
+      - tapOn:
+          text: "Wait"
+          optional: true
+          label: "Dismiss the transient Pixel Launcher ANR dialog while waiting for the blank target link"
+      - extendedWaitUntil:
+          visible: "Example Domain"
+          timeout: 5000
+          optional: true
 - extendedWaitUntil:
     visible: "Example Domain"
     timeout: 15000


### PR DESCRIPTION
## What
- Fixed Android WebView safe-area margins for `toolbarType: BLANK` so top, bottom, left, and right insets are applied to the plugin WebView layout.
- Added focused Android unit coverage for safe-area inset margin calculation.
- Hardened PR CI setup by pinning the Bun version and made the Android blank-target Maestro flow dismiss the Pixel Launcher ANR dialog even after the harness is ready.

## Why
- Closes #540.
- The dialog WebView could receive already-consumed or zero local insets, so `useTopInset`, `enabledSafeTopMargin`, and `enabledSafeBottomMargin` did not reliably affect the visible WebView area.
- The draft PR checks also exposed CI flakiness in setup-bun tag lookup and the blank-target Android Maestro flow.

## How
- Listen for window insets on the dialog root layout, then apply computed margins directly to the managed WebView.
- Re-request insets after dialog window setup and after runtime safe-area setting changes.
- Pin `oven-sh/setup-bun` to Bun 1.3.11 in PR CI and add extra optional ANR-dialog dismissal steps to the blank-target flow.

## Testing
- `bun run verify`
- `bun run lint`
- `bunx prettier --write android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java android/src/test/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupportTest.java example-app/.maestro/blank-target-http-stays-in-webview.yaml --plugin=prettier-plugin-java`
- YAML parse check for `example-app/.maestro/blank-target-http-stays-in-webview.yaml`
- `git diff --check`
- GitHub Actions PR checks are being re-run on the updated branch.

## Not Tested
- Manual testing on a physical Android device with gesture navigation and display cutouts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved safe-area handling on Android with smarter top/bottom margin adjustments for system bars, gestures, and keyboard.

* **Tests**
  * Added unit tests covering safe-area inset and margin calculations.

* **Chores**
  * Pinned build runtime version in CI workflow and refined a test scenario’s dialog-dismissal/retry timing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-inappbrowser/pull/542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->