### PR TITLE
fix(android): add NEW_TASK flag to Custom Tabs fallback intent

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
@@ -769,6 +769,7 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
             tabsIntent.launchUrl(getContext(), targetUri);
         } catch (ActivityNotFoundException e) {
             Intent fallback = new Intent(Intent.ACTION_VIEW, targetUri);
+            fallback.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             Bundle extras = tabsIntent.intent.getExtras();
             if (extras != null) {
                 fallback.putExtras(extras);


### PR DESCRIPTION
## Summary
- Add `FLAG_ACTIVITY_NEW_TASK` to the `ACTION_VIEW` fallback intent used when `CustomTabsIntent.launchUrl` fails with `preventDeeplink: true` (#585 / #587).
- Ensures the external browser opens in its own task and avoids `AndroidRuntimeException` when `getContext().startActivity()` is used outside an Activity context.

## Context
This follow-up was requested in review on #587. The main Custom Tabs fallback fix landed in #587, but the `NEW_TASK` flag was not included in the merged commit.

## Test plan
- [x] `bun run verify:android`
- [ ] Manual: on a device whose default browser lacks Custom Tabs, call `InAppBrowser.open({ url, preventDeeplink: true })` and confirm the URL opens without crashing

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback behavior for opening links when the primary in-app browser method is unavailable, ensuring better reliability across various Android configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->