### PR TITLE
[codex] fix android proxy unsupported statuses

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupport.java
@@ -217,6 +217,18 @@ final class ProxyRequestSupport {
         }
     }
 
+    static boolean supportsWebResourceResponseStatus(int statusCode) {
+        return (statusCode >= 100 && statusCode <= 299) || (statusCode >= 400 && statusCode <= 599);
+    }
+
+    static boolean shouldFallbackToWebViewForUnsupportedStatus(boolean bridgeBackedRequest, int statusCode) {
+        return !bridgeBackedRequest && !supportsWebResourceResponseStatus(statusCode);
+    }
+
+    static boolean hasHeaderIgnoreCase(Map<String, String> headers, String expectedKey) {
+        return findHeaderKeyIgnoreCase(headers, expectedKey) != null;
+    }
+
     static String resolveRedirectMethod(String method, int statusCode) {
         String normalizedMethod = normalizeMethod(method);
         if ("HEAD".equals(normalizedMethod)) {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -4472,6 +4472,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                         _options,
                         requestContext.url
                     );
+                    NativeResponseData directResponseData = null;
 
                     NativeProxyRule outboundRule =
                         legacyProxyMode && shouldDelegateLegacyRequest
@@ -4523,7 +4524,11 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                                 if (proxiedRequest.response != null) {
                                     return proxiedRequest.response;
                                 }
-                                requestContext = proxiedRequest.requestContext != null ? proxiedRequest.requestContext : requestContext;
+                                if (proxiedRequest.nativeResponse != null) {
+                                    directResponseData = proxiedRequest.nativeResponse;
+                                } else {
+                                    requestContext = proxiedRequest.requestContext != null ? proxiedRequest.requestContext : requestContext;
+                                }
                             } else {
                                 synchronized (proxiedRequest) {
                                     proxiedRequest.timedOut = true;
@@ -4539,12 +4544,14 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                         }
                     }
 
-                    NativeResponseData nativeResponse;
-                    try {
-                        nativeResponse = performNativeRequest(requestContext);
-                    } catch (IOException error) {
-                        Log.e("InAppBrowserProxy", "Native request failed for: " + requestContext.url, error);
-                        return bridgeBackedRequest ? createCanceledResponse() : null;
+                    NativeResponseData nativeResponse = directResponseData;
+                    if (nativeResponse == null) {
+                        try {
+                            nativeResponse = performNativeRequest(requestContext);
+                        } catch (IOException error) {
+                            Log.e("InAppBrowserProxy", "Native request failed for: " + requestContext.url, error);
+                            return bridgeBackedRequest ? createCanceledResponse() : null;
+                        }
                     }
 
                     int redirectsFollowed = 0;
@@ -4564,7 +4571,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                                 redirectsFollowed++;
                                 continue;
                             }
-                            return buildWebResourceResponse(nativeResponse);
+                            return createWebResourceResponseOrFallback(nativeResponse, bridgeBackedRequest, requestContext.url);
                         }
                         if (inboundRule.getAction() == NativeProxyRule.Action.CANCEL) {
                             return createCanceledResponse();
@@ -4600,6 +4607,9 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                                 if (proxiedRequest.response != null) {
                                     return proxiedRequest.response;
                                 }
+                                if (proxiedRequest.nativeResponse != null) {
+                                    nativeResponse = proxiedRequest.nativeResponse;
+                                }
                             } else {
                                 synchronized (proxiedRequest) {
                                     proxiedRequest.timedOut = true;
@@ -4624,7 +4634,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                             redirectsFollowed++;
                             continue;
                         }
-                        return buildWebResourceResponse(nativeResponse);
+                        return createWebResourceResponseOrFallback(nativeResponse, bridgeBackedRequest, requestContext.url);
                     }
                 }
 
@@ -5477,14 +5487,42 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         return response;
     }
 
