### PR TITLE
fix(android): only inject proxy bridge JS in legacy proxyRequests mode

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupport.java
@@ -62,7 +62,7 @@ final class ProxyRequestSupport {
     private ProxyRequestSupport() {}
 
     static boolean shouldInjectBridge(Options options) {
-        return options != null && usesLegacyJsProxyMode(options);
+        return usesLegacyJsProxyMode(options);
     }
 
     static boolean usesLegacyJsProxyMode(Options options) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the in-app browser decision logic for whether to activate the native bridge, removing redundant checks while keeping behavior the same.

* **Bug Fixes**
  * *(No user-visible behavior changes identified in this update.)*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->