### PR TITLE
fix(ios): guard WKURLSchemeTask completion against post-stop and double calls

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
+++ b/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
@@ -636,13 +636,14 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
 
             if let error {
                 if (error as NSError).code == NSURLErrorCancelled {
-                    // A cancellation with a pending redirect is the expected signal that
-                    // willPerformHTTPRedirection suppressed automatic following; the task
-                    // continues via the redirect, so leave it tracked. Otherwise no
-                    // terminal scheme-task call happens here, so remove it explicitly.
-                    if pendingTask.redirectRequest == nil {
-                        self.removePendingTask(requestId: requestId)
-                    }
+                    // The data task is only canceled by webView(_:stop:) or
+                    // cancelAllPendingTasks(), and both own the task's lifecycle: stop has
+                    // already removed it (and marked it stopped) before canceling, while
+                    // cancelAll routes a terminal failSchemeTask through completeSchemeTask,
+                    // which removes it on the main queue. Removing it here on the URLSession
+                    // background queue would unhook it from pendingTasks before a racing
+                    // stop could mark it stopped, reopening the post-stop completion crash.
+                    // So just stop processing and let the owning path complete it.
                     return
                 }
                 self.failSchemeTask(pendingTask, with: error)
@@ -843,14 +844,6 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
         let task = pendingTasks[requestId]
         taskLock.unlock()
         return task
-    }
-
-    private func removePendingTask(requestId: String) {
-        taskLock.lock()
-        pendingTasks.removeValue(forKey: requestId)
-        stoppedRequests.removeValue(forKey: requestId)
-        timedOutRequests.removeValue(forKey: requestId)
-        taskLock.unlock()
     }
 
     private func routeCurrentRequest(requestId: String) {

--- a/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
+++ b/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
@@ -403,6 +403,7 @@ enum ProxySchemeRequestSupport {
 }
 
 final class PendingProxyTask {
+    let requestId: String
     let schemeTask: WKURLSchemeTask
     var requestContext: NativeRequestContext
     var responseData: NativeResponseData?
@@ -421,7 +422,8 @@ final class PendingProxyTask {
     /// race to finish the same request.
     private var isComplete = false
 
-    init(schemeTask: WKURLSchemeTask, requestContext: NativeRequestContext, phase: String) {
+    init(requestId: String, schemeTask: WKURLSchemeTask, requestContext: NativeRequestContext, phase: String) {
+        self.requestId = requestId
         self.schemeTask = schemeTask
         self.requestContext = requestContext
         self.phase = phase
@@ -510,7 +512,7 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
             base64Body: extractBody(from: urlSchemeTask.request),
             isMainFrame: ProxySchemeRequestSupport.isMainFrameRequest(urlSchemeTask.request)
         )
-        let pendingTask = PendingProxyTask(schemeTask: urlSchemeTask, requestContext: requestContext, phase: "outbound")
+        let pendingTask = PendingProxyTask(requestId: requestId, schemeTask: urlSchemeTask, requestContext: requestContext, phase: "outbound")
 
         taskLock.lock()
         pendingTasks[requestId] = pendingTask
@@ -593,7 +595,6 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
 
         if pendingTask.canceled {
             finishWithCanceledResponse(task: pendingTask)
-            removePendingTask(requestId: requestId)
             return
         }
 
@@ -603,7 +604,6 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
         ) {
         case .finishCachedResponse:
             guard let responseData = pendingTask.responseData else { return }
-            removePendingTask(requestId: requestId)
             syncResponseCookies(from: responseData, fallbackURL: pendingTask.requestContext.url) {
                 self.finish(task: pendingTask, with: responseData)
             }
@@ -628,7 +628,6 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
                     userInfo: [NSLocalizedDescriptionKey: error.localizedDescription]
                 )
             )
-            removePendingTask(requestId: requestId)
             return
         }
         let task = session.dataTask(with: request) { [weak self] data, response, error in
@@ -636,13 +635,17 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
             guard let pendingTask = self.pendingTask(for: requestId) else { return }
 
             if let error {
-                if (error as NSError).code == NSURLErrorCancelled, pendingTask.redirectRequest != nil {
+                if (error as NSError).code == NSURLErrorCancelled {
+                    // A cancellation with a pending redirect is the expected signal that
+                    // willPerformHTTPRedirection suppressed automatic following; the task
+                    // continues via the redirect, so leave it tracked. Otherwise no
+                    // terminal scheme-task call happens here, so remove it explicitly.
+                    if pendingTask.redirectRequest == nil {
+                        self.removePendingTask(requestId: requestId)
+                    }
                     return
                 }
-                if (error as NSError).code != NSURLErrorCancelled {
-                    self.failSchemeTask(pendingTask, with: error)
-                }
-                self.removePendingTask(requestId: requestId)
+                self.failSchemeTask(pendingTask, with: error)
                 return
             }
 
@@ -701,13 +704,11 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
             switch inboundRule.action {
             case .cancel:
                 finishWithCanceledResponse(task: pendingTask)
-                removePendingTask(requestId: requestId)
             case .continue:
                 if pendingTask.redirectRequest != nil {
                     followPendingRedirect(requestId: requestId)
                 } else {
                     finish(task: pendingTask, with: responseData)
-                    removePendingTask(requestId: requestId)
                 }
             case .delegateToJs:
                 emitProxyEvent(requestId: requestId, pendingTask: pendingTask)
@@ -718,7 +719,6 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
                 followPendingRedirect(requestId: requestId)
             } else {
                 finish(task: pendingTask, with: responseData)
-                removePendingTask(requestId: requestId)
             }
         }
     }
@@ -780,7 +780,6 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
                 self.fallbackToNativePipeline(requestId: requestId)
                 return
             case .finishCachedResponse:
-                self.pendingTasks.removeValue(forKey: requestId)
                 self.taskLock.unlock()
                 guard let responseData else { return }
                 self.syncResponseCookies(from: responseData, fallbackURL: pendingTask.requestContext.url) {
@@ -788,7 +787,6 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
                 }
                 return
             case .failRequest:
-                self.pendingTasks.removeValue(forKey: requestId)
                 self.taskLock.unlock()
             }
 
