### PR TITLE
fix(android): keep secure auth window alive across backgrounding

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -1730,7 +1730,11 @@ public class InAppBrowserPlugin extends Plugin implements WebViewDialog.Permissi
         builder.setShareState(CustomTabsIntent.SHARE_STATE_OFF);
         builder.setEphemeralBrowsingEnabled(Boolean.TRUE.equals(call.getBoolean("prefersEphemeralWebBrowserSession", false)));
         CustomTabsIntent customTabsIntent = builder.build();
-        customTabsIntent.intent.setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        // Note: FLAG_ACTIVITY_NO_HISTORY is intentionally omitted. With it set, backgrounding the app
+        // (e.g. to copy an OTP/password) finishes the Custom Tab, which then resumes the host activity
+        // and trips the cancel heuristic in handleOnResume(), aborting the auth flow. Without it, the
+        // tab is restored on return instead of being destroyed.
+        customTabsIntent.intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         customTabsIntent.intent.putExtra(CustomTabsIntent.EXTRA_ENABLE_INSTANT_APPS, false);
         customTabsIntent.intent.putExtra(CustomTabsIntent.EXTRA_DISABLE_BACKGROUND_INTERACTION, false);
         customTabsIntent.launchUrl(getActivity(), Uri.parse(authEndpoint));


### PR DESCRIPTION
Fixes #559

## Problem

On Android, `openSecureWindow` aborts the auth flow if the user backgrounds the app while the auth page is open — for example, to switch to a password manager or copy an OTP. On returning to the app, the in-app browser closes and the call rejects with `OAuth cancelled or no callback received`. iOS is unaffected because it uses `ASWebAuthenticationSession`, which is system-managed and survives backgrounding.

## Root cause

Two pieces combine:

1. `handleOnResume()` rejects any pending `openSecureWindowSavedCall` on resume, as a heuristic for "user dismissed the Custom Tab → cancel". It can't distinguish a genuine cancel from a transient background→foreground cycle.
2. The Custom Tab was launched with `FLAG_ACTIVITY_NO_HISTORY`, which finishes the tab as soon as the user navigates away (e.g. presses Home). When the user returns, the tab is gone, the host activity resumes, and the cancel heuristic fires mid-auth.

The normal success path survives only because the redirect deep-link triggers `handleOnNewIntent()` (resolving and nulling the call) before `onResume`.

## Fix

Drop `FLAG_ACTIVITY_NO_HISTORY` from the Custom Tab intent. The tab is now restored to the foreground on return instead of being destroyed, so the host activity doesn't resume and the heuristic isn't tripped. The resolve/reject/cancel logic is otherwise untouched:

- **Background to copy OTP, then return** → tab restored, auth continues ✅
- **Genuine cancel (back/close in the tab)** → tab finishes, host resumes, cancel still detected ✅
- **Successful auth** → redirect resolves via `handleOnNewIntent()`, unchanged ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)