### PR TITLE
fix(android): correct blank toolbar safe area sizing

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
@@ -47,10 +47,25 @@ final class SafeAreaInsetsSupport {
     }
 
     static int resolveTopMargin(boolean enabledSafeTopMargin, boolean useTopInset, int systemBarsTop, boolean appBarHandlesTopInset) {
+        return resolveTopMarginWithFallback(enabledSafeTopMargin, useTopInset, systemBarsTop, appBarHandlesTopInset, 0, false);
+    }
+
+    static int resolveTopMarginWithFallback(
+        boolean enabledSafeTopMargin,
+        boolean useTopInset,
+        int systemBarsTop,
+        boolean appBarHandlesTopInset,
+        int fallbackTopInset,
+        boolean applyFallbackWhenZero
+    ) {
         if (!enabledSafeTopMargin || !useTopInset || appBarHandlesTopInset) {
             return 0;
         }
 
-        return systemBarsTop;
+        if (systemBarsTop > 0 || !applyFallbackWhenZero || fallbackTopInset <= 0) {
+            return systemBarsTop;
+        }
+
+        return fallbackTopInset;
     }
 }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -61,6 +61,7 @@ import android.widget.Toast;
 import android.widget.Toolbar;
 import androidx.activity.result.ActivityResult;
 import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.content.FileProvider;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
@@ -2575,8 +2576,13 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             }
         }
 
+        boolean isBlankToolbar = _options != null && TextUtils.equals(_options.getToolbarType(), "blank");
+        if (isBlankToolbar) {
+            configureBlankToolbarLayout();
+        }
+
         // Special handling for Android 15+