@@ -864,7 +862,6 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
             switch outboundRule.action {
             case .cancel:
                 finishWithCanceledResponse(task: pendingTask)
-                removePendingTask(requestId: requestId)
             case .continue:
                 executeNativePipeline(requestId: requestId)
             case .delegateToJs:
@@ -1055,11 +1052,22 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
     /// helper funnels every terminal call onto the main thread (the same queue WebKit
     /// uses for `start`/`stop`) and gates it behind `beginCompletionIfLive()`, so the
     /// liveness check and the actual call cannot be separated by a `stop`.
+    ///
+    /// This helper is also the single owner of task removal. Callers MUST NOT remove
+    /// the task from `pendingTasks` eagerly on a background thread before calling a
+    /// terminal method: doing so creates a window where `webView(_:stop:)` (which only
+    /// finds tasks via `pendingTasks`) can no longer mark the task stopped, so a queued
+    /// completion would then call `didReceive`/`didFinish`/`didFailWithError` on an
+    /// already-stopped task and crash. Keeping the task tracked until this main-queue
+    /// block runs lets a racing `stop` win the liveness claim.
     private func completeSchemeTask(_ task: PendingProxyTask, _ body: @escaping (WKURLSchemeTask) -> Void) {
         let runBody: () -> Void = { [weak self] in
             guard let self else { return }
             self.taskLock.lock()
             let isLive = task.beginCompletionIfLive()
+            self.pendingTasks.removeValue(forKey: task.requestId)
+            self.stoppedRequests.removeValue(forKey: task.requestId)
+            self.timedOutRequests.removeValue(forKey: task.requestId)
             self.taskLock.unlock()
             guard isLive else { return }
             body(task.schemeTask)
@@ -1195,7 +1203,10 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
     func cancelAllPendingTasks() {
         taskLock.lock()
         let pending = pendingTasks
-        pendingTasks.removeAll()
+        // Do not clear pendingTasks here. completeSchemeTask removes each task on the
+        // main queue once its failure is claimed, so a concurrent webView(_:stop:) can
+        // still find and mark the task stopped before the queued failure runs. Clearing
+        // eagerly would reopen the post-stop completion crash this fix closes.
         stoppedRequests.removeAll()
         taskLock.unlock()
         session.invalidateAndCancel()

--- a/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
+++ b/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
@@ -411,11 +411,30 @@ final class PendingProxyTask {
     var redirectRequest: URLRequest?
     var timeoutToken: UUID?
     var canceled = false
+    /// Set true when WebKit calls `webView(_:stop:)` for this task. Once stopped,
+    /// the `WKURLSchemeTask` must never receive `didReceive`/`didFinish`/`didFailWithError`
+    /// again or WebKit raises an uncatchable NSException.
+    var isStopped = false
+    /// Set true the first time a terminal scheme-task call sequence is committed.
+    /// Guarantees at-most-once completion even when multiple async sources
+    /// (URLSession delegate queue, cookie-sync main hop, global timeout, cancel-all)
+    /// race to finish the same request.
+    private var isComplete = false
 
     init(schemeTask: WKURLSchemeTask, requestContext: NativeRequestContext, phase: String) {
         self.schemeTask = schemeTask
         self.requestContext = requestContext
         self.phase = phase
+    }
+
+    /// Claims the right to issue the single allowed terminal call sequence on the
+    /// scheme task. Returns true exactly once, and only while the task is live
+    /// (not stopped). Callers MUST hold the handler's `taskLock` so the claim is
+    /// atomic with respect to `webView(_:stop:)` marking the task stopped.
+    func beginCompletionIfLive() -> Bool {
+        if isComplete || isStopped { return false }
+        isComplete = true
+        return true
     }
 }
 
@@ -503,6 +522,7 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
     public func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {
         taskLock.lock()
         if let entry = pendingTasks.first(where: { $0.value.schemeTask === urlSchemeTask }) {
+            entry.value.isStopped = true
             pendingTasks.removeValue(forKey: entry.key)
             let cleanupToken = UUID()
             stoppedRequests[entry.key] = cleanupToken
@@ -600,8 +620,9 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
         do {
             request = try makeURLRequest(from: pendingTask.requestContext)
         } catch {
-            pendingTask.schemeTask.didFailWithError(
-                NSError(
+            failSchemeTask(
+                pendingTask,
+                with: NSError(
                     domain: "ProxySchemeHandler",
                     code: -3,
                     userInfo: [NSLocalizedDescriptionKey: error.localizedDescription]
@@ -619,7 +640,7 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
                     return
                 }
                 if (error as NSError).code != NSURLErrorCancelled {
-                    pendingTask.schemeTask.didFailWithError(error)
+                    self.failSchemeTask(pendingTask, with: error)
                 }
                 self.removePendingTask(requestId: requestId)
                 return
@@ -771,8 +792,9 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
                 self.taskLock.unlock()
             }
 
-            pendingTask.schemeTask.didFailWithError(
-                NSError(
+            self.failSchemeTask(
+                pendingTask,
+                with: NSError(
                     domain: "ProxySchemeHandler",
                     code: NSURLErrorTimedOut,
                     userInfo: [NSLocalizedDescriptionKey: "Proxy handler did not respond within \(Int(self.proxyTimeoutSeconds)) seconds"]
@@ -1022,27 +1044,62 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
         )
     }
 
-    private func finish(task: PendingProxyTask, with responseData: NativeResponseData) {
-        guard let url = URL(string: task.requestContext.url),
-              let httpResponse = HTTPURLResponse(
-                url: url,
-                statusCode: responseData.statusCode,
-                httpVersion: "HTTP/1.1",
-                headerFields: responseData.headers
-              )
-        else {
-            task.schemeTask.didFailWithError(
-                NSError(
-                    domain: "ProxySchemeHandler",
-                    code: -2,
-                    userInfo: [NSLocalizedDescriptionKey: "Failed to create response"]
-                )
-            )
-            return
+    /// Runs a terminal `WKURLSchemeTask` call sequence at most once, and never after
+    /// the task has been stopped.
+    ///
+    /// `WKURLSchemeTask` raises an uncatchable NSException if `didReceive`/`didFinish`/
+    /// `didFailWithError` is called after `webView(_:stop:)`, after the task already
+    /// completed, or out of order. Completion can be triggered from several racing
+    /// sources — the URLSession delegate queue, the cookie-sync main-thread hop, the
+    /// global timeout closure, `webView(_:stop:)`, and `cancelAllPendingTasks()`. This
+    /// helper funnels every terminal call onto the main thread (the same queue WebKit
+    /// uses for `start`/`stop`) and gates it behind `beginCompletionIfLive()`, so the
+    /// liveness check and the actual call cannot be separated by a `stop`.
+    private func completeSchemeTask(_ task: PendingProxyTask, _ body: @escaping (WKURLSchemeTask) -> Void) {
+        let runBody: () -> Void = { [weak self] in
+            guard let self else { return }
+            self.taskLock.lock()
+            let isLive = task.beginCompletionIfLive()
+            self.taskLock.unlock()
+            guard isLive else { return }
+            body(task.schemeTask)
         }
-        task.schemeTask.didReceive(httpResponse)
-        task.schemeTask.didReceive(responseData.body)
-        task.schemeTask.didFinish()
+        if Thread.isMainThread {
+            runBody()
+        } else {
+            DispatchQueue.main.async(execute: runBody)
+        }
+    }
+
+    private func failSchemeTask(_ task: PendingProxyTask, with error: Error) {
+        completeSchemeTask(task) { schemeTask in
+            schemeTask.didFailWithError(error)
+        }
+    }
+
+    private func finish(task: PendingProxyTask, with responseData: NativeResponseData) {
+        completeSchemeTask(task) { schemeTask in
+            guard let url = URL(string: task.requestContext.url),
+                  let httpResponse = HTTPURLResponse(
+                    url: url,
+                    statusCode: responseData.statusCode,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: responseData.headers
+                  )
+            else {
+                schemeTask.didFailWithError(
+                    NSError(
+                        domain: "ProxySchemeHandler",
+                        code: -2,
+                        userInfo: [NSLocalizedDescriptionKey: "Failed to create response"]
+                    )
+                )
+                return
+            }
+            schemeTask.didReceive(httpResponse)
+            schemeTask.didReceive(responseData.body)
+            schemeTask.didFinish()
+        }
     }
 
     private func finishWithCanceledResponse(task: PendingProxyTask) {
@@ -1145,8 +1202,9 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
 
         for (_, task) in pending {
             task.urlSessionTask?.cancel()
-            task.schemeTask.didFailWithError(
-                NSError(
+            failSchemeTask(
+                task,
+                with: NSError(
                     domain: "ProxySchemeHandler",
                     code: NSURLErrorCancelled,
                     userInfo: [NSLocalizedDescriptionKey: "WebView closed"]


### PR DESCRIPTION
## Summary

Fixes production iOS crashes in the proxy scheme handler caused by `WKURLSchemeTask` lifecycle violations. WebKit raises an **uncatchable `NSException`** if `didReceive(_:)` / `didFinish()` / `didFailWithError(_:)` is called:

- after `webView(_:stop:)` has been called for the task,
- after the task has already completed (double completion), or
- out of order.

Crash reports for the shipped build pointed at exactly these paths:
- `ProxySchemeHandler.finish(task:with:)` — ~19 devices
- `ProxySchemeHandler.cancelAllPendingTasks()` — ~3 devices
- CFNetwork completion (URLSession delegate queue) — ~2 devices

## Root cause

A request can be completed from several **racing, independently-scheduled sources**, none of which checked whether the scheme task was already stopped or finished:

1. the URLSession `dataTask` completion (background delegate queue),
2. the cookie-sync main-thread hop (`writeCookiesOnMain`),
3. the global timeout closure (`DispatchQueue.global().asyncAfter`),
4. `webView(_:stop:)` (main thread, WebKit-initiated teardown),
5. `cancelAllPendingTasks()` (WebView close).

When two of these reach the same task — e.g. the global timeout fires while a stop is being processed, or `cancelAllPendingTasks` runs against a task WebKit already stopped — the second terminal call hits a dead/stopped `WKURLSchemeTask` and crashes the app.

## Fix

Introduce an at-most-once, liveness-checked completion path:

- **`PendingProxyTask`** gains `isStopped` and a private `isComplete`, plus `beginCompletionIfLive()` which returns `true` exactly once and only while the task is live. Callers hold `taskLock` so the claim is atomic w.r.t. stop.
- **`completeSchemeTask(_:_:)`** funnels every terminal call onto the **main thread** (the same queue WebKit uses for `start`/`stop`) and gates it behind `beginCompletionIfLive()`. Because the liveness check and the actual scheme-task call both run on the serial main queue, a `stop` cannot interleave between them.
- **`finish(...)`**, **`finishWithCanceledResponse(...)`** (via `finish`), and all standalone `didFailWithError` sites (request-build failure, dataTask error, timeout, `cancelAllPendingTasks`) now route through this helper.
- **`webView(_:stop:)`** marks the task `isStopped = true` under `taskLock` before removing it.

Net effect: late or duplicate completions become safe no-ops instead of crashes. No change to the success-path behavior of a normally-completing request.

## Scope

- iOS only. One file: `ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift` (+83 / −25).
- No public API change. The pure `ProxySchemeRequestSupport` helpers (covered by `ProxyRequestSupportTest`) are untouched.

## Test plan

- [ ] CI iOS build passes (local CLI `swift build` only fails on the pre-existing `UIKit`/`Capacitor` module-resolution limitation, unrelated to this change).
- [ ] Manual: open a proxied WebView (Facebook Marketplace flow), navigate rapidly / close mid-request, and confirm no `WKURLSchemeTask`-related crash.
- [ ] Manual: trigger the 10s proxy timeout and confirm the request fails cleanly without a crash.
- [ ] Manual: close the WebView while requests are in flight (`cancelAllPendingTasks`) and confirm clean teardown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-app browser stability by preventing duplicate or premature network callbacks during page loads and cancellations.
  * Reduced race conditions for loading, timeout, and cancellation flows so navigation, error delivery, and task cancellation are more reliable and predictable.

* **Refactor**
  * Internal lifecycle handling simplified to ensure only a single final callback is delivered per navigation, improving consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-inappbrowser/pull/554?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->