### PR TITLE
[codex] fix Android proxy passthrough errors

### DIFF
--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -40,13 +40,17 @@ bun run build
 
 case "$platform" in
   android)
-    bunx cap add android
+    if [[ ! -d android ]]; then
+      bunx cap add android
+    fi
     bunx cap sync android
     cd android
     ./gradlew build test
     ;;
   ios)
-    bunx cap add ios
+    if [[ ! -d ios ]]; then
+      bunx cap add ios
+    fi
     bunx cap sync ios
     xcodebuild -project ios/App/App.xcodeproj -scheme App -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
     ;;

--- a/android/src/main/assets/proxy-bridge.js
+++ b/android/src/main/assets/proxy-bridge.js
@@ -31,6 +31,17 @@
     }
     return null;
   }
+  function isNativeProxyErrorResponse(response) {
+    return response.status === 599 && response.headers.get("x-capgo-proxy-error") !== null;
+  }
+  function nativeProxyErrorMessage(response) {
+    const nativeErrorHeader = response.headers.get("x-capgo-proxy-error");
+    if (!nativeErrorHeader) {
+      return "Network request failed";
+    }
+    const nativeMessage = nativeErrorHeader.trim();
+    return nativeMessage || "Network request failed";
+  }
   function replaceCapturedHeader(headers, name, value) {
     const existingKey = findCapturedHeaderKey(headers, name);
     if (existingKey && existingKey !== name) {
@@ -442,10 +453,14 @@
         } catch (_error) {
           return originalFetch.call(window, input, init);
         }
-        return originalFetch.call(window, proxyUrl, {
+        const proxyResponse = yield originalFetch.call(globalThis, proxyUrl, {
           method: "GET",
           signal
         });
+        if (isNativeProxyErrorResponse(proxyResponse)) {
+          throw new TypeError(nativeProxyErrorMessage(proxyResponse));
+        }
+        return proxyResponse;
       });
     };
     const originalXhrOpen = XMLHttpRequest.prototype.open;

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupport.java
@@ -22,6 +22,9 @@ final class ProxyRequestSupport {
 
     record ParsedResponseHeaders(Map<String, String> responseHeaders, List<String> cookieHeaders) {}
 
+    static final int SYNTHETIC_NATIVE_FAILURE_STATUS = 599;
+    static final String SYNTHETIC_NATIVE_FAILURE_HEADER = "X-Capgo-Proxy-Error";
+
     private static final String[] SAFE_MARKER_HEADER_NAMES = {
         "Accept",
         "Accept-Encoding",
@@ -474,6 +477,31 @@ final class ProxyRequestSupport {
         return new ParsedResponseHeaders(responseHeaders, cookieHeaders);
     }
 
+    static String describeNativeRequestFailure(IOException error) {
+        if (error == null || error.getMessage() == null || error.getMessage().isBlank()) {
+            return "Native proxy request failed";
+        }
+        String sanitizedMessage = sanitizeHeaderValue(error.getMessage());
+        return sanitizedMessage.isBlank() ? "Native proxy request failed" : sanitizedMessage;
+    }
+
+    static Map<String, String> createNativeRequestFailureHeaders(IOException error) {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Cache-Control", "no-store");
+        headers.put("Content-Type", "text/plain; charset=utf-8");
+        headers.put(SYNTHETIC_NATIVE_FAILURE_HEADER, describeNativeRequestFailure(error));
+        return headers;
+    }
+
+    static byte[] createNativeRequestFailureBody(String requestUrl, IOException error) {
+        StringBuilder message = new StringBuilder("Native proxy request failed");
+        if (requestUrl != null && !requestUrl.isBlank()) {
+            message.append(" for ").append(requestUrl);
+        }
+        message.append(": ").append(describeNativeRequestFailure(error));
+        return message.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
     static JSObject normalizeLegacySyntheticResponse(JSONObject legacyResponse) {
         JSObject normalizedResponse = new JSObject();
         if (legacyResponse == null) {
@@ -572,6 +600,25 @@ final class ProxyRequestSupport {
             return "GET";
         }
         return method.trim().toUpperCase(Locale.US);
+    }
+
+    private static String sanitizeHeaderValue(String value) {
+        StringBuilder sanitizedValue = new StringBuilder(value.length());
+        boolean previousWasSpace = false;
+        for (int index = 0; index < value.length(); index++) {
+            char character = value.charAt(index);
+            boolean shouldReplaceWithSpace = character <= 31 || character == 127;
+            if (shouldReplaceWithSpace) {
+                if (!previousWasSpace) {
+                    sanitizedValue.append(' ');
+                    previousWasSpace = true;
+                }
+                continue;
+            }
+            sanitizedValue.append(character);
+            previousWasSpace = character == ' ';
+        }
+        return sanitizedValue.toString().trim();
     }
 
     private static String normalizeCredentialsMode(String credentialsMode) {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -4544,7 +4544,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                             nativeResponse = performNativeRequest(requestContext);
                         } catch (IOException error) {
                             Log.e("InAppBrowserProxy", "Native request failed for: " + requestContext.url, error);
-                            return bridgeBackedRequest ? createCanceledResponse() : null;
+                            return bridgeBackedRequest ? createNativeFailureResponse(requestContext.url, error) : null;
                         }
                     }
 
@@ -4557,7 +4557,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                                 redirectReplay = followRedirectForWebView(requestContext, nativeResponse, redirectsFollowed);
                             } catch (IOException error) {
                                 Log.e("InAppBrowserProxy", "Native redirect replay failed for: " + requestContext.url, error);
-                                return bridgeBackedRequest ? createCanceledResponse() : null;
+                                return bridgeBackedRequest ? createNativeFailureResponse(requestContext.url, error) : null;
                             }
                             if (redirectReplay != null) {
                                 requestContext = redirectReplay.requestContext;
@@ -4620,7 +4620,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                             redirectReplay = followRedirectForWebView(requestContext, nativeResponse, redirectsFollowed);
                         } catch (IOException error) {
                             Log.e("InAppBrowserProxy", "Native redirect replay failed for: " + requestContext.url, error);
-                            return bridgeBackedRequest ? createCanceledResponse() : null;
+                            return bridgeBackedRequest ? createNativeFailureResponse(requestContext.url, error) : null;
                         }
                         if (redirectReplay != null) {
                             requestContext = redirectReplay.requestContext;
@@ -4923,6 +4923,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             case (504) -> "Gateway Timeout";
             case (505) -> "HTTP Version Not Supported";
             case (507) -> "Insufficient Storage";
+            case (599) -> "Network Error";
             default -> "";
         };
     }
@@ -5479,6 +5480,17 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         response.setStatusCodeAndReasonPhrase(204, "No Content");
         response.setResponseHeaders(new HashMap<>());
         return response;
+    }
+
+    private WebResourceResponse createNativeFailureResponse(String requestUrl, IOException error) {
+        NativeResponseData responseData = new NativeResponseData(
+            ProxyRequestSupport.SYNTHETIC_NATIVE_FAILURE_STATUS,
+            "text/plain; charset=utf-8",
+            ProxyRequestSupport.createNativeRequestFailureHeaders(error),
+            ProxyRequestSupport.createNativeRequestFailureBody(requestUrl, error)
+        );
+        WebResourceResponse response = buildWebResourceResponse(responseData);
+        return response != null ? response : createCanceledResponse();
     }
 
     private WebResourceResponse createWebResourceResponseOrFallback(

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupportTest.java
@@ -47,8 +47,25 @@ public class ProxyRequestSupportTest {
     public void supportsWebResourceResponseStatusRejectsAndroidUnsupportedRedirectRange() {
         assertTrue(ProxyRequestSupport.supportsWebResourceResponseStatus(200));
         assertTrue(ProxyRequestSupport.supportsWebResourceResponseStatus(404));
+        assertTrue(ProxyRequestSupport.supportsWebResourceResponseStatus(599));
         assertFalse(ProxyRequestSupport.supportsWebResourceResponseStatus(302));
         assertFalse(ProxyRequestSupport.supportsWebResourceResponseStatus(304));
+    }
+
+    @Test
+    public void createNativeRequestFailureResponsePayloadMarksSyntheticNetworkErrors() {
+        IOException error = new IOException("Unable to resolve host\nexample.test");
+
+        Map<String, String> headers = ProxyRequestSupport.createNativeRequestFailureHeaders(error);
+        String body = new String(
+            ProxyRequestSupport.createNativeRequestFailureBody("https://example.test/api", error),
+            StandardCharsets.UTF_8
+        );
+
+        assertEquals("Unable to resolve host example.test", headers.get(ProxyRequestSupport.SYNTHETIC_NATIVE_FAILURE_HEADER));
+        assertEquals("no-store", headers.get("Cache-Control"));
+        assertTrue(body.contains("https://example.test/api"));
+        assertTrue(body.contains("Unable to resolve host example.test"));
     }
 
     @Test

--- a/src/proxy-bridge-support.test.ts
+++ b/src/proxy-bridge-support.test.ts
@@ -7,6 +7,8 @@ import {
   ensureInferredContentType,
   getSubmitEventSubmitter,
   inferContentTypeFromBody,
+  isNativeProxyErrorResponse,
+  nativeProxyErrorMessage,
   replaySubmitAfterProxyFailure,
   replaceCapturedHeader,
   restoreXhrReplayState,
@@ -42,6 +44,25 @@ describe('proxy bridge header helpers', () => {
 
     expect(inferredHeaders).toEqual({ 'content-type': 'application/x-www-form-urlencoded;charset=UTF-8' });
     expect(explicitHeaders).toEqual({ 'Content-Type': 'application/json' });
+  });
+});
+
+describe('proxy bridge native error helpers', () => {
+  it('detects synthetic native proxy failures', () => {
+    const response = new Response('', {
+      status: 599,
+      headers: { 'X-Capgo-Proxy-Error': 'Unable to resolve host' },
+    });
+
+    expect(isNativeProxyErrorResponse(response)).toBe(true);
+    expect(nativeProxyErrorMessage(response)).toBe('Unable to resolve host');
+  });
+
+  it('ignores ordinary 599 responses without the native proxy marker header', () => {
+    const response = new Response('', { status: 599 });
+
+    expect(isNativeProxyErrorResponse(response)).toBe(false);
+    expect(nativeProxyErrorMessage(response)).toBe('Network request failed');
   });
 });
 

--- a/src/proxy-bridge-support.ts
+++ b/src/proxy-bridge-support.ts
@@ -8,6 +8,22 @@ export function findCapturedHeaderKey(headers: Record<string, string>, headerNam
   return null;
 }
 
+export const NATIVE_PROXY_ERROR_STATUS = 599;
+export const NATIVE_PROXY_ERROR_HEADER = 'x-capgo-proxy-error';
+
+export function isNativeProxyErrorResponse(response: Pick<Response, 'status' | 'headers'>): boolean {
+  return response.status === 599 && response.headers.get('x-capgo-proxy-error') !== null;
+}
+
+export function nativeProxyErrorMessage(response: Pick<Response, 'headers'>): string {
+  const nativeErrorHeader = response.headers.get('x-capgo-proxy-error');
+  if (!nativeErrorHeader) {
+    return 'Network request failed';
+  }
+  const nativeMessage = nativeErrorHeader.trim();
+  return nativeMessage || 'Network request failed';
+}
+
 export function replaceCapturedHeader(headers: Record<string, string>, name: string, value: string): void {
   const existingKey = findCapturedHeaderKey(headers, name);
   if (existingKey && existingKey !== name) {

--- a/src/proxy-bridge.ts
+++ b/src/proxy-bridge.ts
@@ -4,6 +4,8 @@ import {
   consumeProxySubmitReplayBypass,
   ensureInferredContentType,
   getSubmitEventSubmitter,
+  isNativeProxyErrorResponse,
+  nativeProxyErrorMessage,
   replaySubmitAfterProxyFailure,
   replaceCapturedHeader,
   restoreXhrReplayState,
@@ -372,10 +374,14 @@ import {
     } catch (_error) {
       return originalFetch.call(window, input, init);
     }
-    return originalFetch.call(window, proxyUrl, {
+    const proxyResponse = await originalFetch.call(globalThis, proxyUrl, {
       method: 'GET',
       signal,
     });
+    if (isNativeProxyErrorResponse(proxyResponse)) {
+      throw new TypeError(nativeProxyErrorMessage(proxyResponse));
+    }
+    return proxyResponse;
   };
 
   const originalXhrOpen = XMLHttpRequest.prototype.open;


### PR DESCRIPTION
## What
- Fix Android proxied passthrough native request failures so they surface as network errors instead of empty `204` responses.
- Make the packed example verification reuse existing native platform directories before syncing.

## Why
- Closes #550 by preserving failure semantics when the Android native replay path cannot complete a proxied request.
- The packed example CI copies an example app that already contains native platform directories, so re-adding those platforms fails before the actual build runs.

## How
- Return a synthetic Android proxy failure response with a dedicated status/header/body when native replay throws `IOException`.
- Detect that synthetic response in the bridge script and reject the proxied fetch with a `TypeError`.
- Keep explicit request cancellations mapped to the existing empty `204` response.
- Skip `cap add` in packed example verification when the target platform directory already exists.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/Users/martindonadieu/Library/Android/sdk ANDROID_SDK_ROOT=/Users/martindonadieu/Library/Android/sdk bun run verify`
- `bun test src/proxy-bridge-support.test.ts`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/Users/martindonadieu/Library/Android/sdk ANDROID_SDK_ROOT=/Users/martindonadieu/Library/Android/sdk bash ./.github/scripts/verify-packed-example.sh android`
- `bash ./.github/scripts/verify-packed-example.sh ios`

## Not Tested
- Manual Android WebView reproduction against a failing live upstream endpoint.

Implemented with Codex assistance.
