### PR TITLE
fix(android): fall back when Custom Tabs launch fails with preventDeeplink

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
@@ -2,6 +2,7 @@ package ee.forgr.capacitor_inappbrowser;
 
 import android.Manifest;
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -763,7 +764,25 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
             tabsIntent.intent.putExtra("isPresentAfterPageLoad", true);
         }
 
-        tabsIntent.launchUrl(getContext(), Uri.parse(url));
+        Uri targetUri = Uri.parse(url);
+        try {
+            tabsIntent.launchUrl(getContext(), targetUri);
+        } catch (ActivityNotFoundException e) {
+            Intent fallback = new Intent(Intent.ACTION_VIEW, targetUri);
+            Bundle extras = tabsIntent.intent.getExtras();
+            if (extras != null) {
+                fallback.putExtras(extras);
+            }
+            if (tabsIntent.intent.getPackage() != null) {
+                fallback.setPackage(tabsIntent.intent.getPackage());
+            }
+            try {
+                getContext().startActivity(fallback);
+            } catch (ActivityNotFoundException e2) {
+                call.reject("No browser found to open URL: " + url);
+                return;
+            }
+        }
 
         call.resolve();
     }


### PR DESCRIPTION
## Summary
- Catch `ActivityNotFoundException` when `CustomTabsIntent.launchUrl` fails because the locked default browser package does not expose a Custom Tabs activity.
- Fall back to `Intent.ACTION_VIEW` on the same package (preserving referrer/headers and deeplink protection) instead of crashing through the Capacitor bridge.
- Reject the plugin call only when both Custom Tabs and the plain browser intent fail.

## Test plan
- [x] `bun run verify:android`
- [ ] Manual: on a device whose default browser lacks Custom Tabs, call `InAppBrowser.open({ url, preventDeeplink: true })` and confirm the URL opens without crashing
- [ ] Manual: on a normal device with Custom Tabs support, confirm `open()` behavior is unchanged

Fixes #585

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL opening reliability by adding a fallback mechanism that automatically attempts alternative browser loading if the initial method fails.
  * Improved error messaging to inform users when no compatible browser is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->