### PR TITLE
[codex] fix Android openWebView x/y positioning

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -33,6 +33,7 @@ import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Log;
 import android.util.TypedValue;
+import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -5990,12 +5991,14 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             params.height = (int) getPixels(height);
             params.x = (x != null) ? (int) getPixels(x) : 0;
             params.y = (y != null) ? (int) getPixels(y) : 0;
+            params.gravity = Gravity.TOP | Gravity.START;
         } else if (height != null && width == null) {
             // If only height is specified, use custom height with fullscreen width
             params.width = WindowManager.LayoutParams.MATCH_PARENT;
             params.height = (int) getPixels(height);
             params.x = 0;
             params.y = (y != null) ? (int) getPixels(y) : 0;
+            params.gravity = Gravity.TOP | Gravity.START;
         } else {
             // Default to fullscreen
             params.width = WindowManager.LayoutParams.MATCH_PARENT;


### PR DESCRIPTION
## Summary
- Fix Android `openWebView` custom `x`/`y` positioning so coordinates are measured from the top-left screen edge, matching the documented API.
- Set dialog window gravity to `TOP | START` whenever custom width/height positioning is applied, since `LayoutParams.x`/`y` are offsets from the gravity anchor (default center).

Fixes #575

## Root cause
Android dialog windows default to center gravity. With center gravity, `x: 0, y: 0` places the window at the screen center rather than the top-left corner.

## Test plan
- [x] `bun run verify`
- [ ] Manual: open a custom-sized WebView with `x: 0, y: 0` and confirm it appears in the top-left corner
- [ ] Manual: open with `x: 100, y: 200` and confirm the window top-left is 100px from the left edge and 200px from the top edge


Made with [Cursor](https://cursor.com)