### PR TITLE
fix: pass through iOS custom dimension touches

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ The official Capacitor Browser plugin has strict security limitations that preve
 - **Camera and microphone access** within the browser context
 - **URL change monitoring** for navigation tracking
 - **Custom toolbars and UI** for branded experiences
-- **Cookie and cache management** for session control
-- **Custom sizes** for extra control of the display position
+- **Native browser layering** behind Ionic or Capacitor UI with input forwarding
+- **Partial-screen WebViews** with click-through areas outside the browser frame
+- **Cookie, cache, and full browsing-data controls** for private or isolated sessions
+- **Native proxy, download, and popup handling** for advanced embedded web apps
 
-Perfect for OAuth flows, embedded web apps, video calls, and any scenario requiring deep integration with web content.
+Perfect for OAuth flows, embedded web apps, checkout screens, browser-backed payment flows, video calls, support portals, and apps that need native UI around live web content.
 
 ## Documentation
 
@@ -73,6 +75,82 @@ import { InAppBrowser } from '@capgo/capacitor-inappbrowser';
 
 InAppBrowser.open({ url: 'YOUR_URL' });
 ```
+
+### Common use cases
+
+#### Show Ionic UI over a live browser page
+
+Use `toBack` when the native browser should stay visible behind your Ionic or Capacitor UI. This is useful for checkout overlays, payment confirmation panels, guided browser flows, or any flow where your app owns the controls while the web page remains loaded behind it.
+
+```js
+import { InAppBrowser } from '@capgo/capacitor-inappbrowser';
+
+const { id } = await InAppBrowser.openWebView({
+  url: 'https://example.com/checkout',
+  toBack: true,
+  transparentBackground: true,
+});
+
+// If your overlay needs to interact with the page behind it, forward the gesture.
+await InAppBrowser.dispatchInputEvent({
+  id,
+  type: 'click',
+  x: 160,
+  y: 420,
+});
+
+// Bring the browser back above the app when the native overlay is done.
+await InAppBrowser.bringToFront({ id });
+```
+
+Make the app background transparent wherever the browser should be visible. `dispatchInputEvent()` supports click, touch, and scroll forwarding; coordinates are relative to the browser viewport.
+
+#### Build a partial-screen browser or bottom sheet
+
+Use `height`, `width`, `x`, and `y` for picture-in-picture views, browser sheets, or layouts where the user should keep interacting with the Ionic app around the browser. When the WebView does not cover the full screen, touches outside the browser frame pass through to the underlying Capacitor WebView on Android and iOS.
+
+```js
+const bottomGap = 200;
+
+const { id } = await InAppBrowser.openWebView({
+  url: 'https://example.com/offers',
+  height: window.innerHeight - bottomGap,
+  y: 0,
+});
+```
+
+Use `updateDimensions()` to resize the browser while keeping the same page state, for example when expanding a mini browser into a larger sheet.
+
+#### Keep checkout, auth, or support sessions private
+
+Use `persistWebViewData: false` when a WebView must avoid persistent cookies, cache, local storage, IndexedDB, and other website data where the platform supports it. Use `clearAllBrowsingData()` when the app needs to wipe the default store and all opened managed WebViews.
+
+```js
+const { id } = await InAppBrowser.openWebView({
+  url: 'https://example.com/login',
+  persistWebViewData: false,
+});
+
+// Later, after logout or account switching:
+await InAppBrowser.clearAllBrowsingData();
+```
+
+#### Keep multiple browser instances ready
+
+Use `hidden`, `hide()`, and `show()` when you need to preload or preserve several WebViews without keeping them on screen. This keeps browser state available while the native modal is dismissed so it does not block touches in the app.
+
+```js
+const first = await InAppBrowser.openWebView({ url: 'https://example.com/a', hidden: true });
+const second = await InAppBrowser.openWebView({ url: 'https://example.com/b', hidden: true });
+
+await InAppBrowser.show({ id: first.id });
+await InAppBrowser.hide({ id: first.id });
+await InAppBrowser.show({ id: second.id });
+```
+
+#### Embed advanced web app flows
+
+Use proxy rules and `handleDownloads` for web apps that need request control, file uploads, downloads, or controlled popup behavior inside the managed browser. Typical examples include document portals, support desks, payment pages, Google Pay flows on Android, and apps that need to keep `_blank` links inside the same managed WebView.
 
 ### Customize Chrome Custom Tab Appearance (Android)
 

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -1382,6 +1382,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
                 containerView.backgroundColor = .clear
                 containerView.frame = UIScreen.main.bounds
                 containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+                containerView.passthroughView = self.bridge?.webView
 
                 let targetFrame = CustomWebViewFrameSupport.resolvedFrame(
                     width: width.map { CGFloat($0) },

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -3266,6 +3266,7 @@ class PassThroughView: UIView {
         }
     }
     weak var framedContentView: UIView?
+    weak var passthroughView: UIView?
 
     override func layoutSubviews() {
         super.layoutSubviews()
@@ -3278,14 +3279,14 @@ class PassThroughView: UIView {
     }
 
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        // If we have a target frame and the touch is outside it, pass through
-        if let frame = targetFrame {
-            if !frame.contains(point) {
-                return nil  // Pass through to underlying views
+        if let frame = targetFrame, !frame.contains(point) {
+            guard let passthroughView else {
+                return nil
             }
+            let convertedPoint = convert(point, to: passthroughView)
+            return passthroughView.hitTest(convertedPoint, with: event)
         }
 
-        // Otherwise, handle normally
         return super.hitTest(point, with: event)
     }
 }

--- a/ios/Tests/InAppBrowserPluginTests/InAppBrowserPluginTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/InAppBrowserPluginTests.swift
@@ -71,6 +71,25 @@ final class InAppBrowserPluginTests: XCTestCase {
         XCTAssertEqual(contentView.frame, targetFrame)
     }
 
+    func testPassThroughViewRoutesTouchesOutsideTargetFrameToUnderlyingView() {
+        let container = PassThroughView(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        let contentView = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 600))
+        let underlyingView = UIView(frame: container.bounds)
+        let underlyingButton = UIView(frame: CGRect(x: 12, y: 700, width: 80, height: 48))
+
+        underlyingView.addSubview(underlyingButton)
+        container.addSubview(contentView)
+        container.framedContentView = contentView
+        container.targetFrame = contentView.frame
+        container.passthroughView = underlyingView
+
+        let outsideHit = container.hitTest(CGPoint(x: 24, y: 712), with: nil)
+        let insideHit = container.hitTest(CGPoint(x: 24, y: 120), with: nil)
+
+        XCTAssertTrue(outsideHit === underlyingButton)
+        XCTAssertTrue(insideHit === contentView)
+    }
+
     func testViewportRefreshIgnoresZeroSizeBeforeLayout() {
         XCTAssertFalse(
             WebViewViewportLayoutSupport.shouldRefreshViewport(


### PR DESCRIPTION
## What
- Routes touches outside an iOS custom-dimension in-app browser frame to the underlying Capacitor WebView.
- Adds a Swift regression test for the pass-through hit-test behavior.
- Updates the README with common managed WebView use cases: UI layering, partial-screen pass-through, private sessions, hidden instances, and advanced embedded web app flows.

## Why
- A non-fullscreen iOS browser could visually reveal the Ionic app behind it while still swallowing taps in the transparent area.
- Android already lets the uncovered app area receive input, so iOS should match that behavior where the browser is not covering the point.
- The README needed to describe the recent InAppBrowser capabilities as practical patterns for users.

## How
- Stores the Capacitor host WebView on the pass-through presentation wrapper.
- When a touch is outside the browser target frame, converts the point into the host WebView and returns its hit target instead of returning nil to UIKit's modal container.
- Adds README examples for `toBack`, `transparentBackground`, `dispatchInputEvent()`, custom dimensions, `persistWebViewData`, `clearAllBrowsingData()`, `hidden`, `hide()`, `show()`, proxy rules, downloads, and popup handling.

## Testing
- `bun run fmt`
- `bun run verify:ios`
- `xcodebuild test -scheme CapgoCapacitorInappbrowser -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- `bun run verify`

## Not Tested
- Manual test in the customer's Ionic app.
