### PR TITLE
fix(android): enforce navigation bar bottom inset for enabledSafeBottomMargin

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
@@ -48,8 +48,10 @@ final class SafeAreaInsetsSupport {
             return false;
         }
 
-        return Math.max(systemBarsLeft, navigationBarsLeft) >= minSideNavBarInset
-            || Math.max(systemBarsRight, navigationBarsRight) >= minSideNavBarInset;
+        return (
+            Math.max(systemBarsLeft, navigationBarsLeft) >= minSideNavBarInset ||
+            Math.max(systemBarsRight, navigationBarsRight) >= minSideNavBarInset
+        );
     }
 
     static int resolveBottomMargin(boolean enabledSafeBottomMargin, int safeBottomInset, int imeBottom) {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
@@ -26,19 +26,30 @@ final class SafeAreaInsetsSupport {
         boolean applyFallbackWhenZero
     ) {
         int inset = resolveSafeBottomInset(systemBarsBottom, navigationBarsBottom, systemGesturesBottom, mandatoryGesturesBottom);
-        if (inset > 0 || !applyFallbackWhenZero || fallbackBottomInset <= 0) {
+        if (!applyFallbackWhenZero || fallbackBottomInset <= 0) {
             return inset;
         }
 
-        if (hasSideNavigationBarInsets(systemBarsLeft, systemBarsRight, navigationBarsLeft, navigationBarsRight)) {
-            return 0;
+        if (hasSideNavigationBarInsets(systemBarsLeft, systemBarsRight, navigationBarsLeft, navigationBarsRight, fallbackBottomInset)) {
+            return inset;
         }
 
-        return fallbackBottomInset;
+        return Math.max(inset, fallbackBottomInset);
     }
 
-    static boolean hasSideNavigationBarInsets(int systemBarsLeft, int systemBarsRight, int navigationBarsLeft, int navigationBarsRight) {
-        return systemBarsLeft > 0 || systemBarsRight > 0 || navigationBarsLeft > 0 || navigationBarsRight > 0;
+    static boolean hasSideNavigationBarInsets(
+        int systemBarsLeft,
+        int systemBarsRight,
+        int navigationBarsLeft,
+        int navigationBarsRight,
+        int minSideNavBarInset
+    ) {
+        if (minSideNavBarInset <= 0) {
+            return false;
+        }
+
+        return Math.max(systemBarsLeft, navigationBarsLeft) >= minSideNavBarInset
+            || Math.max(systemBarsRight, navigationBarsRight) >= minSideNavBarInset;
     }
 
     static int resolveBottomMargin(boolean enabledSafeBottomMargin, int safeBottomInset, int imeBottom) {

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupportTest.java
@@ -17,8 +17,20 @@ public class SafeAreaInsetsSupportTest {
     }
 
     @Test
-    public void safeBottomInsetIgnoresFallbackWhenInsetsArePresent() {
-        assertEquals(24, SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 16, 24, 8, 0, 0, 0, 0, 48, true));
+    public void safeBottomInsetKeepsReportedInsetWhenItMatchesNavigationBarHeight() {
+        assertEquals(24, SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 16, 24, 8, 0, 0, 0, 0, 24, true));
+    }
+
+    @Test
+    public void safeBottomInsetUsesFallbackWhenReportedInsetUndershootsNavigationBarHeight() {
+        assertEquals(48, SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 16, 24, 8, 0, 0, 0, 0, 48, true));
+        assertEquals(48, SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 0, 16, 8, 0, 0, 0, 0, 48, true));
+    }
+
+    @Test
+    public void safeBottomInsetUsesFallbackDespiteMinorHorizontalInsets() {
+        assertEquals(48, SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 0, 0, 0, 8, 0, 0, 0, 48, true));
+        assertEquals(48, SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(0, 0, 0, 0, 0, 12, 0, 0, 48, true));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- When `enabledSafeBottomMargin: true`, bottom inset now uses `max(reportedInsets, navigation_bar_height)` so dialog WebViews clear the Android system navigation bar even when window insets only report gesture-sized values or zero.
- Side-navigation detection now requires a significant horizontal inset (>= navigation bar height) so minor display-corner insets no longer disable the bottom fallback on portrait devices.

## Why
Fixes #580 / #576 follow-up: after #577, users still saw web content drawn behind the Android 3-button navigation bar because undersized non-zero gesture insets prevented the fallback, and any tiny horizontal inset incorrectly skipped it entirely.

## Test plan
- [x] `bun run verify:android`
- [ ] Open `https://pdf-download.onrender.com/` with `openWebView({ enabledSafeBottomMargin: true, activeNativeNavigationForWebview: true, useTopInset: true })` on Android 16 with 3-button navigation
- [ ] Confirm page bottom UI sits above the system navigation bar
- [ ] Confirm landscape side navigation bar still does not add an extra bottom gap


Made with [Cursor](https://cursor.com)