### PR TITLE
fix(android): display proxied SVG assets correctly

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupport.java
@@ -3,6 +3,7 @@ package ee.forgr.capacitor_inappbrowser;
 import com.getcapacitor.JSObject;
 import java.io.IOException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
@@ -21,6 +22,8 @@ final class ProxyRequestSupport {
     record WebResourceResponseMetadata(String mimeType, String encoding) {}
 
     record ParsedResponseHeaders(Map<String, String> responseHeaders, List<String> cookieHeaders) {}
+
+    record ProxiedResponseMetadata(String contentType, Map<String, String> headers) {}
 
     static final int SYNTHETIC_NATIVE_FAILURE_STATUS = 599;
     static final String SYNTHETIC_NATIVE_FAILURE_HEADER = "X-Capgo-Proxy-Error";
@@ -405,14 +408,162 @@ final class ProxyRequestSupport {
         return new WebResourceResponseMetadata(mimeType, encoding);
     }
 
+    static ProxiedResponseMetadata normalizeProxiedResponseMetadata(
+        String contentType,
+        Map<String, String> responseHeaders,
+        String requestUrl
+    ) {
+        Map<String, String> headers = responseHeaders != null ? new LinkedHashMap<>(responseHeaders) : new LinkedHashMap<>();
+        String headerContentType = findHeaderIgnoreCase(headers, "Content-Type");
+        String resolvedContentType = resolveProxiedContentType(firstNonEmpty(contentType, headerContentType), requestUrl);
+        if (resolvedContentType == null || resolvedContentType.isBlank()) {
+            resolvedContentType = "application/octet-stream";
+        }
+        if (!hasHeaderIgnoreCase(headers, "Content-Type")) {
+            headers.put("Content-Type", resolvedContentType);
+        }
+        return new ProxiedResponseMetadata(resolvedContentType, headers);
+    }
+
     static WebResourceResponseMetadata resolveWebResourceResponseConstructorMetadata(
         String contentType,
         Map<String, String> responseHeaders
     ) {
-        if (hasHeaderIgnoreCase(responseHeaders, "Content-Type")) {
+        String headerContentType = findHeaderIgnoreCase(responseHeaders, "Content-Type");
+        if (headerContentType != null && shouldDeferConstructorMimeTypeToContentTypeHeader(headerContentType)) {
             return new WebResourceResponseMetadata(null, null);
         }
         return resolveWebResourceResponseMetadata(contentType, responseHeaders);
+    }
+
+    static String resolveProxiedContentType(String contentType, String requestUrl) {
+        String mimeOnly = extractMimeType(contentType);
+        if (mimeOnly != null && !mimeOnly.isBlank() && !isGenericProxiedMimeType(mimeOnly)) {
+            if (shouldNormalizeSvgContentType(requestUrl, mimeOnly)) {
+                return "image/svg+xml";
+            }
+            return contentType.trim();
+        }
+
+        String guessedContentType = guessContentTypeFromRequestUrl(requestUrl);
+        if (guessedContentType != null) {
+            return guessedContentType;
+        }
+
+        return contentType != null && !contentType.isBlank() ? contentType.trim() : null;
+    }
+
+    static String guessContentTypeFromRequestUrl(String requestUrl) {
+        if (requestUrl == null || requestUrl.isBlank()) {
+            return null;
+        }
+
+        String fileName;
+        try {
+            fileName = new URL(requestUrl).getPath();
+        } catch (Exception error) {
+            return null;
+        }
+        if (fileName == null || fileName.isBlank()) {
+            return null;
+        }
+
+        int slashIndex = fileName.lastIndexOf('/');
+        if (slashIndex >= 0) {
+            fileName = fileName.substring(slashIndex + 1);
+        }
+        if (fileName.isBlank()) {
+            return null;
+        }
+
+        String guessedType = URLConnection.guessContentTypeFromName(fileName);
+        if (guessedType != null && !guessedType.isBlank()) {
+            return guessedType;
+        }
+
+        int dotIndex = fileName.lastIndexOf('.');
+        if (dotIndex < 0 || dotIndex == fileName.length() - 1) {
+            return null;
+        }
+        String extension = fileName.substring(dotIndex + 1).toLowerCase(Locale.US);
+        return switch (extension) {
+            case "svg" -> "image/svg+xml";
+            case "png" -> "image/png";
+            case "jpg", "jpeg" -> "image/jpeg";
+            case "gif" -> "image/gif";
+            case "webp" -> "image/webp";
+            case "pdf" -> "application/pdf";
+            case "json" -> "application/json";
+            case "txt" -> "text/plain";
+            case "csv" -> "text/csv";
+            case "html", "htm" -> "text/html";
+            case "xhtml" -> "application/xhtml+xml";
+            default -> null;
+        };
+    }
+
+    private static boolean shouldNormalizeSvgContentType(String requestUrl, String mimeType) {
+        if (!"svg".equalsIgnoreCase(fileExtensionFromRequestUrl(requestUrl))) {
+            return false;
+        }
+        String normalizedMimeType = mimeType.toLowerCase(Locale.US);
+        return (
+            isGenericProxiedMimeType(normalizedMimeType) ||
+            "text/xml".equals(normalizedMimeType) ||
+            "application/xml".equals(normalizedMimeType)
+        );
+    }
+
+    private static String fileExtensionFromRequestUrl(String requestUrl) {
+        if (requestUrl == null || requestUrl.isBlank()) {
+            return "";
+        }
+        try {
+            String path = new URL(requestUrl).getPath();
+            if (path == null || path.isBlank()) {
+                return "";
+            }
+            int slashIndex = path.lastIndexOf('/');
+            String fileName = slashIndex >= 0 ? path.substring(slashIndex + 1) : path;
+            int dotIndex = fileName.lastIndexOf('.');
+            if (dotIndex < 0 || dotIndex == fileName.length() - 1) {
+                return "";
+            }
+            return fileName.substring(dotIndex + 1);
+        } catch (Exception error) {
+            return "";
+        }
+    }
+
+    private static String extractMimeType(String contentType) {
+        if (contentType == null || contentType.isBlank()) {
+            return null;
+        }
+        String mimeType = contentType.split(";")[0].trim();
+        return mimeType.isEmpty() ? null : mimeType;
+    }
+
+    private static boolean isGenericProxiedMimeType(String mimeType) {
+        if (mimeType == null || mimeType.isBlank()) {
+            return true;
+        }
+        String normalizedMimeType = mimeType.trim().toLowerCase(Locale.US);
+        return (
+            normalizedMimeType.equals("application/octet-stream") ||
+            normalizedMimeType.equals("binary/octet-stream") ||
+            normalizedMimeType.equals("application/download") ||
+            normalizedMimeType.equals("application/x-download") ||
+            normalizedMimeType.equals("application/binary") ||
+            normalizedMimeType.equals("application/x-binary")
+        );
+    }
+
+    private static boolean shouldDeferConstructorMimeTypeToContentTypeHeader(String contentTypeHeader) {
+        String mimeType = extractMimeType(contentTypeHeader);
+        if (mimeType == null) {
+            return false;
+        }
+        return mimeType.toLowerCase(Locale.US).startsWith("multipart/");
     }
 
     static ParsedResponseHeaders splitResponseHeaders(Map<String, List<String>> rawHeaders) {
@@ -831,6 +982,9 @@ final class ProxyRequestSupport {
             return false;
         }
         String normalizedMimeType = mimeType.trim().toLowerCase(Locale.US);
+        if (normalizedMimeType.startsWith("image/")) {
+            return false;
+        }
         return (
             normalizedMimeType.startsWith("text/") ||
             normalizedMimeType.equals("application/json") ||

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -6135,7 +6135,18 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                 contentType = conn.getContentType();
             }
 
-            return new NativeResponseData(status, contentType, responseHeaders, bodyBytes);
+            ProxyRequestSupport.ProxiedResponseMetadata normalizedResponse = ProxyRequestSupport.normalizeProxiedResponseMetadata(
+                contentType,
+                responseHeaders,
+                requestContext.url
+            );
+
+            return new NativeResponseData(
+                status,
+                normalizedResponse.contentType(),
+                normalizedResponse.headers(),
+                bodyBytes
+            );
         } finally {
             conn.disconnect();
         }
@@ -6261,14 +6272,21 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                     if (contentType == null) {
                         contentType = responseHeaders.get("Content-Type");
                     }
-                    if (contentType == null) {
-                        contentType = "application/octet-stream";
-                    }
+                    ProxyRequestSupport.ProxiedResponseMetadata normalizedResponse = ProxyRequestSupport.normalizeProxiedResponseMetadata(
+                        contentType,
+                        responseHeaders,
+                        proxiedRequest.requestContext != null ? proxiedRequest.requestContext.url : null
+                    );
 
                     if (status < 100 || status > 599) {
                         status = 200;
                     }
-                    proxiedRequest.nativeResponse = new NativeResponseData(status, contentType, responseHeaders, bodyBytes);
+                    proxiedRequest.nativeResponse = new NativeResponseData(
+                        status,
+                        normalizedResponse.contentType(),
+                        normalizedResponse.headers(),
+                        bodyBytes
+                    );
                     proxiedRequest.response = buildWebResourceResponse(proxiedRequest.nativeResponse);
                 }
             } catch (IOException invalidBodyError) {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -6141,12 +6141,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                 requestContext.url
             );
 
