### PR TITLE
fix(ios): correct blank toolbar bottom safe area layout

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -237,12 +237,16 @@ enum WebViewViewportLayoutSupport {
 }
 
 enum WebViewSafeAreaLayoutSupport {
-    static func contentInsetAdjustmentBehavior(enabledSafeBottomMargin: Bool) -> UIScrollViewContentInsetAdjustmentBehavior {
+    static func contentInsetAdjustmentBehavior(enabledSafeBottomMargin: Bool) -> UIScrollView.ContentInsetAdjustmentBehavior {
         enabledSafeBottomMargin ? .automatic : .never
     }
 
     static func shouldInsetLayoutMarginsFromSafeArea(enabledSafeBottomMargin: Bool) -> Bool {
         enabledSafeBottomMargin
+    }
+
+    static func rawSystemBottomInset(effectiveBottomInset: CGFloat, additionalBottomInset: CGFloat) -> CGFloat {
+        max(0, effectiveBottomInset - additionalBottomInset)
     }
 
     static func additionalBottomSafeAreaOffset(enabledSafeBottomMargin: Bool, safeAreaBottomInset: CGFloat) -> CGFloat {
@@ -434,6 +438,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
     private var isWebViewInitialized = false
     private var isObservingKeyboardViewportChanges = false
     private var lastViewportRefreshSize: CGSize?
+    private var lastInjectedSafeAreaInsets: (top: Int, bottom: Int, left: Int, right: Int)?
     private var downloadStates: [ObjectIdentifier: WKDownloadState] = [:]
     private var previewItemURL: URL?
 
@@ -1123,9 +1128,14 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
             return
         }
 
+        let rawSafeAreaBottomInset = WebViewSafeAreaLayoutSupport.rawSystemBottomInset(
+            effectiveBottomInset: view.safeAreaInsets.bottom,
+            additionalBottomInset: additionalSafeAreaInsets.bottom
+        )
+
         let bottomOffset = WebViewSafeAreaLayoutSupport.additionalBottomSafeAreaOffset(
             enabledSafeBottomMargin: enabledSafeBottomMargin,
-            safeAreaBottomInset: view.safeAreaInsets.bottom
+            safeAreaBottomInset: rawSafeAreaBottomInset
         )
         if additionalSafeAreaInsets.bottom != bottomOffset {
             additionalSafeAreaInsets.bottom = bottomOffset
@@ -1133,17 +1143,33 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
 
         configureWebViewScrollViewSafeArea(webView)
 
+        let topInset = WebViewSafeAreaLayoutSupport.cssTopInset(
+            enabledSafeTopMargin: enabledSafeTopMargin,
+            safeAreaTopInset: view.safeAreaInsets.top
+        )
+        let bottomInset = WebViewSafeAreaLayoutSupport.cssBottomInset(
+            enabledSafeBottomMargin: enabledSafeBottomMargin,
+            safeAreaBottomInset: rawSafeAreaBottomInset
+        )
+        let leftInset = view.safeAreaInsets.left
+        let rightInset = view.safeAreaInsets.right
+
+        let roundedInsets = (
+            top: Int(topInset.rounded()),
+            bottom: Int(bottomInset.rounded()),
+            left: Int(leftInset.rounded()),
+            right: Int(rightInset.rounded())
+        )
+        guard roundedInsets != lastInjectedSafeAreaInsets else {
+            return
+        }
+        lastInjectedSafeAreaInsets = roundedInsets
+
         let script = WebViewSafeAreaLayoutSupport.safeAreaCssVariablesScript(
-            top: WebViewSafeAreaLayoutSupport.cssTopInset(
-                enabledSafeTopMargin: enabledSafeTopMargin,
-                safeAreaTopInset: view.safeAreaInsets.top
-            ),
-            bottom: WebViewSafeAreaLayoutSupport.cssBottomInset(
-                enabledSafeBottomMargin: enabledSafeBottomMargin,
-                safeAreaBottomInset: view.safeAreaInsets.bottom
-            ),
-            left: view.safeAreaInsets.left,
-            right: view.safeAreaInsets.right
+            top: topInset,
+            bottom: bottomInset,
+            left: leftInset,
+            right: rightInset
         )
         webView.evaluateJavaScript(script, completionHandler: nil)
     }

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -236,6 +236,45 @@ enum WebViewViewportLayoutSupport {
     }
 }
 
+enum WebViewSafeAreaLayoutSupport {
+    static func contentInsetAdjustmentBehavior(enabledSafeBottomMargin: Bool) -> UIScrollViewContentInsetAdjustmentBehavior {
+        enabledSafeBottomMargin ? .automatic : .never
+    }
+
+    static func shouldInsetLayoutMarginsFromSafeArea(enabledSafeBottomMargin: Bool) -> Bool {
+        enabledSafeBottomMargin
+    }
+
+    static func additionalBottomSafeAreaOffset(enabledSafeBottomMargin: Bool, safeAreaBottomInset: CGFloat) -> CGFloat {
+        guard !enabledSafeBottomMargin, safeAreaBottomInset > 0 else {
+            return 0
+        }
+
+        return -safeAreaBottomInset
+    }
+
+    static func cssBottomInset(enabledSafeBottomMargin: Bool, safeAreaBottomInset: CGFloat) -> CGFloat {
+        enabledSafeBottomMargin ? safeAreaBottomInset : 0
+    }
+
+    static func cssTopInset(enabledSafeTopMargin: Bool, safeAreaTopInset: CGFloat) -> CGFloat {
+        enabledSafeTopMargin ? safeAreaTopInset : 0
+    }
+
+    static func safeAreaCssVariablesScript(top: CGFloat, bottom: CGFloat, left: CGFloat, right: CGFloat) -> String {
+        let topValue = Int(top.rounded())
+        let bottomValue = Int(bottom.rounded())
+        let leftValue = Int(left.rounded())
+        let rightValue = Int(right.rounded())
+
+        return "(function(){var root=document.documentElement;" +
+            "root.style.setProperty('--safe-area-inset-top','\(topValue)px');" +
+            "root.style.setProperty('--safe-area-inset-bottom','\(bottomValue)px');" +
+            "root.style.setProperty('--safe-area-inset-left','\(leftValue)px');" +
+            "root.style.setProperty('--safe-area-inset-right','\(rightValue)px');})();"
+    }
+}
+
 open class WKWebViewController: UIViewController, WKScriptMessageHandler {
 
     public init() {
@@ -898,7 +937,13 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
 
     override open func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        syncWebViewSafeAreaLayout()
         refreshWebViewViewportIfNeeded()
+    }
+
+    override open func viewSafeAreaInsetsDidChange() {
+        super.viewSafeAreaInsetsDidChange()
+        syncWebViewSafeAreaLayout()
     }
 
     func updateButtonTintColors() {
@@ -1056,6 +1101,51 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
         webView.scrollView.setNeedsLayout()
         webView.scrollView.layoutIfNeeded()
         webView.evaluateJavaScript("window.dispatchEvent(new Event('resize'));", completionHandler: nil)
+    }
+
+    private func configureWebViewScrollViewSafeArea(_ webView: WKWebView) {
+        if #available(iOS 11.0, *) {
+            webView.scrollView.contentInsetAdjustmentBehavior = WebViewSafeAreaLayoutSupport
+                .contentInsetAdjustmentBehavior(enabledSafeBottomMargin: enabledSafeBottomMargin)
+        }
+
+        webView.insetsLayoutMarginsFromSafeArea = WebViewSafeAreaLayoutSupport
+            .shouldInsetLayoutMarginsFromSafeArea(enabledSafeBottomMargin: enabledSafeBottomMargin)
+
+        if !enabledSafeBottomMargin {
+            webView.scrollView.contentInset = .zero
+            webView.scrollView.scrollIndicatorInsets = .zero
+        }
+    }
+
+    private func syncWebViewSafeAreaLayout() {
+        guard let webView = self.webView, webView.superview != nil else {
+            return
+        }
+
+        let bottomOffset = WebViewSafeAreaLayoutSupport.additionalBottomSafeAreaOffset(
+            enabledSafeBottomMargin: enabledSafeBottomMargin,
+            safeAreaBottomInset: view.safeAreaInsets.bottom
+        )
+        if additionalSafeAreaInsets.bottom != bottomOffset {
+            additionalSafeAreaInsets.bottom = bottomOffset
+        }
+
+        configureWebViewScrollViewSafeArea(webView)
+
+        let script = WebViewSafeAreaLayoutSupport.safeAreaCssVariablesScript(
+            top: WebViewSafeAreaLayoutSupport.cssTopInset(
+                enabledSafeTopMargin: enabledSafeTopMargin,
+                safeAreaTopInset: view.safeAreaInsets.top
+            ),
+            bottom: WebViewSafeAreaLayoutSupport.cssBottomInset(
+                enabledSafeBottomMargin: enabledSafeBottomMargin,
+                safeAreaBottomInset: view.safeAreaInsets.bottom
+            ),
+            left: view.safeAreaInsets.left,
+            right: view.safeAreaInsets.right
+        )
+        webView.evaluateJavaScript(script, completionHandler: nil)
     }
 
     private func jsonString(from object: Any) -> String? {
@@ -1500,6 +1590,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
 
         // Disable bounce effect by setting scrollView.bounces to false when disableOverscroll is true
         webView.scrollView.bounces = !self.disableOverscroll
+        configureWebViewScrollViewSafeArea(webView)
 
         webView.addObserver(self, forKeyPath: estimatedProgressKeyPath, options: .new, context: nil)
         if websiteTitleInNavigationBar {
@@ -2062,10 +2153,10 @@ fileprivate extension WKWebViewController {
     }
 
     func setUpState() {
-        navigationController?.setNavigationBarHidden(false, animated: true)
+        navigationController?.setNavigationBarHidden(blankNavigationTab, animated: false)
 
         // Always hide toolbar since we never want it
-        navigationController?.setToolbarHidden(true, animated: true)
+        navigationController?.setToolbarHidden(true, animated: false)
 
         // Set tint colors but don't override specific colors
         if tintColor == nil {
@@ -2947,6 +3038,7 @@ extension WKWebViewController: WKNavigationDelegate {
             webView.topAnchor.constraint(equalTo: topAnchor)
         ])
         self.view.layoutIfNeeded()
+        syncWebViewSafeAreaLayout()
         refreshWebViewViewportIfNeeded(force: true)
     }
 
@@ -2968,6 +3060,7 @@ extension WKWebViewController: WKNavigationDelegate {
             webView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
         self.view.layoutIfNeeded()
+        syncWebViewSafeAreaLayout()
         refreshWebViewViewportIfNeeded(force: true)
     }
 }

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -1160,7 +1160,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
             left: Int(leftInset.rounded()),
             right: Int(rightInset.rounded())
         )
-        guard roundedInsets != lastInjectedSafeAreaInsets else {
+        if lastInjectedSafeAreaInsets == roundedInsets {
             return
         }
         lastInjectedSafeAreaInsets = roundedInsets
@@ -2850,6 +2850,8 @@ extension WKWebViewController: WKNavigationDelegate {
             delegate?.webViewController?(self, didFinish: url)
         }
         self.injectJavaScriptInterface()
+        lastInjectedSafeAreaInsets = nil
+        syncWebViewSafeAreaLayout()
         emit("browserPageLoaded")
     }
 

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -438,7 +438,14 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
     private var isWebViewInitialized = false
     private var isObservingKeyboardViewportChanges = false
     private var lastViewportRefreshSize: CGSize?
-    private var lastInjectedSafeAreaInsets: (top: Int, bottom: Int, left: Int, right: Int)?
+    private struct InjectedSafeAreaInsets: Equatable {
+        let top: Int
+        let bottom: Int
+        let left: Int
+        let right: Int
+    }
+
+    private var lastInjectedSafeAreaInsets: InjectedSafeAreaInsets?
     private var downloadStates: [ObjectIdentifier: WKDownloadState] = [:]
     private var previewItemURL: URL?
 
@@ -1154,7 +1161,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
         let leftInset = view.safeAreaInsets.left
         let rightInset = view.safeAreaInsets.right
 
-        let roundedInsets = (
+        let roundedInsets = InjectedSafeAreaInsets(
             top: Int(topInset.rounded()),
             bottom: Int(bottomInset.rounded()),
             left: Int(leftInset.rounded()),

--- a/ios/Tests/InAppBrowserPluginTests/InAppBrowserPluginTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/InAppBrowserPluginTests.swift
@@ -153,6 +153,23 @@ final class InAppBrowserPluginTests: XCTestCase {
         )
     }
 
+    func testSafeAreaLayoutRecoversRawSystemBottomInset() {
+        XCTAssertEqual(
+            WebViewSafeAreaLayoutSupport.rawSystemBottomInset(
+                effectiveBottomInset: 0,
+                additionalBottomInset: -34
+            ),
+            34
+        )
+        XCTAssertEqual(
+            WebViewSafeAreaLayoutSupport.rawSystemBottomInset(
+                effectiveBottomInset: 10,
+                additionalBottomInset: 4
+            ),
+            6
+        )
+    }
+
     func testSafeAreaCssVariablesScriptUsesRoundedPixelValues() {
         let script = WebViewSafeAreaLayoutSupport.safeAreaCssVariablesScript(
             top: 59.4,

--- a/ios/Tests/InAppBrowserPluginTests/InAppBrowserPluginTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/InAppBrowserPluginTests.swift
@@ -168,6 +168,13 @@ final class InAppBrowserPluginTests: XCTestCase {
             ),
             6
         )
+        XCTAssertEqual(
+            WebViewSafeAreaLayoutSupport.rawSystemBottomInset(
+                effectiveBottomInset: 10,
+                additionalBottomInset: 20
+            ),
+            0
+        )
     }
 
     func testSafeAreaCssVariablesScriptUsesRoundedPixelValues() {

--- a/ios/Tests/InAppBrowserPluginTests/InAppBrowserPluginTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/InAppBrowserPluginTests.swift
@@ -99,6 +99,72 @@ final class InAppBrowserPluginTests: XCTestCase {
         )
     }
 
+    func testSafeAreaLayoutDisablesAutomaticBottomInsetByDefault() {
+        XCTAssertEqual(
+            WebViewSafeAreaLayoutSupport.contentInsetAdjustmentBehavior(enabledSafeBottomMargin: false),
+            .never
+        )
+        XCTAssertFalse(
+            WebViewSafeAreaLayoutSupport.shouldInsetLayoutMarginsFromSafeArea(enabledSafeBottomMargin: false)
+        )
+    }
+
+    func testSafeAreaLayoutKeepsAutomaticBottomInsetWhenEnabled() {
+        XCTAssertEqual(
+            WebViewSafeAreaLayoutSupport.contentInsetAdjustmentBehavior(enabledSafeBottomMargin: true),
+            .automatic
+        )
+        XCTAssertTrue(
+            WebViewSafeAreaLayoutSupport.shouldInsetLayoutMarginsFromSafeArea(enabledSafeBottomMargin: true)
+        )
+    }
+
+    func testSafeAreaLayoutNegatesBottomInsetWhenDisabled() {
+        XCTAssertEqual(
+            WebViewSafeAreaLayoutSupport.additionalBottomSafeAreaOffset(
+                enabledSafeBottomMargin: false,
+                safeAreaBottomInset: 34
+            ),
+            -34
+        )
+        XCTAssertEqual(
+            WebViewSafeAreaLayoutSupport.cssBottomInset(
+                enabledSafeBottomMargin: false,
+                safeAreaBottomInset: 34
+            ),
+            0
+        )
+    }
+
+    func testSafeAreaLayoutPreservesBottomInsetWhenEnabled() {
+        XCTAssertEqual(
+            WebViewSafeAreaLayoutSupport.additionalBottomSafeAreaOffset(
+                enabledSafeBottomMargin: true,
+                safeAreaBottomInset: 34
+            ),
+            0
+        )
+        XCTAssertEqual(
+            WebViewSafeAreaLayoutSupport.cssBottomInset(
+                enabledSafeBottomMargin: true,
+                safeAreaBottomInset: 34
+            ),
+            34
+        )
+    }
+
+    func testSafeAreaCssVariablesScriptUsesRoundedPixelValues() {
+        let script = WebViewSafeAreaLayoutSupport.safeAreaCssVariablesScript(
+            top: 59.4,
+            bottom: 0,
+            left: 0,
+            right: 0
+        )
+
+        XCTAssertTrue(script.contains("--safe-area-inset-top','59px'"))
+        XCTAssertTrue(script.contains("--safe-area-inset-bottom','0px'"))
+    }
+
     func testLegacyProxyRequestsConfigurationSupportsBooleanValues() {
         let enabled = ProxySchemeRequestSupport.legacyProxyRequestsConfiguration(from: true)
         XCTAssertTrue(enabled.isEnabled)


### PR DESCRIPTION
## Summary
- Fix iOS `openWebView({ toolbarType: BLANK })` applying an incorrect bottom safe-area offset on SDK 18.x when `enabledSafeBottomMargin` is left at its default (`false`).
- Disable automatic WKWebView bottom inset adjustment unless `enabledSafeBottomMargin` is explicitly enabled, negate propagated bottom safe-area insets for edge-to-edge layout, and inject `--safe-area-inset-*` CSS variables for web content parity with Android.
- Keep blank-toolbar navigation chrome hidden during `setUpState()` so layout is not reset after presentation.

Closes #584

## Why
On iOS 18, BLANK webviews could still reserve home-indicator space inside the web content even though the native webview was pinned to the bottom edge. This mirrors the Android blank-toolbar safe-area fixes from #579/#577.

## Test plan
- [x] `bun run verify:android`
- [x] `bun run verify:web`
- [x] `bun run swiftlint -- --fix --format` on changed Swift files
- [ ] Open `InAppBrowser.openWebView({ toolbarType: ToolBarType.BLANK, isAnimated: false })` on iPhone 16 Pro / iOS 18.6 simulator and confirm web content reaches the bottom edge
- [ ] Confirm `enabledSafeBottomMargin: true` still respects the home-indicator inset
- [ ] Smoke test non-blank toolbar types for regressions


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved iOS safe-area synchronization for the in-app web view by refreshing spacing on layout updates and when safe-area insets change, including consistent safe-area CSS variable values.
  * Refined scroll-view inset behavior for enabled vs. disabled safe bottom margins.
  * Corrected navigation bar and toolbar hiding animation timing when using an empty navigation tab.

* **Tests**
  * Added XCTest coverage validating safe-area inset calculations and the generated safe-area CSS variable script contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->