### PR TITLE
fix: Android managed downloads fail — WebView.getUrl() called on background thread

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -1416,6 +1416,8 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
     }
 
     private void downloadUrlToFile(String url, String userAgent, String contentDisposition, String mimeType) {
+        // WebView methods must run on the main thread; capture the page URL before the background download starts.
+        final String pageUrl = currentManagedDownloadPageUrl();
         executorService.execute(() -> {
             HttpURLConnection connection = null;
             InputStream inputStream = null;
@@ -1423,7 +1425,6 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             boolean downloadSucceeded = false;
 
             try {
-                String pageUrl = currentManagedDownloadPageUrl();
                 String currentUrl = url;
                 int redirectsFollowed = 0;
                 while (true) {


### PR DESCRIPTION
## What

Fix a bug that makes every managed (non-blob) download fail on Android when `handleDownloads: true` is enabled: `downloadUrlToFile` calls `WebView.getUrl()` (via `currentManagedDownloadPageUrl()`) from the background download executor, which Android forbids — WebView methods must run on the thread the WebView was created on. The download thread throws immediately and the user only sees the "Failed to download file" toast.

## Bug

Stack trace (plugin 8.6.21, reproduced on a physical device):

```
E InAppBrowser: Failed to download file
E InAppBrowser: java.lang.RuntimeException: java.lang.Throwable: A WebView method was called on thread 'pool-28-thread-1'.
                All WebView methods must be called on the same thread. (Expected Looper Looper (main, tid 2) ...)
E InAppBrowser:   at android.webkit.WebView.checkThread(WebView.java:2738)
E InAppBrowser:   at android.webkit.WebView.getUrl(WebView.java:1344)
E InAppBrowser:   at ee.forgr.capacitor_inappbrowser.WebViewDialog.currentManagedDownloadPageUrl(WebViewDialog.java:1339)
E InAppBrowser:   at ee.forgr.capacitor_inappbrowser.WebViewDialog.lambda$downloadUrlToFile$4(WebViewDialog.java:1426)
```

The `DownloadListener` fires correctly (`Handling WebView download: ... mimeType=application/pdf`), but the first statement inside `executorService.execute(...)` is `currentManagedDownloadPageUrl()`, which reads `_webView.getUrl()` off the main thread and throws before the HTTP request is even opened.

## Reproduction

Open https://pdf-download.onrender.com in the webview on Android:

```ts
await InAppBrowser.openWebView({
  url: 'https://pdf-download.onrender.com',
  handleDownloads: true,
  openBlankTargetInWebView: true,
});
```

Log in (credentials are prefilled) and tap **Download PDF**. Expected: the PDF downloads and opens. Actual: "Failed to download file" toast, `downloadFailed` event, stack trace above in logcat.

## How

Hoist the `currentManagedDownloadPageUrl()` call out of the executor lambda into `downloadUrlToFile` itself. The method's only call chain is `DownloadListener.onDownloadStart` → `handleDownloadRequest` → `downloadUrlToFile`, which runs on the main thread, so reading `WebView.getUrl()` there is safe; the captured value is then used inside the background task as before.

## Testing

- Reproduced the failure on a physical Android device against the page above (stack trace included); every download attempt fails without this change.
- Applying this same change to 8.6.21 via patch-package in our app removes the off-main-thread `WebView.getUrl()` call from the download path.
- The example-app Maestro flows were not run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced overall download reliability by optimizing how HTTP referrer headers are properly captured and managed during file download operations. The app now ensures referrer information is correctly applied throughout the entire download process, providing improved stability and more reliable downloads when users access content from different pages or external sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
