### PR TITLE
fix: wait for iOS sendToBack dismissal before layering

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -190,11 +190,16 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
-    private func dismissNavigationControllerIfPresented(_ navigationController: UINavigationController?) {
-        guard let navigationController, navigationController.presentingViewController != nil else {
+    private func dismissNavigationControllerIfPresented(_ navigationController: UINavigationController?, completion: (() -> Void)? = nil) {
+        guard let navigationController else {
+            completion?()
             return
         }
-        navigationController.dismiss(animated: false)
+        guard navigationController.presentingViewController != nil else {
+            completion?()
+            return
+        }
+        navigationController.dismiss(animated: false, completion: completion)
     }
 
     private func unregisterWebView(id: String) {
@@ -446,7 +451,6 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         }
 
         dismissActiveKeyboard()
-        dismissNavigationControllerIfPresented(navigationController)
         navigationController.view.removeFromSuperview()
         if transparentBackground {
             makeHostWebViewTransparent(for: id)
@@ -1602,14 +1606,16 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
             }
 
             let transparentBackground = call.getBool("transparentBackground", true)
-            webViewController.isLayeredBehind = true
-            webViewController.transparentHostBackground = transparentBackground
-            guard self.sendNavigationControllerToBack(id: resolvedId, transparentBackground: transparentBackground) else {
-                call.reject("Failed to send webview to back")
-                return
+            self.dismissNavigationControllerIfPresented(navigationController) {
+                webViewController.isLayeredBehind = true
+                webViewController.transparentHostBackground = transparentBackground
+                guard self.sendNavigationControllerToBack(id: resolvedId, transparentBackground: transparentBackground) else {
+                    call.reject("Failed to send webview to back")
+                    return
+                }
+                self.setActiveWebView(id: resolvedId, webView: webViewController, navigationController: navigationController)
+                call.resolve()
             }
-            self.setActiveWebView(id: resolvedId, webView: webViewController, navigationController: navigationController)
-            call.resolve()
         }
     }
 


### PR DESCRIPTION
## What
- Fix iOS `sendToBack()` for browser tabs that were previously presented in front.
- Wait for modal dismissal completion before moving the native browser view behind the Capacitor host WebView.

## Why
- Ivan reported that `openWebView({ toBack: true })` works, but opening normally and later calling `sendToBack({ id })` makes the app layer visible while a transparent app layer reveals a black screen.
- The later path dismissed the presented navigation controller and reparented its view in the same synchronous flow, so UIKit dismissal cleanup could run after the reparent and leave the behind layer blank.

## How
- Let `dismissNavigationControllerIfPresented` accept a completion callback.
- Move the public `sendToBack()` layering work into that dismissal completion.
- Keep `sendNavigationControllerToBack` focused on attaching the existing navigation controller view behind Capacitor.

## Testing
- `bun run verify`

## Not Tested
- Manual reproduction in Ivan’s sample app or a physical iOS device.