+    private WebResourceResponse createWebResourceResponseOrFallback(
+        NativeResponseData responseData,
+        boolean bridgeBackedRequest,
+        String requestUrl
+    ) {
+        WebResourceResponse response = buildWebResourceResponse(responseData);
+        if (response != null) {
+            return response;
+        }
+
+        // Android WebResourceResponse rejects 3xx statuses; let the original WebView request handle them.
+        if (ProxyRequestSupport.shouldFallbackToWebViewForUnsupportedStatus(bridgeBackedRequest, responseData.statusCode)) {
+            Log.w(
+                "InAppBrowserProxy",
+                "Allowing WebView to handle unsupported proxy response status " + responseData.statusCode + " for: " + requestUrl
+            );
+            return null;
+        }
+
+        Log.w("InAppBrowserProxy", "Canceling bridge proxy response with unsupported status: " + responseData.statusCode);
+        return createCanceledResponse();
+    }
+
     private WebResourceResponse buildWebResourceResponse(NativeResponseData responseData) {
+        if (!ProxyRequestSupport.supportsWebResourceResponseStatus(responseData.statusCode)) {
+            return null;
+        }
+
         ProxyRequestSupport.WebResourceResponseMetadata metadata = ProxyRequestSupport.resolveWebResourceResponseMetadata(
             responseData.contentType,
             responseData.headers
         );
+        boolean hasContentTypeHeader = ProxyRequestSupport.hasHeaderIgnoreCase(responseData.headers, "Content-Type");
         WebResourceResponse webResourceResponse = new WebResourceResponse(
-            metadata.mimeType(),
-            metadata.encoding(),
+            hasContentTypeHeader ? null : metadata.mimeType(),
+            hasContentTypeHeader ? null : metadata.encoding(),
             new ByteArrayInputStream(responseData.bodyBytes)
         );
         String reasonPhrase = getReasonPhrase(responseData.statusCode);

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupportTest.java
@@ -44,6 +44,21 @@ public class ProxyRequestSupportTest {
     }
 
     @Test
+    public void supportsWebResourceResponseStatusRejectsAndroidUnsupportedRedirectRange() {
+        assertTrue(ProxyRequestSupport.supportsWebResourceResponseStatus(200));
+        assertTrue(ProxyRequestSupport.supportsWebResourceResponseStatus(404));
+        assertFalse(ProxyRequestSupport.supportsWebResourceResponseStatus(302));
+        assertFalse(ProxyRequestSupport.supportsWebResourceResponseStatus(304));
+    }
+
+    @Test
+    public void shouldFallbackToWebViewOnlyForOriginalUnsupportedStatuses() {
+        assertTrue(ProxyRequestSupport.shouldFallbackToWebViewForUnsupportedStatus(false, 304));
+        assertFalse(ProxyRequestSupport.shouldFallbackToWebViewForUnsupportedStatus(true, 304));
+        assertFalse(ProxyRequestSupport.shouldFallbackToWebViewForUnsupportedStatus(false, 200));
+    }
+
+    @Test
     public void resolveRedirectMethodPreservesNonPostMethodsOnLegacyRedirects() {
         assertEquals("GET", ProxyRequestSupport.resolveRedirectMethod("POST", 302));
         assertEquals("PUT", ProxyRequestSupport.resolveRedirectMethod("PUT", 302));
@@ -138,6 +153,27 @@ public class ProxyRequestSupportTest {
         assertFalse(overrideHeaders.containsKey("Origin"));
         assertFalse(overrideHeaders.containsKey("Referer"));
         assertEquals("application/json", overrideHeaders.get("Accept"));
+    }
+
+    @Test
+    public void stripCacheValidatorHeadersRemovesOnlyRevalidationHeaders() {
+        Map<String, String> headers = ProxyRequestSupport.stripCacheValidatorHeaders(
+            Map.of(
+                "If-None-Match",
+                "\"abc\"",
+                "If-Modified-Since",
+                "Wed, 21 Oct 2015 07:28:00 GMT",
+                "If-Match",
+                "\"write-guard\"",
+                "Accept",
+                "application/json"
+            )
+        );
+
+        assertFalse(headers.containsKey("If-None-Match"));
+        assertFalse(headers.containsKey("If-Modified-Since"));
+        assertEquals("\"write-guard\"", headers.get("If-Match"));
+        assertEquals("application/json", headers.get("Accept"));
     }
 
     @Test
@@ -364,6 +400,12 @@ public class ProxyRequestSupportTest {
 
         assertEquals("image/png", imageMetadata.mimeType());
         assertNull(imageMetadata.encoding());
+    }
+
+    @Test
+    public void hasHeaderIgnoreCaseFindsContentTypeWithOriginalCasing() {
+        assertTrue(ProxyRequestSupport.hasHeaderIgnoreCase(Map.of("content-type", "multipart/mixed; boundary=test"), "Content-Type"));
+        assertFalse(ProxyRequestSupport.hasHeaderIgnoreCase(Map.of("Accept", "application/json"), "Content-Type"));
     }
 
     @Test


### PR DESCRIPTION
## What
- Fix Android proxy pass-through handling for response statuses that `WebResourceResponse` cannot represent, such as 3xx and 304.
- Preserve original `Content-Type` response headers when building Android `WebResourceResponse` objects.
- Add Android unit coverage for unsupported status fallback, cache validator stripping, and case-insensitive content-type detection.

## Why
- Fixes #539. Android rejects 3xx statuses in `WebResourceResponse.setStatusCodeAndReasonPhrase`, which can crash when broad proxy rules route unchanged requests through the native proxy pipeline.

## How
- Centralized the Android-supported `WebResourceResponse` status check.
- Let non-bridge WebView requests fall back to the original WebView loader when the native pass-through response status cannot be represented safely.
- Kept bridge-backed proxy requests fail-closed for unsupported statuses because native cannot replay the marker request transparently.

## Testing
- `bun run fmt`
- `cd android && ./gradlew testDebugUnitTest --tests 'ee.forgr.capacitor_inappbrowser.ProxyRequestSupportTest'`
- `bun run verify`

## Not Tested
- Manual Android device reproduction for the exact affected app traffic.