### PR TITLE
fix(android): skip proxy-bridge injection for rule-based proxy

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupport.java
@@ -59,7 +59,7 @@ final class ProxyRequestSupport {
     private ProxyRequestSupport() {}
 
     static boolean shouldInjectBridge(Options options) {
-        return options != null && options.shouldEnableNativeProxy();
+        return options != null && usesLegacyJsProxyMode(options);
     }
 
     static boolean usesLegacyJsProxyMode(Options options) {

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupportTest.java
@@ -19,13 +19,13 @@ import org.junit.Test;
 public class ProxyRequestSupportTest {
 
     @Test
-    public void shouldInjectBridgeWhenRulesEnableNativeProxy() {
+    public void shouldNotInjectBridgeWhenOnlyOutboundInboundRules() {
         Options options = new Options();
         options.setOutboundProxyRules(
             List.of(new NativeProxyRule(null, null, null, null, null, null, null, null, false, NativeProxyRule.Action.DELEGATE_TO_JS))
         );
 
-        assertTrue(ProxyRequestSupport.shouldInjectBridge(options));
+        assertFalse(ProxyRequestSupport.shouldInjectBridge(options));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Gate `proxy-bridge.js` injection on `usesLegacyJsProxyMode` instead of `shouldEnableNativeProxy`, so outbound/inbound rule configs no longer monkey-patch every page `fetch`/`XHR`.
- Update `ProxyRequestSupportTest` to assert the bridge is not injected when only rule-based proxy is enabled.

Fixes #555

## Test plan
- [x] `bun run verify` (iOS, Android Gradle test/lint, web)
- [ ] Manual: open WebView with `inboundProxyRules` only; confirm `window.fetch` is native and non-matching URLs are not routed via `/_capgo_proxy_`
- [ ] Manual: legacy `proxyRequests` / `proxyRequestsPattern` still injects bridge and proxies matching URLs


Made with [Cursor](https://cursor.com)