### PR TITLE
fix(android): respect system navigation bar with enabledSafeBottomMargin

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
@@ -13,6 +13,27 @@ final class SafeAreaInsetsSupport {
         return Math.max(systemBarsBottom, Math.max(navigationBarsBottom, Math.max(systemGesturesBottom, mandatoryGesturesBottom)));
     }
 
+    static int resolveSafeBottomInsetWithFallback(
+        int systemBarsBottom,
+        int navigationBarsBottom,
+        int systemGesturesBottom,
+        int mandatoryGesturesBottom,
+        int fallbackBottomInset,
+        boolean applyFallbackWhenZero
+    ) {
+        int inset = resolveSafeBottomInset(
+            systemBarsBottom,
+            navigationBarsBottom,
+            systemGesturesBottom,
+            mandatoryGesturesBottom
+        );
+        if (inset > 0 || !applyFallbackWhenZero || fallbackBottomInset <= 0) {
+            return inset;
+        }
+
+        return fallbackBottomInset;
+    }
+
     static int resolveBottomMargin(boolean enabledSafeBottomMargin, int safeBottomInset, int imeBottom) {
         int bottomInset = enabledSafeBottomMargin ? safeBottomInset : 0;
         return Math.max(bottomInset, imeBottom);

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
@@ -21,12 +21,7 @@ final class SafeAreaInsetsSupport {
         int fallbackBottomInset,
         boolean applyFallbackWhenZero
     ) {
-        int inset = resolveSafeBottomInset(
-            systemBarsBottom,
-            navigationBarsBottom,
-            systemGesturesBottom,
-            mandatoryGesturesBottom
-        );
+        int inset = resolveSafeBottomInset(systemBarsBottom, navigationBarsBottom, systemGesturesBottom, mandatoryGesturesBottom);
         if (inset > 0 || !applyFallbackWhenZero || fallbackBottomInset <= 0) {
             return inset;
         }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
@@ -18,6 +18,10 @@ final class SafeAreaInsetsSupport {
         int navigationBarsBottom,
         int systemGesturesBottom,
         int mandatoryGesturesBottom,
+        int systemBarsLeft,
+        int systemBarsRight,
+        int navigationBarsLeft,
+        int navigationBarsRight,
         int fallbackBottomInset,
         boolean applyFallbackWhenZero
     ) {
@@ -26,7 +30,15 @@ final class SafeAreaInsetsSupport {
             return inset;
         }
 
+        if (hasSideNavigationBarInsets(systemBarsLeft, systemBarsRight, navigationBarsLeft, navigationBarsRight)) {
+            return 0;
+        }
+
         return fallbackBottomInset;
+    }
+
+    static boolean hasSideNavigationBarInsets(int systemBarsLeft, int systemBarsRight, int navigationBarsLeft, int navigationBarsRight) {
+        return systemBarsLeft > 0 || systemBarsRight > 0 || navigationBarsLeft > 0 || navigationBarsRight > 0;
     }
 
     static int resolveBottomMargin(boolean enabledSafeBottomMargin, int safeBottomInset, int imeBottom) {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -2743,6 +2743,10 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             navigationBars.bottom,
             systemGestures.bottom,
             mandatoryGestures.bottom,
+            bars.left,
+            bars.right,
+            navigationBars.left,
+            navigationBars.right,
             fallbackBottomInset,
             _options.getEnabledSafeMargin()
         );

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -2626,10 +2626,9 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             }
         }
 
-        View coordinatorView = findViewById(R.id.coordinator_layout);
-        final View insetsSourceView = coordinatorView != null ? coordinatorView : _webView;
+        // Resolve insets from the dialog window root; layout children can receive already-fitted zero insets.
+        final View insetsSourceView = resolveSafeAreaInsetsSourceView();
 
-        // Resolve insets from the dialog root; child WebViews can receive already-fitted zero insets.
         ViewCompat.setOnApplyWindowInsetsListener(insetsSourceView, (v, windowInsets) -> {
             Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
             Insets navigationBars = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars());
@@ -2738,11 +2737,14 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             return;
         }
 
