### PR TITLE
fix: add browsing data controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ The W3C Payment Request API (used by Google Pay) requires Android WebView 120+. 
 * [`clearCookies(...)`](#clearcookies)
 * [`clearAllCookies(...)`](#clearallcookies)
 * [`clearCache(...)`](#clearcache)
+* [`clearAllBrowsingData()`](#clearallbrowsingdata)
 * [`getCookies(...)`](#getcookies)
 * [`close(...)`](#close)
 * [`hide(...)`](#hide)
@@ -559,6 +560,24 @@ When `id` is omitted, applies to all open webviews.
 **Returns:** <code>Promise&lt;any&gt;</code>
 
 **Since:** 6.5.0
+
+--------------------
+
+
+### clearAllBrowsingData()
+
+```typescript
+clearAllBrowsingData() => Promise<any>
+```
+
+Clear all browsing data from the default store and any opened managed webviews.
+
+This removes cookies, disk cache, memory cache, local storage, session storage, IndexedDB,
+WebSQL where supported, form data, and HTTP auth data where the platform exposes it.
+
+**Returns:** <code>Promise&lt;any&gt;</code>
+
+**Since:** 8.6.36
 
 --------------------
 
@@ -759,12 +778,18 @@ Listen for url change, only for openWebView
 addListener(eventName: 'buttonNearDoneClick', listenerFunc: ButtonNearListener) => Promise<PluginListenerHandle>
 ```
 
+Listen for buttonNearDone clicks.
+
+The event payload contains the webview `id`.
+
 | Param              | Type                                                              |
 | ------------------ | ----------------------------------------------------------------- |
 | **`eventName`**    | <code>'buttonNearDoneClick'</code>                                |
 | **`listenerFunc`** | <code><a href="#buttonnearlistener">ButtonNearListener</a></code> |
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+**Since:** 0.0.1
 
 --------------------
 
@@ -1238,6 +1263,7 @@ And in the AndroidManifest.xml file:
 | **`jsInterface`**                      |                                                                                                                                                                        | JavaScript Interface: The webview automatically injects a JavaScript interface providing: - `window.mobileApp.close()`: Closes the webview from JavaScript - `window.mobileApp.postMessage(obj)`: Sends a message to the app (listen via "messageFromWebview" event) - `window.mobileApp.hide()` / `window.mobileApp.show()` when allowWebViewJsVisibilityControl is true in CapacitorConfig - `window.mobileApp.takeScreenshot()` when `allowScreenshotsFromWebPage` is true                                                                              |                                                               | 6.10.0 |
 | **`allowScreenshotsFromWebPage`**      | <code>boolean</code>                                                                                                                                                   | Allows page JavaScript to call `window.mobileApp.takeScreenshot()`. Disabled by default so only the host app can trigger native screenshots through the plugin API.                                                                                                                                                                                                                                                                                                                                                                                        | <code>false</code>                                            | 8.4.0  |
 | **`captureConsoleLogs`**               | <code>boolean</code>                                                                                                                                                   | Emits `consoleMessage` events for JavaScript `console.*` output coming from the managed page. Useful when the webview stays hidden and you still need page-level diagnostics.                                                                                                                                                                                                                                                                                                                                                                              | <code>false</code>                                            | 8.6.0  |
+| **`persistWebViewData`**               | <code>boolean</code>                                                                                                                                                   | Controls whether the webview should persist website data such as cache, cookies, local storage, IndexedDB, and session data. When false, iOS uses a non-persistent `WKWebsiteDataStore`. Android disables per-view cache and DOM/database storage where the system WebView supports it. Android cookies use the shared WebView cookie store, so call `clearAllBrowsingData()` to remove cookies and other global data.                                                                                                                                     | <code>true</code>                                             | 8.6.36 |
 | **`handleDownloads`**                  | <code>boolean</code>                                                                                                                                                   | Automatically handles downloads triggered inside the webview without requiring a custom JavaScript bridge. When enabled: - Standard attachment responses are written to a temporary file. - `blob:` downloads are also captured when the platform supports them. - Previewable files reopen inside the in-app browser when possible. - Other files are handed off to the native preview or viewer flow. - `downloadCompleted` and `downloadFailed` events notify the host app about the saved file.                                                        | <code>false</code>                                            | 8.6.0  |
 | **`shareDisclaimer`**                  | <code><a href="#disclaimeroptions">DisclaimerOptions</a></code>                                                                                                        | Share options for the webview. When provided, shows a disclaimer dialog before sharing content. This is useful for: - Warning users about sharing sensitive information - Getting user consent before sharing - Explaining what will be shared - Complying with privacy regulations Note: shareSubject is required when using shareDisclaimer                                                                                                                                                                                                              |                                                               | 0.1.0  |
 | **`toolbarType`**                      | <code><a href="#toolbartype">ToolBarType</a></code>                                                                                                                    | Toolbar type determines the appearance and behavior of the browser's toolbar - "activity": Shows a simple toolbar with just a close button and share button - "navigation": Shows a full navigation toolbar with back/forward buttons - "blank": Shows no toolbar - "": Default toolbar with close button                                                                                                                                                                                                                                                  | <code>ToolBarType.DEFAULT</code>                              | 0.1.0  |
@@ -1354,6 +1380,13 @@ Any regex property that is omitted is treated as a wildcard.
 | --------- | ------------------- | ------------------------- | ----- |
 | **`id`**  | <code>string</code> | Webview instance id.      |       |
 | **`url`** | <code>string</code> | Emit when the url changes | 0.0.1 |
+
+
+#### ButtonNearDoneEvent
+
+| Prop     | Type                | Description          | Since  |
+| -------- | ------------------- | -------------------- | ------ |
+| **`id`** | <code>string</code> | Webview instance id. | 8.6.36 |
 
 
 #### BtnEvent
@@ -1568,7 +1601,7 @@ Construct a type with a set of properties K of type T
 
 #### ButtonNearListener
 
-<code>(state: object): void</code>
+<code>(state: <a href="#buttonneardoneevent">ButtonNearDoneEvent</a>): void</code>
 
 
 #### ConfirmBtnListener

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
@@ -19,7 +19,9 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.webkit.CookieManager;
 import android.webkit.PermissionRequest;
+import android.webkit.WebStorage;
 import android.webkit.WebView;
+import android.webkit.WebViewDatabase;
 import androidx.activity.result.ActivityResult;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -814,6 +816,41 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
     }
 
     @PluginMethod
+    public void clearAllBrowsingData(PluginCall call) {
+        this.getActivity().runOnUiThread(() -> {
+            try {
+                ArrayList<WebView> targetWebViews = cacheWebViewsFor(null);
+                WebView bridgeWebView = getBridge() != null ? getBridge().getWebView() : null;
+                if (bridgeWebView != null && !targetWebViews.contains(bridgeWebView)) {
+                    targetWebViews.add(bridgeWebView);
+                }
+
+                for (WebView targetWebView : targetWebViews) {
+                    targetWebView.stopLoading();
+                    targetWebView.clearCache(true);
+                    targetWebView.clearHistory();
+                    targetWebView.clearFormData();
+                    targetWebView.clearSslPreferences();
+                }
+
+                WebStorage.getInstance().deleteAllData();
+                WebViewDatabase webViewDatabase = WebViewDatabase.getInstance(getContext());
+                webViewDatabase.clearFormData();
+                webViewDatabase.clearHttpAuthUsernamePassword();
+
+                CookieManager cookieManager = CookieManager.getInstance();
+                cookieManager.removeAllCookies((value) -> {
+                    cookieManager.flush();
+                    call.resolve();
+                });
+            } catch (Exception e) {
+                Log.e("InAppBrowser", "Error clearing browsing data: " + e.getMessage());
+                call.reject("Failed to clear browsing data: " + e.getMessage());
+            }
+        });
+    }
+
+    @PluginMethod
     public void clearCookies(PluginCall call) {
         String url = call.getString("url", currentUrl);
         if (url == null || TextUtils.isEmpty(url)) {
@@ -942,6 +979,7 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
         options.setCaptureConsoleLogs(Boolean.TRUE.equals(call.getBoolean("captureConsoleLogs", false)));
         options.setHandleDownloads(Boolean.TRUE.equals(call.getBoolean("handleDownloads", false)));
 
+        options.setPersistWebViewData(call.getBoolean("persistWebViewData", true));
         // Set text zoom if specified in options (default is 100)
         Integer textZoom = call.getInt("textZoom");
         if (textZoom != null) {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
@@ -196,6 +196,7 @@ public class Options {
     private boolean allowScreenshotsFromWebPage = false;
     private boolean captureConsoleLogs = false;
     private boolean handleDownloads = false;
+    private boolean persistWebViewData = true;
     private InvisibilityMode invisibilityMode = InvisibilityMode.AWARE;
     private String httpMethod = null;
     private String httpBody = null;
@@ -276,6 +277,14 @@ public class Options {
 
     public void setHandleDownloads(boolean handleDownloads) {
         this.handleDownloads = handleDownloads;
+    }
+
+    public boolean getPersistWebViewData() {
+        return persistWebViewData;
+    }
+
+    public void setPersistWebViewData(boolean persistWebViewData) {
+        this.persistWebViewData = persistWebViewData;
     }
 
     public void setMaterialPicker(boolean materialPicker) {
@@ -708,6 +717,7 @@ public class Options {
         copy.setEnableGooglePaySupport(enableGooglePaySupport);
         copy.setBlockedHosts(new ArrayList<>(getBlockedHosts()));
         copy.setWidth(width);
+        copy.setPersistWebViewData(persistWebViewData);
         copy.setHeight(height);
         copy.setX(x);
         copy.setY(y);

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -52,6 +52,7 @@ import android.webkit.WebChromeClient;
 import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
+import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.ImageButton;
@@ -1834,6 +1835,17 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         _webView.getSettings().setUseWideViewPort(true);
         _webView.getSettings().setAllowFileAccessFromFileURLs(true);
         _webView.getSettings().setAllowUniversalAccessFromFileURLs(true);
+        if (!_options.getPersistWebViewData()) {
+            _webView.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
+            _webView.getSettings().setDatabaseEnabled(false);
+            _webView.getSettings().setDomStorageEnabled(false);
+            _webView.clearCache(true);
+            _webView.clearHistory();
+            _webView.clearFormData();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                CookieManager.getInstance().setAcceptThirdPartyCookies(_webView, false);
+            }
+        }
         _webView.getSettings().setMediaPlaybackRequiresUserGesture(false);
         injectDocumentStartJavaScriptInterface();
 
@@ -5077,6 +5089,13 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                     _webView.evaluateJavascript(clearInputsScript, null);
                 } catch (Exception e) {
                     Log.w("InAppBrowser", "Could not clear file inputs (WebView may be in invalid state): " + e.getMessage());
+                }
+
+                if (_options != null && !_options.getPersistWebViewData()) {
+                    _webView.clearCache(true);
+                    _webView.clearHistory();
+                    _webView.clearFormData();
+                    _webView.clearSslPreferences();
                 }
 
                 forceStopMediaCapture(_webView);

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -109,6 +109,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getCookies", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "clearAllCookies", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "clearCache", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "clearAllBrowsingData", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "reload", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setUrl", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "show", returnType: CAPPluginReturnPromise),
@@ -346,6 +347,26 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         return stores
     }
 
+    private func allBrowsingDataStores() -> [WKWebsiteDataStore] {
+        var seen = Set<ObjectIdentifier>()
+        var stores: [WKWebsiteDataStore] = []
+
+        func append(_ store: WKWebsiteDataStore) {
+            let identifier = ObjectIdentifier(store)
+            if seen.insert(identifier).inserted {
+                stores.append(store)
+            }
+        }
+
+        append(WKWebsiteDataStore.default())
+        for controller in webViewControllers.values {
+            if let store = controller.websiteDataStore() {
+                append(store)
+            }
+        }
+        return stores
+    }
+
     private func parseProxyRules(_ rawRules: [Any]) throws -> [NativeProxyRule] {
         try rawRules.enumerated().map { index, item in
             guard let dictionary = item as? [String: Any] else {
@@ -572,6 +593,24 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
+    @objc func clearAllBrowsingData(_ call: CAPPluginCall) {
+        DispatchQueue.main.async {
+            let dataStores = self.allBrowsingDataStores()
+            let dataTypes = WKWebsiteDataStore.allWebsiteDataTypes()
+            let group = DispatchGroup()
+            for dataStore in dataStores {
+                group.enter()
+                dataStore.removeData(ofTypes: dataTypes,
+                                     modifiedSince: Date(timeIntervalSince1970: 0)) {
+                    group.leave()
+                }
+            }
+            group.notify(queue: .main) {
+                call.resolve()
+            }
+        }
+    }
+
     @objc func clearCookies(_ call: CAPPluginCall) {
         guard let url = call.getString("url"),
               let host = URL(string: url)?.host else {
@@ -777,6 +816,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         let allowScreenshotsFromWebPage = call.getBool("allowScreenshotsFromWebPage", false)
         let captureConsoleLogs = call.getBool("captureConsoleLogs", false)
         let handleDownloads = call.getBool("handleDownloads", false)
+        let persistWebViewData = call.getBool("persistWebViewData", true)
         let invisibilityModeRaw = call.getString("invisibilityMode", "AWARE")
         self.invisibilityMode = InvisibilityMode(rawValue: invisibilityModeRaw.uppercased()) ?? .aware
 
@@ -918,36 +958,32 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
                 self.proxyBridges[webViewId] = proxyBridge
             }
 
-            self.webViewController = WKWebViewController.init(
-                url: url,
-                headers: headers,
-                isInspectable: isInspectable,
-                credentials: credentials,
-                preventDeeplink: preventDeeplink,
-                blankNavigationTab: toolbarType == "blank",
-                enabledSafeBottomMargin: enabledSafeBottomMargin,
-                enabledSafeTopMargin: enabledSafeTopMargin,
-                blockedHosts: blockedHosts,
+            let webViewController = WKWebViewController()
+            webViewController.blankNavigationTab = toolbarType == "blank"
+            webViewController.enabledSafeBottomMargin = enabledSafeBottomMargin
+            webViewController.enabledSafeTopMargin = enabledSafeTopMargin
+            webViewController.source = .remote(url)
+            webViewController.setCredentials(credentials: credentials)
+            webViewController.allowWebViewJsVisibilityControl = allowWebViewJsVisibilityControl
+            webViewController.allowScreenshotsFromWebPage = allowScreenshotsFromWebPage
+            webViewController.captureConsoleLogs = captureConsoleLogs
+            webViewController.proxyRequests = legacyProxyRequests.isEnabled
+            webViewController.proxySchemeHandler = proxyHandler
+            webViewController.proxyBridge = proxyBridge
+            webViewController.proxyBridgeAccessToken = proxyBridgeAccessToken
+            webViewController.legacyProxyRequestURLRegexPattern = legacyProxyRequests.urlRegex?.pattern
+            webViewController.openBlankTargetInWebView = openBlankTargetInWebView
+            webViewController.persistWebViewData = persistWebViewData
+            webViewController.setHeaders(headers: headers)
+            webViewController.setPreventDeeplink(preventDeeplink: preventDeeplink)
+            webViewController.setBlockedHosts(blockedHosts: blockedHosts)
+            webViewController.setAuthorizedAppLinks(authorizedAppLinks: authorizedAppLinks)
+            webViewController.documentStartUserScripts = self.documentStartUserScripts(
                 authorizedAppLinks: authorizedAppLinks,
-                allowWebViewJsVisibilityControl: allowWebViewJsVisibilityControl,
-                allowScreenshotsFromWebPage: allowScreenshotsFromWebPage,
-                captureConsoleLogs: captureConsoleLogs,
-                proxyRequests: legacyProxyRequests.isEnabled,
-                proxySchemeHandler: proxyHandler,
-                proxyBridge: proxyBridge,
-                proxyBridgeAccessToken: proxyBridgeAccessToken,
-                legacyProxyRequestURLRegexPattern: legacyProxyRequests.urlRegex?.pattern,
-                documentStartUserScripts: self.documentStartUserScripts(
-                    authorizedAppLinks: authorizedAppLinks,
-                    openBlankTargetInWebView: openBlankTargetInWebView
-                ),
                 openBlankTargetInWebView: openBlankTargetInWebView
             )
-
-            guard let webViewController = self.webViewController else {
-                call.reject("Failed to initialize WebViewController")
-                return
-            }
+            webViewController.initWebview(isInspectable: isInspectable)
+            self.webViewController = webViewController
 
             webViewController.instanceId = webViewId
 

--- a/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
+++ b/ios/Sources/InAppBrowserPlugin/ProxySchemeHandler.swift
@@ -1169,7 +1169,6 @@ public class ProxySchemeHandler: NSObject, WKURLSchemeHandler, URLSessionTaskDel
         }
     }
 
-
     private func makeInitialRequestContext(from urlSchemeTask: WKURLSchemeTask, requestURL: URL) -> NativeRequestContext? {
         let requestURLString = requestURL.absoluteString
 

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -387,6 +387,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
     open var allowWebViewJsVisibilityControl = false
     open var allowScreenshotsFromWebPage = false
     open var captureConsoleLogs = false
+    open var persistWebViewData = true
     open var handleDownloads = false
     open var delegate: WKWebViewControllerDelegate?
     open var bypassedSSLHosts: [String]?
@@ -748,8 +749,8 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
             .compactMap { $0 as? UIWindowScene }
             .first { $0.activationState == .foregroundActive }
             ?? UIApplication.shared.connectedScenes
-                .compactMap { $0 as? UIWindowScene }
-                .first
+            .compactMap { $0 as? UIWindowScene }
+            .first
         return windowScene?.statusBarManager?.statusBarFrame.height ?? 0
     }
 
@@ -1513,6 +1514,9 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
         self.edgesForExtendedLayout = [.bottom]
 
         let webConfiguration = initialWebConfiguration ?? WKWebViewConfiguration()
+        if !persistWebViewData {
+            webConfiguration.websiteDataStore = .nonPersistent()
+        }
         let userContentController = webConfiguration.userContentController
         userContentController.removeAllUserScripts()
         userContentController.removeScriptMessageHandler(forName: "messageHandler")
@@ -1763,6 +1767,8 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
         self.blockedHosts = parent.blockedHosts
         self.authorizedAppLinks = parent.authorizedAppLinks
         self.activeNativeNavigationForWebview = parent.activeNativeNavigationForWebview
+        self.initialWebConfiguration = configuration
+        self.persistWebViewData = parent.persistWebViewData
         self.disableOverscroll = parent.disableOverscroll
         self.proxyRequests = parent.proxyRequests
         self.proxySchemeHandler = proxySchemeHandler
@@ -1934,7 +1940,6 @@ public extension WKWebViewController {
         }
         return false
     }
-
 
     func load(source sourceValue: WKWebSource) {
         switch sourceValue {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -48,9 +48,18 @@ export interface BtnEvent {
   url: string;
 }
 
+export interface ButtonNearDoneEvent {
+  /**
+   * Webview instance id.
+   *
+   * @since 8.6.36
+   */
+  id: string;
+}
+
 export type UrlChangeListener = (state: UrlEvent) => void;
 export type ConfirmBtnListener = (state: BtnEvent) => void;
-export type ButtonNearListener = (state: object) => void;
+export type ButtonNearListener = (state: ButtonNearDoneEvent) => void;
 export type CustomSchemeInterceptedListener = (state: CustomSchemeInterceptedEvent) => void;
 
 export enum BackgroundColor {
@@ -622,6 +631,18 @@ export interface OpenWebViewOptions {
    * @since 8.6.0
    */
   captureConsoleLogs?: boolean;
+  /**
+   * Controls whether the webview should persist website data such as cache, cookies, local storage,
+   * IndexedDB, and session data.
+   *
+   * When false, iOS uses a non-persistent `WKWebsiteDataStore`. Android disables per-view cache and
+   * DOM/database storage where the system WebView supports it. Android cookies use the shared
+   * WebView cookie store, so call `clearAllBrowsingData()` to remove cookies and other global data.
+   *
+   * @default true
+   * @since 8.6.36
+   */
+  persistWebViewData?: boolean;
   /**
    * Automatically handles downloads triggered inside the webview without requiring a custom JavaScript bridge.
    *
@@ -1199,6 +1220,16 @@ export interface InAppBrowserPlugin {
   clearCache(options?: { id?: string }): Promise<any>;
 
   /**
+   * Clear all browsing data from the default store and any opened managed webviews.
+   *
+   * This removes cookies, disk cache, memory cache, local storage, session storage, IndexedDB,
+   * WebSQL where supported, form data, and HTTP auth data where the platform exposes it.
+   *
+   * @since 8.6.36
+   */
+  clearAllBrowsingData(): Promise<any>;
+
+  /**
    * Get cookies for a specific URL.
    * @param options The options, including the URL to get cookies for.
    * @returns A promise that resolves with the cookies.
@@ -1269,6 +1300,13 @@ export interface InAppBrowserPlugin {
    */
   addListener(eventName: 'urlChangeEvent', listenerFunc: UrlChangeListener): Promise<PluginListenerHandle>;
 
+  /**
+   * Listen for buttonNearDone clicks.
+   *
+   * The event payload contains the webview `id`.
+   *
+   * @since 0.0.1
+   */
   addListener(eventName: 'buttonNearDoneClick', listenerFunc: ButtonNearListener): Promise<PluginListenerHandle>;
 
   /**

--- a/src/web.ts
+++ b/src/web.ts
@@ -21,6 +21,10 @@ export class InAppBrowserWeb extends WebPlugin implements InAppBrowserPlugin {
     console.log('clearCache');
     return Promise.resolve();
   }
+  clearAllBrowsingData(): Promise<any> {
+    console.log('clearAllBrowsingData');
+    return Promise.resolve();
+  }
   async open(options: OpenOptions): Promise<any> {
     console.log('open', options);
     return options;


### PR DESCRIPTION
## What
- Fix `buttonNearDoneClick` listener typing to expose the emitted `{ id }` payload.
- Add `persistWebViewData` to `openWebView` and wire native storage behavior.
- Add `clearAllBrowsingData()` to clear default and managed WebView browsing data.

## Why
- Users reported the ButtonNearListener type did not match the runtime payload.
- Apps need control over whether opened WebViews keep browser data.
- Existing cookie/cache helpers did not clear all WebView storage surfaces.

## How
- Updated generated API source docs/types and regenerated README through docgen.
- Uses iOS non-persistent WKWebsiteDataStore when persistence is disabled.
- Disables Android per-view cache/DOM/database storage and adds full global/managed WebView cleanup using CookieManager, WebStorage, WebViewDatabase, and WebView clear helpers.

## Testing
- `bun run fmt`
- `bun run verify`

## Not Tested
- Manual device validation of cookie persistence behavior on real iOS/Android devices.
