### PR TITLE
[codex] fix Capgo InAppBrowser plugin id

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
@@ -61,7 +61,7 @@ import org.json.JSONObject;
     },
     requestCodes = { WebViewDialog.FILE_CHOOSER_REQUEST_CODE }
 )
-public class InAppBrowserPlugin extends Plugin implements WebViewDialog.PermissionHandler {
+public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.PermissionHandler {
 
     private final String pluginVersion = "8.6.17";
 
@@ -301,11 +301,11 @@ public class InAppBrowserPlugin extends Plugin implements WebViewDialog.Permissi
             getContext(),
             android.R.style.Theme_NoTitleBar,
             options,
-            InAppBrowserPlugin.this,
+            CapgoInAppBrowserPlugin.this,
             getBridge().getWebView()
         );
         dialog.setInstanceId(webViewId);
-        dialog.activity = InAppBrowserPlugin.this.getActivity();
+        dialog.activity = CapgoInAppBrowserPlugin.this.getActivity();
         registerWebView(webViewId, dialog, makeActive);
         return dialog;
     }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -53,7 +53,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 @CapacitorPlugin(
-    name = "InAppBrowser",
+    name = "CapgoInAppBrowser",
     permissions = {
         @Permission(alias = "camera", strings = { Manifest.permission.CAMERA }),
         @Permission(alias = "microphone", strings = { Manifest.permission.RECORD_AUDIO }),

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -1,0 +1,17 @@
+package ee.forgr.capacitor_inappbrowser;
+
+import android.Manifest;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import com.getcapacitor.annotation.Permission;
+
+@Deprecated
+@CapacitorPlugin(
+    name = "CapgoInAppBrowser",
+    permissions = {
+        @Permission(alias = "camera", strings = { Manifest.permission.CAMERA }),
+        @Permission(alias = "microphone", strings = { Manifest.permission.RECORD_AUDIO }),
+        @Permission(alias = "storage", strings = { Manifest.permission.READ_EXTERNAL_STORAGE })
+    },
+    requestCodes = { WebViewDialog.FILE_CHOOSER_REQUEST_CODE }
+)
+public class InAppBrowserPlugin extends CapgoInAppBrowserPlugin {}

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -71,15 +71,15 @@ extension UIColor {
  * Please read the Capacitor iOS Plugin Development Guide
  * here: https://capacitorjs.com/docs/plugins/ios
  */
-@objc(InAppBrowserPlugin)
-public class InAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
+@objc(CapgoInAppBrowserPlugin)
+public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
     enum InvisibilityMode: String {
         case aware = "AWARE"
         case fakeVisible = "FAKE_VISIBLE"
     }
     private let pluginVersion: String = "8.6.17"
-    public let identifier = "InAppBrowserPlugin"
-    public let jsName = "InAppBrowser"
+    public let identifier = "CapgoInAppBrowserPlugin"
+    public let jsName = "CapgoInAppBrowser"
     public let pluginMethods: [CAPPluginMethod] = [
         CAPPluginMethod(name: "goBack", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "open", returnType: CAPPluginReturnPromise),
@@ -325,7 +325,7 @@ public class InAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         try rawRules.enumerated().map { index, item in
             guard let dictionary = item as? [String: Any] else {
                 throw NSError(
-                    domain: "InAppBrowserPlugin",
+                    domain: "CapgoInAppBrowserPlugin",
                     code: -1,
                     userInfo: [NSLocalizedDescriptionKey: "Proxy rule at index \(index) must be an object"]
                 )
@@ -1931,7 +1931,7 @@ public class InAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 }
 
-extension InAppBrowserPlugin: ASWebAuthenticationPresentationContextProviding {
+extension CapgoInAppBrowserPlugin: ASWebAuthenticationPresentationContextProviding {
     public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         return self.bridge?.viewController?.view.window ?? ASPresentationAnchor()
     }

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -1931,6 +1931,9 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 }
 
+@available(*, deprecated, renamed: "CapgoInAppBrowserPlugin")
+public typealias InAppBrowserPlugin = CapgoInAppBrowserPlugin
+
 extension CapgoInAppBrowserPlugin: ASWebAuthenticationPresentationContextProviding {
     public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         return self.bridge?.viewController?.view.window ?? ASPresentationAnchor()

--- a/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
+++ b/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
@@ -449,7 +449,7 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
     /// still reach finish() or the scheme task strands.
     static let redirectStatusCodes: Set<Int> = [301, 302, 303, 307, 308]
 
-    weak var plugin: InAppBrowserPlugin?
+    weak var plugin: CapgoInAppBrowserPlugin?
     private var pendingTasks: [String: PendingProxyTask] = [:]
     private var stoppedRequests: [String: UUID] = [:]
     private var timedOutRequests: [String: String] = [:]
@@ -464,7 +464,7 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
     private lazy var session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
 
     init(
-        plugin: InAppBrowserPlugin,
+        plugin: CapgoInAppBrowserPlugin,
         webviewId: String,
         legacyProxyRequests: Bool,
         legacyProxyRequestURLRegex: NSRegularExpression?,

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -348,7 +348,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
     open var headers: [String: String]?
     open var httpMethod: String?
     open var httpBody: String?
-    open var capBrowserPlugin: InAppBrowserPlugin?
+    open var capBrowserPlugin: CapgoInAppBrowserPlugin?
     var instanceId: String = ""
     var shareDisclaimer: [String: Any]?
     var shareSubject: String?

--- a/scripts/check-capacitor-plugin-wiring.mjs
+++ b/scripts/check-capacitor-plugin-wiring.mjs
@@ -86,6 +86,12 @@ function uniq(arr) {
   return out;
 }
 
+function parseStringConstant(txt, name) {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`\\bconst\\s+${escapedName}\\s*=\\s*['"]([^'"]+)['"]`);
+  return re.exec(txt)?.[1] || "";
+}
+
 function parseArgs(argv) {
   const out = { dir: process.cwd() };
   for (let i = 2; i < argv.length; i++) {
@@ -132,10 +138,15 @@ if (exists(jsSrcDir)) {
   const jsFiles = walkFiles(jsSrcDir, [".ts", ".js"]);
   const reRegister = /registerPlugin(?:<[^>]*>)?\(\s*['"]([^'"]+)['"]/;
   for (const f of jsFiles) {
-    const m = reRegister.exec(readText(f));
+    const txt = readText(f);
+    const m = reRegister.exec(txt);
     if (m) {
       jsName = m[1];
       break;
+    }
+    if (txt.includes("registerPlugin") && txt.includes("CAPGO_PLUGIN_NAME")) {
+      jsName = parseStringConstant(txt, "CAPGO_PLUGIN_NAME");
+      if (jsName) break;
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { Capacitor, registerPlugin } from '@capacitor/core';
 import type { PluginListenerHandle } from '@capacitor/core';
-import type { CapacitorInstance, PluginHeader } from '@capacitor/core/types/definitions-internal';
 
 import type {
   InAppBrowserPlugin,
@@ -11,14 +10,7 @@ import type {
 } from './definitions';
 
 const CAPGO_PLUGIN_NAME = 'CapgoInAppBrowser';
-const LEGACY_PLUGIN_NAME = 'InAppBrowser';
-const LEGACY_CAPGO_METHOD = 'openWebView';
-
-function hasNativePluginMethod(pluginName: string, methodName: string): boolean {
-  const headers: readonly PluginHeader[] = (Capacitor as CapacitorInstance).PluginHeaders ?? [];
-  const header = headers.find((pluginHeader) => pluginHeader.name === pluginName);
-  return header?.methods.some((method) => method.name === methodName) ?? false;
-}
+const PREVIOUS_PLUGIN_NAME = 'InAppBrowser';
 
 function resolvePluginName(): string {
   if (!Capacitor.isNativePlatform()) {
@@ -29,12 +21,12 @@ function resolvePluginName(): string {
     return CAPGO_PLUGIN_NAME;
   }
 
-  if (hasNativePluginMethod(LEGACY_PLUGIN_NAME, LEGACY_CAPGO_METHOD)) {
-    return LEGACY_PLUGIN_NAME;
+  if (Capacitor.isPluginAvailable(PREVIOUS_PLUGIN_NAME)) {
+    return PREVIOUS_PLUGIN_NAME;
   }
 
   console.warn(
-    `[InAppBrowser] Neither '${CAPGO_PLUGIN_NAME}' nor legacy '${LEGACY_PLUGIN_NAME}' native plugin detected. ` +
+    `[InAppBrowser] Neither '${CAPGO_PLUGIN_NAME}' nor '${PREVIOUS_PLUGIN_NAME}' native plugin detected. ` +
       'Ensure @capgo/capacitor-inappbrowser native code is installed.',
   );
   return CAPGO_PLUGIN_NAME;

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,10 +50,7 @@ const inAppBrowserImplementations = {
   web: () => import('./web').then((m) => new m.InAppBrowserWeb()),
 };
 
-const InAppBrowser =
-  resolvePluginName() === CAPGO_PLUGIN_NAME
-    ? registerPlugin<InAppBrowserPlugin>('CapgoInAppBrowser', inAppBrowserImplementations)
-    : registerPlugin<InAppBrowserPlugin>('InAppBrowser', inAppBrowserImplementations);
+const InAppBrowser = registerPlugin<InAppBrowserPlugin>(resolvePluginName(), inAppBrowserImplementations);
 
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Capacitor, registerPlugin } from '@capacitor/core';
 import type { PluginListenerHandle } from '@capacitor/core';
+import type { CapacitorInstance, PluginHeader } from '@capacitor/core/types/definitions-internal';
 
 import type {
   InAppBrowserPlugin,
@@ -9,23 +10,12 @@ import type {
   ProxyResponse,
 } from './definitions';
 
-type CapacitorPluginHeader = {
-  readonly name: string;
-  readonly methods: readonly {
-    readonly name: string;
-  }[];
-};
-
-type CapacitorWithPluginHeaders = typeof Capacitor & {
-  readonly PluginHeaders?: readonly CapacitorPluginHeader[];
-};
-
 const CAPGO_PLUGIN_NAME = 'CapgoInAppBrowser';
 const LEGACY_PLUGIN_NAME = 'InAppBrowser';
 const LEGACY_CAPGO_METHOD = 'openWebView';
 
 function hasNativePluginMethod(pluginName: string, methodName: string): boolean {
-  const headers = (Capacitor as CapacitorWithPluginHeaders).PluginHeaders ?? [];
+  const headers: readonly PluginHeader[] = (Capacitor as CapacitorInstance).PluginHeaders ?? [];
   const header = headers.find((pluginHeader) => pluginHeader.name === pluginName);
   return header?.methods.some((method) => method.name === methodName) ?? false;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { registerPlugin } from '@capacitor/core';
+import { Capacitor, registerPlugin } from '@capacitor/core';
 import type { PluginListenerHandle } from '@capacitor/core';
 
 import type {
@@ -9,9 +9,51 @@ import type {
   ProxyResponse,
 } from './definitions';
 
-const InAppBrowser = registerPlugin<InAppBrowserPlugin>('InAppBrowser', {
+type CapacitorPluginHeader = {
+  readonly name: string;
+  readonly methods: readonly {
+    readonly name: string;
+  }[];
+};
+
+type CapacitorWithPluginHeaders = typeof Capacitor & {
+  readonly PluginHeaders?: readonly CapacitorPluginHeader[];
+};
+
+const CAPGO_PLUGIN_NAME = 'CapgoInAppBrowser';
+const LEGACY_PLUGIN_NAME = 'InAppBrowser';
+const LEGACY_CAPGO_METHOD = 'openWebView';
+
+function hasNativePluginMethod(pluginName: string, methodName: string): boolean {
+  const headers = (Capacitor as CapacitorWithPluginHeaders).PluginHeaders ?? [];
+  const header = headers.find((pluginHeader) => pluginHeader.name === pluginName);
+  return header?.methods.some((method) => method.name === methodName) ?? false;
+}
+
+function resolvePluginName(): string {
+  if (!Capacitor.isNativePlatform()) {
+    return CAPGO_PLUGIN_NAME;
+  }
+
+  if (Capacitor.isPluginAvailable(CAPGO_PLUGIN_NAME)) {
+    return CAPGO_PLUGIN_NAME;
+  }
+
+  if (hasNativePluginMethod(LEGACY_PLUGIN_NAME, LEGACY_CAPGO_METHOD)) {
+    return LEGACY_PLUGIN_NAME;
+  }
+
+  return CAPGO_PLUGIN_NAME;
+}
+
+const inAppBrowserImplementations = {
   web: () => import('./web').then((m) => new m.InAppBrowserWeb()),
-});
+};
+
+const InAppBrowser =
+  resolvePluginName() === CAPGO_PLUGIN_NAME
+    ? registerPlugin<InAppBrowserPlugin>('CapgoInAppBrowser', inAppBrowserImplementations)
+    : registerPlugin<InAppBrowserPlugin>('InAppBrowser', inAppBrowserImplementations);
 
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer);

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,10 @@ function resolvePluginName(): string {
     return LEGACY_PLUGIN_NAME;
   }
 
+  console.warn(
+    `[InAppBrowser] Neither '${CAPGO_PLUGIN_NAME}' nor legacy '${LEGACY_PLUGIN_NAME}' native plugin detected. ` +
+      'Ensure @capgo/capacitor-inappbrowser native code is installed.',
+  );
   return CAPGO_PLUGIN_NAME;
 }
 


### PR DESCRIPTION
## What
- Rename the internal Capacitor bridge/plugin id from `InAppBrowser` to `CapgoInAppBrowser` on JS, Android, and iOS.
- Keep the exported user-facing `InAppBrowser` import unchanged.
- Add a JS fallback that binds to the legacy `InAppBrowser` native plugin only when the native headers still expose Capgo's `openWebView` method.

## Why
- `@capgo/capacitor-inappbrowser` and `@capacitor/inappbrowser` currently both register the `InAppBrowser` plugin id, causing duplicate registration/conflicting identity errors when both are installed.

## How
- Updated `registerPlugin` to prefer `CapgoInAppBrowser` and detect old native builds through Capacitor plugin headers.
- Updated Android `@CapacitorPlugin(name = ...)` to `CapgoInAppBrowser`.
- Updated iOS `CAPBridgedPlugin` identity and references to `CapgoInAppBrowserPlugin` / `CapgoInAppBrowser`.

## Testing
- `bun run verify`
- `bun run lint`
- `bun run check:wiring`

## Not Tested
- Runtime coexistence in a sample app with both `@capgo/capacitor-inappbrowser` and `@capacitor/inappbrowser` installed.

Generated by Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Plugin rebranded to a new canonical name across platforms.
  * Runtime selection now prefers the new name while falling back to the legacy name when needed.
  * Deprecated alias retained for backward compatibility.

* **Chores**
  * Improved tooling to detect plugin names in source files for more reliable native/web wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->