-        int safeBottomInset = SafeAreaInsetsSupport.resolveSafeBottomInset(
+        int fallbackBottomInset = _options.getEnabledSafeMargin() ? getSystemNavigationBarHeight() : 0;
+        int safeBottomInset = SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(
             bars.bottom,
             navigationBars.bottom,
             systemGestures.bottom,
-            mandatoryGestures.bottom
+            mandatoryGestures.bottom,
+            fallbackBottomInset,
+            _options.getEnabledSafeMargin()
         );
         int imeBottom = keyboardVisible ? ime.bottom : 0;
         int navTop = SafeAreaInsetsSupport.resolveTopMargin(
@@ -2759,9 +2761,30 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         _webView.setLayoutParams(mlp);
     }
 
-    private void requestSafeAreaInsets() {
+    private View resolveSafeAreaInsetsSourceView() {
+        Window window = getWindow();
+        if (window != null) {
+            View decorView = window.getDecorView();
+            if (decorView != null) {
+                return decorView;
+            }
+        }
+
         View coordinatorView = findViewById(R.id.coordinator_layout);
-        View insetsSourceView = coordinatorView != null ? coordinatorView : _webView;
+        return coordinatorView != null ? coordinatorView : _webView;
+    }
+
+    private int getSystemNavigationBarHeight() {
+        int resourceId = getContext().getResources().getIdentifier("navigation_bar_height", "dimen", "android");
+        if (resourceId <= 0) {
+            return 0;
+        }
+
+        return getContext().getResources().getDimensionPixelSize(resourceId);
+    }
+
+    private void requestSafeAreaInsets() {
+        View insetsSourceView = resolveSafeAreaInsetsSourceView();
         if (insetsSourceView == null) {
             return;
         }

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupportTest.java
@@ -13,17 +13,23 @@ public class SafeAreaInsetsSupportTest {
 
     @Test
     public void safeBottomInsetUsesFallbackWhenInsetsAreZeroAndOptionEnabled() {
-        assertEquals(48, SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 0, 0, 0, 48, true));
+        assertEquals(48, SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 0, 0, 0, 0, 0, 0, 0, 48, true));
     }
 
     @Test
     public void safeBottomInsetIgnoresFallbackWhenInsetsArePresent() {
-        assertEquals(24, SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 16, 24, 8, 48, true));
+        assertEquals(24, SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 16, 24, 8, 0, 0, 0, 0, 48, true));
     }
 
     @Test
     public void safeBottomInsetIgnoresFallbackWhenOptionDisabled() {
-        assertEquals(0, SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 0, 0, 0, 48, false));
+        assertEquals(0, SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 0, 0, 0, 0, 0, 0, 0, 48, false));
+    }
+
+    @Test
+    public void safeBottomInsetSkipsFallbackWhenNavigationBarIsOnTheSide() {
+        assertEquals(0, SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 0, 0, 0, 48, 0, 0, 0, 48, true));
+        assertEquals(0, SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 0, 0, 0, 0, 48, 0, 0, 48, true));
     }
 
     @Test

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupportTest.java
@@ -12,6 +12,30 @@ public class SafeAreaInsetsSupportTest {
     }
 
     @Test
+    public void safeBottomInsetUsesFallbackWhenInsetsAreZeroAndOptionEnabled() {
+        assertEquals(
+            48,
+            SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 0, 0, 0, 48, true)
+        );
+    }
+
+    @Test
+    public void safeBottomInsetIgnoresFallbackWhenInsetsArePresent() {
+        assertEquals(
+            24,
+            SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 16, 24, 8, 48, true)
+        );
+    }
+
+    @Test
+    public void safeBottomInsetIgnoresFallbackWhenOptionDisabled() {
+        assertEquals(
+            0,
+            SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 0, 0, 0, 48, false)
+        );
+    }
+
+    @Test
     public void bottomMarginFollowsSafeBottomOptionAndKeyboardInset() {
         assertEquals(16, SafeAreaInsetsSupport.resolveBottomMargin(true, 16, 0));
         assertEquals(0, SafeAreaInsetsSupport.resolveBottomMargin(false, 16, 0));

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupportTest.java
@@ -13,26 +13,17 @@ public class SafeAreaInsetsSupportTest {
 
     @Test
     public void safeBottomInsetUsesFallbackWhenInsetsAreZeroAndOptionEnabled() {
-        assertEquals(
-            48,
-            SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 0, 0, 0, 48, true)
-        );
+        assertEquals(48, SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 0, 0, 0, 48, true));
     }
 
     @Test
     public void safeBottomInsetIgnoresFallbackWhenInsetsArePresent() {
-        assertEquals(
-            24,
-            SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 16, 24, 8, 48, true)
-        );
+        assertEquals(24, SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 16, 24, 8, 48, true));
     }
 
     @Test
     public void safeBottomInsetIgnoresFallbackWhenOptionDisabled() {
-        assertEquals(
-            0,
-            SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 0, 0, 0, 48, false)
-        );
+        assertEquals(0, SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 0, 0, 0, 48, false));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Read safe-area insets from the dialog window decor view instead of the coordinator layout, which could report zero bottom insets on Android 16.
- When `enabledSafeBottomMargin: true` and window insets are still zero, fall back to the system `navigation_bar_height` so the WebView bottom margin clears the Android navigation bar.
- Add unit coverage for the fallback inset calculation.

## Why
- Fixes #576 where `enabledSafeBottomMargin: true` had no visible effect and web content was drawn behind the Android system navigation bar.

## Test plan
- [x] `./gradlew test` in `android/`
- [ ] Open `https://pdf-download.onrender.com/` with `openWebView({ enabledSafeBottomMargin: true, activeNativeNavigationForWebview: true, useTopInset: true })` on Android 16 with 3-button navigation
- [ ] Confirm the page bottom UI sits above the system navigation bar
- [ ] Confirm keyboard inset behavior still lifts the WebView when the IME is visible


Made with [Cursor](https://cursor.com)