### PR TITLE
fix(android): ignore subframe errors when debugging WebView

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -5283,8 +5283,13 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                     if (view == null || _webView == null) {
                         return;
                     }
-                    _options.getCallbacks().pageLoadError();
-                    if (request != null && request.isForMainFrame() && !isInitialized) {
+                    if (request == null || !request.isForMainFrame()) {
+                        return;
+                    }
+                    if (_options.getCallbacks() != null) {
+                        _options.getCallbacks().pageLoadError();
+                    }
+                    if (!isInitialized) {
                         CharSequence description = error != null ? error.getDescription() : null;
                         String message = description != null ? "Initial page load failed: " + description : "Initial page load failed";
                         rejectOpenWebViewIfNeeded(message);


### PR DESCRIPTION
## Summary
- Only emit `pageLoadError` from `onReceivedError` for main-frame navigations on Android.
- Avoids false positives when attaching Chrome DevTools via `chrome://inspect`, which triggers subresource load errors in the WebView.
- Aligns Android behavior with iOS, where `pageLoadError` is tied to main navigation failures.

Fixes #517

## Test plan
- [x] `bun run verify`
- [ ] Open an InAppBrowser WebView on Android, attach Chrome DevTools from `chrome://inspect`, confirm no `pageLoadError` event fires for the same `webViewId`.
- [ ] Load a URL that truly fails at the document level and confirm `pageLoadError` still fires.


Made with [Cursor](https://cursor.com)