-        if (isAndroid15Plus) {
+        if (isAndroid15Plus && !isBlankToolbar) {
             // Get AppBarLayout which contains the toolbar
             if (toolbarView != null && toolbarView.getParent() instanceof com.google.android.material.appbar.AppBarLayout appBarLayout) {
                 // Remove elevation to eliminate shadows (only on Android 15+)
@@ -2751,18 +2757,76 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             _options.getEnabledSafeMargin()
         );
         int imeBottom = keyboardVisible ? ime.bottom : 0;
-        int navTop = SafeAreaInsetsSupport.resolveTopMargin(
+        boolean applyTopFallback = _options.getEnabledSafeTopMargin() && _options.getUseTopInset();
+        int fallbackTopInset = applyTopFallback ? getSystemStatusBarHeight() : 0;
+        int navTop = SafeAreaInsetsSupport.resolveTopMarginWithFallback(
             _options.getEnabledSafeTopMargin(),
             _options.getUseTopInset(),
             bars.top,
-            appBarHandlesTopInset
+            appBarHandlesTopInset,
+            fallbackTopInset,
+            applyTopFallback
         );
+        int bottomMargin = SafeAreaInsetsSupport.resolveBottomMargin(_options.getEnabledSafeMargin(), safeBottomInset, imeBottom);
 
         mlp.topMargin = navTop;
-        mlp.bottomMargin = SafeAreaInsetsSupport.resolveBottomMargin(_options.getEnabledSafeMargin(), safeBottomInset, imeBottom);
+        mlp.bottomMargin = bottomMargin;
         mlp.leftMargin = bars.left;
         mlp.rightMargin = bars.right;
         _webView.setLayoutParams(mlp);
+        injectSafeAreaCssVariables(navTop, bottomMargin, bars.left, bars.right);
+    }
+
+    private void configureBlankToolbarLayout() {
+        View appBarLayout = findViewById(R.id.app_bar_layout);
+        if (appBarLayout != null) {
+            appBarLayout.setVisibility(View.GONE);
+        }
+
+        View statusBarColorView = findViewById(R.id.status_bar_color_view);
+        if (statusBarColorView != null) {
+            statusBarColorView.setVisibility(View.GONE);
+        }
+
+        View contentBrowserLayout = findViewById(R.id.content_browser_layout);
+        if (contentBrowserLayout != null && contentBrowserLayout.getLayoutParams() instanceof CoordinatorLayout.LayoutParams) {
+            CoordinatorLayout.LayoutParams layoutParams = (CoordinatorLayout.LayoutParams) contentBrowserLayout.getLayoutParams();
+            layoutParams.setBehavior(null);
+            contentBrowserLayout.setLayoutParams(layoutParams);
+        }
+    }
+
+    private int getSystemStatusBarHeight() {
+        int resourceId = getContext().getResources().getIdentifier("status_bar_height", "dimen", "android");
+        if (resourceId <= 0) {
+            return 0;
+        }
+
+        return getContext().getResources().getDimensionPixelSize(resourceId);
+    }
+
+    private void injectSafeAreaCssVariables(int top, int bottom, int left, int right) {
+        if (_webView == null) {
+            return;
+        }
+
+        String script = String.format(
+            Locale.US,
+            "(function(){var root=document.documentElement;" +
+            "root.style.setProperty('--safe-area-inset-top','%dpx');" +
+            "root.style.setProperty('--safe-area-inset-bottom','%dpx');" +
+            "root.style.setProperty('--safe-area-inset-left','%dpx');" +
+            "root.style.setProperty('--safe-area-inset-right','%dpx');})();",
+            top,
+            bottom,
+            left,
+            right
+        );
+        _webView.post(() -> {
+            if (_webView != null) {
+                _webView.evaluateJavascript(script, null);
+            }
+        });
     }
 
     private View resolveSafeAreaInsetsSourceView() {
@@ -3594,6 +3658,8 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             // Status bar color is already set at the top of this method, no need to set again
         } else if (TextUtils.equals(_options.getToolbarType(), "blank")) {
             _toolbar.setVisibility(View.GONE);
+            configureBlankToolbarLayout();
+            requestSafeAreaInsets();
 
             // Also set window background color to match status bar for blank toolbar
             View statusBarColorView = findViewById(R.id.status_bar_color_view);

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -2813,10 +2813,10 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         String script = String.format(
             Locale.US,
             "(function(){var root=document.documentElement;" +
-            "root.style.setProperty('--safe-area-inset-top','%dpx');" +
-            "root.style.setProperty('--safe-area-inset-bottom','%dpx');" +
-            "root.style.setProperty('--safe-area-inset-left','%dpx');" +
-            "root.style.setProperty('--safe-area-inset-right','%dpx');})();",
+                "root.style.setProperty('--safe-area-inset-top','%dpx');" +
+                "root.style.setProperty('--safe-area-inset-bottom','%dpx');" +
+                "root.style.setProperty('--safe-area-inset-left','%dpx');" +
+                "root.style.setProperty('--safe-area-inset-right','%dpx');})();",
             top,
             bottom,
             left,

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupportTest.java
@@ -47,4 +47,21 @@ public class SafeAreaInsetsSupportTest {
         assertEquals(0, SafeAreaInsetsSupport.resolveTopMargin(true, false, 48, false));
         assertEquals(0, SafeAreaInsetsSupport.resolveTopMargin(true, true, 48, true));
     }
+
+    @Test
+    public void topMarginUsesFallbackWhenInsetsAreZeroAndOptionEnabled() {
+        assertEquals(48, SafeAreaInsetsSupport.resolveTopMarginWithFallback(true, true, 0, false, 48, true));
+    }
+
+    @Test
+    public void topMarginIgnoresFallbackWhenInsetsArePresent() {
+        assertEquals(32, SafeAreaInsetsSupport.resolveTopMarginWithFallback(true, true, 32, false, 48, true));
+    }
+
+    @Test
+    public void topMarginIgnoresFallbackWhenOptionDisabled() {
+        assertEquals(0, SafeAreaInsetsSupport.resolveTopMarginWithFallback(true, true, 0, false, 48, false));
+        assertEquals(0, SafeAreaInsetsSupport.resolveTopMarginWithFallback(false, true, 0, false, 48, true));
+        assertEquals(0, SafeAreaInsetsSupport.resolveTopMarginWithFallback(true, false, 0, false, 48, true));
+    }
 }


### PR DESCRIPTION
## Summary
- Fix `openWebView` with `toolbarType: BLANK` on Android so safe-area options actually control layout instead of fighting hidden AppBar/status-bar chrome.
- Add status-bar height fallback when window insets report zero (common on Samsung and other devices with navigation bars).
- Inject `--safe-area-inset-*` CSS variables from the computed native margins so web content can match the main Capacitor WebView.

## Why
Closes #549. After #540/#577, BLANK webviews could still overflow the bottom edge and sit under the system status bar because the hidden AppBar layout and zero window insets prevented `enabledSafeTopMargin` / `enabledSafeBottomMargin` from sizing the WebView correctly.

## Test plan
- [x] `bun run verify`
- [ ] Open `openWebView({ toolbarType: BLANK })` on Android 15 emulator with gesture nav and confirm bottom no longer overflows when `enabledSafeBottomMargin: true`
- [ ] Confirm `enabledSafeTopMargin: false, enabledSafeBottomMargin: false` fills the available area without double top offset
- [ ] Verify `--safe-area-inset-bottom` is non-zero in loaded page when safe bottom margin is enabled
- [ ] Smoke test on a Samsung device with 3-button navigation bar


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSS variables for safe area insets are now available in web content

* **Tests**
  * Added comprehensive test coverage for safe area inset fallback scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->