-            return new NativeResponseData(
-                status,
-                normalizedResponse.contentType(),
-                normalizedResponse.headers(),
-                bodyBytes
-            );
+            return new NativeResponseData(status, normalizedResponse.contentType(), normalizedResponse.headers(), bodyBytes);
         } finally {
             conn.disconnect();
         }

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupportTest.java
@@ -429,11 +429,43 @@ public class ProxyRequestSupportTest {
         assertNull(metadata.mimeType());
         assertNull(metadata.encoding());
 
+        ProxyRequestSupport.WebResourceResponseMetadata svgMetadata = ProxyRequestSupport.resolveWebResourceResponseConstructorMetadata(
+            "image/svg+xml",
+            Map.of("Content-Type", "image/svg+xml")
+        );
+
+        assertEquals("image/svg+xml", svgMetadata.mimeType());
+        assertNull(svgMetadata.encoding());
+
         ProxyRequestSupport.WebResourceResponseMetadata fallbackMetadata =
             ProxyRequestSupport.resolveWebResourceResponseConstructorMetadata("text/html; charset=utf-8", Map.of());
 
         assertEquals("text/html", fallbackMetadata.mimeType());
         assertEquals("utf-8", fallbackMetadata.encoding());
+    }
+
+    @Test
+    public void normalizeProxiedResponseMetadataInfersSvgContentTypeFromRequestUrl() {
+        ProxyRequestSupport.ProxiedResponseMetadata metadata = ProxyRequestSupport.normalizeProxiedResponseMetadata(
+            null,
+            Map.of(),
+            "https://example.com/assets/default-logo.svg"
+        );
+
+        assertEquals("image/svg+xml", metadata.contentType());
+        assertEquals("image/svg+xml", metadata.headers().get("Content-Type"));
+    }
+
+    @Test
+    public void normalizeProxiedResponseMetadataNormalizesGenericSvgXmlContentType() {
+        ProxyRequestSupport.ProxiedResponseMetadata metadata = ProxyRequestSupport.normalizeProxiedResponseMetadata(
+            "text/xml",
+            Map.of("Content-Type", "text/xml"),
+            "https://example.com/assets/default-logo.svg"
+        );
+
+        assertEquals("image/svg+xml", metadata.contentType());
+        assertEquals("text/xml", metadata.headers().get("Content-Type"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Normalize passthrough proxy response content types from request URLs so `.svg` assets resolve to `image/svg+xml` instead of generic octet-stream/XML types.
- Build `WebResourceResponse` with explicit image MIME metadata (no UTF-8 encoding for `image/svg+xml`) while still deferring constructor MIME only for `multipart/*` responses.

## Why
Fixes #547 — Android WebView did not render `<img src="...svg">` when proxy handlers passthrough native responses.

## Test plan
- [x] `bun run verify`
- [ ] Manual: open WebView with proxy passthrough and confirm SVG logo renders on Android


Made with [Cursor](https://cursor.com)