### PR TITLE
[codex] fix iOS custom webview frame layout

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -1845,6 +1845,11 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         let xPos = call.getFloat("x")
         let yPos = call.getFloat("y")
 
+        if width != nil && height == nil {
+            call.reject("Height must be specified when width is provided")
+            return
+        }
+
         DispatchQueue.main.async {
             let targetId = call.getString("id") ?? self.activeWebViewId
             guard let webViewController = self.resolveWebViewController(for: targetId) else {

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -51,6 +51,27 @@ enum ProxyResponseRoutingSupport {
     }
 }
 
+enum CustomWebViewFrameSupport {
+    static func resolvedFrame(
+        width: CGFloat?,
+        height: CGFloat?,
+        x: CGFloat?,
+        y: CGFloat?,
+        fallbackSize: CGSize
+    ) -> CGRect? {
+        guard let height else {
+            return nil
+        }
+
+        return CGRect(
+            x: x ?? 0,
+            y: y ?? 0,
+            width: width ?? fallbackSize.width,
+            height: height
+        )
+    }
+}
+
 extension UIColor {
 
     convenience init(hexString: String) {
@@ -1153,29 +1174,29 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
                 // Create a pass-through container
                 let containerView = PassThroughView()
                 containerView.backgroundColor = .clear
+                containerView.frame = UIScreen.main.bounds
+                containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
-                // Calculate dimensions - use screen width if only height is provided
-                let finalWidth = width.map { CGFloat($0) } ?? UIScreen.main.bounds.width
-                let finalHeight = height.map { CGFloat($0) } ?? UIScreen.main.bounds.height
-
-                containerView.targetFrame = CGRect(
-                    x: CGFloat(xPos ?? 0),
-                    y: CGFloat(yPos ?? 0),
-                    width: finalWidth,
-                    height: finalHeight
+                let targetFrame = CustomWebViewFrameSupport.resolvedFrame(
+                    width: width.map { CGFloat($0) },
+                    height: height.map { CGFloat($0) },
+                    x: xPos.map { CGFloat($0) },
+                    y: yPos.map { CGFloat($0) },
+                    fallbackSize: UIScreen.main.bounds.size
                 )
+                containerView.targetFrame = targetFrame
 
                 // Replace the navigation controller's view with our pass-through container
                 if let navController = self.navigationWebViewController,
                    let originalView = navController.view {
                     navController.view = containerView
                     containerView.addSubview(originalView)
-                    originalView.frame = CGRect(
-                        x: CGFloat(xPos ?? 0),
-                        y: CGFloat(yPos ?? 0),
-                        width: finalWidth,
-                        height: finalHeight
-                    )
+                    containerView.framedContentView = originalView
+                    originalView.translatesAutoresizingMaskIntoConstraints = true
+                    originalView.autoresizingMask = []
+                    if let targetFrame {
+                        originalView.frame = targetFrame
+                    }
                 }
             } else {
                 self.navigationWebViewController?.modalPresentationStyle = .overCurrentContext

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -2881,26 +2881,32 @@ extension WKWebViewController: WKNavigationDelegate {
 
     /// Apply custom dimensions to the view if specified
     open func applyCustomDimensions() {
-        guard let navigationController = navigationController else { return }
-
-        // Apply custom dimensions if both width and height are specified
-        if let width = customWidth, let height = customHeight {
-            let xPos = customX ?? 0
-            let yPos = customY ?? 0
-
-            // Set the frame for the navigation controller's view
-            navigationController.view.frame = CGRect(x: xPos, y: yPos, width: width, height: height)
+        guard let navigationController = navigationController,
+              let targetFrame = CustomWebViewFrameSupport.resolvedFrame(
+                width: customWidth,
+                height: customHeight,
+                x: customX,
+                y: customY,
+                fallbackSize: UIScreen.main.bounds.size
+              ) else {
+            return
         }
-        // If only height is specified, use fullscreen width
-        else if let height = customHeight, customWidth == nil {
-            let xPos = customX ?? 0
-            let yPos = customY ?? 0
-            let screenWidth = UIScreen.main.bounds.width
 
-            // Set the frame with fullscreen width and custom height
-            navigationController.view.frame = CGRect(x: xPos, y: yPos, width: screenWidth, height: height)
+        if let passThroughView = navigationController.view as? PassThroughView {
+            passThroughView.targetFrame = targetFrame
+            let contentView = passThroughView.framedContentView ?? passThroughView.subviews.first
+            contentView?.frame = targetFrame
+            contentView?.setNeedsLayout()
+            contentView?.layoutIfNeeded()
+            passThroughView.setNeedsLayout()
+            passThroughView.layoutIfNeeded()
+        } else {
+            navigationController.view.frame = targetFrame
+            navigationController.view.setNeedsLayout()
+            navigationController.view.layoutIfNeeded()
         }
-        // Otherwise, use default fullscreen behavior (no action needed)
+
+        refreshWebViewViewportIfNeeded(force: true)
     }
 
     /// Update dimensions at runtime
@@ -3035,7 +3041,22 @@ class BlockBarButtonItem: UIBarButtonItem {
 
 /// Custom view that passes touches outside a target frame to the underlying view
 class PassThroughView: UIView {
-    var targetFrame: CGRect?
+    var targetFrame: CGRect? {
+        didSet {
+            setNeedsLayout()
+        }
+    }
+    weak var framedContentView: UIView?
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        guard let targetFrame, let framedContentView else {
+            return
+        }
+
+        framedContentView.frame = targetFrame
+    }
 
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         // If we have a target frame and the touch is outside it, pass through

--- a/ios/Tests/InAppBrowserPluginTests/InAppBrowserPluginTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/InAppBrowserPluginTests.swift
@@ -1,7 +1,76 @@
+import UIKit
 import XCTest
 @testable import InappbrowserPlugin
 
 final class InAppBrowserPluginTests: XCTestCase {
+    func testCustomWebViewFrameUsesExplicitDimensions() {
+        XCTAssertEqual(
+            CustomWebViewFrameSupport.resolvedFrame(
+                width: 320,
+                height: 480,
+                x: 12,
+                y: 24,
+                fallbackSize: CGSize(width: 390, height: 844)
+            ),
+            CGRect(x: 12, y: 24, width: 320, height: 480)
+        )
+    }
+
+    func testCustomWebViewFrameUsesFallbackWidthForHeightOnly() {
+        XCTAssertEqual(
+            CustomWebViewFrameSupport.resolvedFrame(
+                width: nil,
+                height: 480,
+                x: nil,
+                y: 32,
+                fallbackSize: CGSize(width: 390, height: 844)
+            ),
+            CGRect(x: 0, y: 32, width: 390, height: 480)
+        )
+    }
+
+    func testCustomWebViewFrameIgnoresMissingDimensions() {
+        XCTAssertNil(
+            CustomWebViewFrameSupport.resolvedFrame(
+                width: nil,
+                height: nil,
+                x: 12,
+                y: 24,
+                fallbackSize: CGSize(width: 390, height: 844)
+            )
+        )
+    }
+
+    func testCustomWebViewFrameIgnoresWidthWithoutHeight() {
+        XCTAssertNil(
+            CustomWebViewFrameSupport.resolvedFrame(
+                width: 320,
+                height: nil,
+                x: 12,
+                y: 24,
+                fallbackSize: CGSize(width: 390, height: 844)
+            )
+        )
+    }
+
+    func testPassThroughViewKeepsContentOnTargetFrameAfterLayout() {
+        let targetFrame = CGRect(x: 12, y: 24, width: 320, height: 480)
+        let container = PassThroughView(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        let contentView = UIView(frame: .zero)
+
+        container.addSubview(contentView)
+        container.framedContentView = contentView
+        container.targetFrame = targetFrame
+        container.layoutIfNeeded()
+
+        XCTAssertEqual(contentView.frame, targetFrame)
+
+        container.frame = CGRect(x: 0, y: 0, width: 430, height: 932)
+        container.layoutIfNeeded()
+
+        XCTAssertEqual(contentView.frame, targetFrame)
+    }
+
     func testViewportRefreshIgnoresZeroSizeBeforeLayout() {
         XCTAssertFalse(
             WebViewViewportLayoutSupport.shouldRefreshViewport(


### PR DESCRIPTION
## What
- Fix iOS `openWebView` custom frame layout so the visible frame, WebKit viewport, and touch target use the same dimensions.
- Add focused iOS tests for custom frame resolution and pass-through content layout.

## Why
- Fixes #568, where custom `x`, `y`, `width`, and `height` rendered in the expected area but `window.innerWidth`/`innerHeight` were doubled and touches were clipped.

## How
- Keep the pass-through modal container full-screen.
- Apply the custom frame only to the embedded navigation content view.
- Update runtime dimension changes to adjust the pass-through content frame instead of resizing the modal root view.
- Prepared by Codex.

## Testing
- `bun run fmt`
- `bun run verify`
- `xcodebuild test -scheme CapgoCapacitorInappbrowser -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`

## Not Tested
- Manual reproduction in an Ionic Vue app was not run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of custom webview dimensions and positioning with better support for partially specified width/height/x/y values.
  * Fixed webview layout behavior to properly apply and maintain configured dimensions across layout updates.

* **Tests**
  * Added comprehensive unit tests for frame resolution logic and layout synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->