### PR TITLE
fix(android): anchor openWebView x/y to top-left corner

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -33,6 +33,7 @@ import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Log;
 import android.util.TypedValue;
+import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -5959,12 +5960,14 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
 
         // If both width and height are specified, use custom dimensions
         if (width != null && height != null) {
+            params.gravity = Gravity.TOP | Gravity.LEFT;
             params.width = (int) getPixels(width);
             params.height = (int) getPixels(height);
             params.x = (x != null) ? (int) getPixels(x) : 0;
             params.y = (y != null) ? (int) getPixels(y) : 0;
         } else if (height != null && width == null) {
             // If only height is specified, use custom height with fullscreen width
+            params.gravity = Gravity.TOP | Gravity.LEFT;
             params.width = WindowManager.LayoutParams.MATCH_PARENT;
             params.height = (int) getPixels(height);
             params.x = 0;


### PR DESCRIPTION
## Summary
- Sets `WindowManager.LayoutParams.gravity` to `TOP | LEFT` when `openWebView` uses custom dimensions
- Ensures `x` and `y` offsets are applied from the top-left corner instead of the default center origin

## Test plan
- [ ] Open a webview with custom `width`, `height`, `x`, and `y` on Android and confirm it is positioned from the top-left
- [ ] Open a webview with only custom `height` and confirm it anchors to the top edge
- [ ] Verify fullscreen/default webview behavior is unchanged

Made with [Cursor](https://cursor.com)