### PR TITLE
fix(android): keep proxy interceptors working offline (#551)

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupport.java
@@ -109,6 +109,27 @@ final class ProxyRequestSupport {
         return !usesLegacyJsProxyMode(options) || matchesProxyRequestsPattern(options.getProxyRequestsPattern(), requestUrl);
     }
 
+    static boolean shouldBootstrapInitialProxyLoad(Options options) {
+        if (options == null || options.isPopupWindowMode()) {
+            return false;
+        }
+        String initialUrl = options.getUrl();
+        if (initialUrl == null || initialUrl.isBlank()) {
+            return false;
+        }
+        if (!options.shouldEnableNativeProxy()) {
+            return false;
+        }
+        if (shouldDelegateLegacyJsProxyRequest(options, initialUrl)) {
+            return true;
+        }
+        return shouldHandleNonBridgeRequest(options, initialUrl) && !usesLegacyJsProxyMode(options);
+    }
+
+    static boolean shouldReturnSyntheticNativeFailure(boolean bridgeBackedRequest, Options options, String requestUrl) {
+        return bridgeBackedRequest || shouldHandleNonBridgeRequest(options, requestUrl);
+    }
+
     static boolean isBridgeMarkerRequestUrl(String requestUrl) {
         if (requestUrl == null || requestUrl.isBlank()) {
             return false;

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -5027,7 +5027,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                             nativeResponse = performNativeRequest(requestContext);
                         } catch (IOException error) {
                             Log.e("InAppBrowserProxy", "Native request failed for: " + requestContext.url, error);
-                            return bridgeBackedRequest ? createNativeFailureResponse(requestContext.url, error) : null;
+                            return createProxiedNativeFailureResponse(requestContext.url, bridgeBackedRequest, error);
                         }
                     }
 
@@ -5040,7 +5040,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                                 redirectReplay = followRedirectForWebView(requestContext, nativeResponse, redirectsFollowed);
                             } catch (IOException error) {
                                 Log.e("InAppBrowserProxy", "Native redirect replay failed for: " + requestContext.url, error);
-                                return bridgeBackedRequest ? createNativeFailureResponse(requestContext.url, error) : null;
+                                return createProxiedNativeFailureResponse(requestContext.url, bridgeBackedRequest, error);
                             }
                             if (redirectReplay != null) {
                                 requestContext = redirectReplay.requestContext;
@@ -5103,7 +5103,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                             redirectReplay = followRedirectForWebView(requestContext, nativeResponse, redirectsFollowed);
                         } catch (IOException error) {
                             Log.e("InAppBrowserProxy", "Native redirect replay failed for: " + requestContext.url, error);
-                            return bridgeBackedRequest ? createNativeFailureResponse(requestContext.url, error) : null;
+                            return createProxiedNativeFailureResponse(requestContext.url, bridgeBackedRequest, error);
                         }
                         if (redirectReplay != null) {
                             requestContext = redirectReplay.requestContext;
@@ -5768,10 +5768,29 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
     }
 
     private boolean shouldBootstrapInitialLegacyProxyLoad() {
-        if (_options == null || _options.isPopupWindowMode()) {
-            return false;
+        return ProxyRequestSupport.shouldBootstrapInitialProxyLoad(_options);
+    }
+
+    private void loadInitialUrlDirect(Map<String, String> requestHeaders, String httpMethod, String httpBody) {
+        if (_webView == null || _options == null) {
+            return;
         }
-        return ProxyRequestSupport.shouldDelegateLegacyJsProxyRequest(_options, _options.getUrl());
+
+        Map<String, String> headers = requestHeaders != null ? requestHeaders : new HashMap<>();
+        if (supportsRequestBody(httpMethod) && httpBody != null) {
+            byte[] postData = httpBody.getBytes(StandardCharsets.UTF_8);
+            _webView.postUrl(_options.getUrl(), postData);
+            if (!headers.isEmpty()) {
+                Log.w(
+                    "InAppBrowser",
+                    "Custom headers were provided but may not be sent with POST request. " +
+                        "Android WebView's postUrl method has limited header support."
+                );
+            }
+            return;
+        }
+
+        _webView.loadUrl(_options.getUrl(), headers);
     }
 
     private void loadInitialLegacyProxyContent(Map<String, String> requestHeaders, String httpMethod, String httpBody) {
@@ -5802,7 +5821,10 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
 
                 NativeResponseData responseData = proxyResult.responseData;
                 if (responseData == null || !canBootstrapHtmlResponse(responseData.contentType)) {
-                    rejectOpenWebViewIfNeeded("Initial legacy proxy request did not return bootstrap HTML");
+                    if (_webView == null) {
+                        return;
+                    }
+                    _webView.post(() -> loadInitialUrlDirect(initialHeaders, initialMethod, httpBody));
                     return;
                 }
 
@@ -5826,7 +5848,19 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                 });
             } catch (IOException error) {
                 Log.e("InAppBrowserProxy", "Initial legacy proxy bootstrap failed for: " + initialUrl, error);
-                rejectOpenWebViewIfNeeded("Initial legacy proxy bootstrap failed: " + error.getMessage());
+                if (_webView == null) {
+                    return;
+                }
+                String failureBody = new String(
+                    ProxyRequestSupport.createNativeRequestFailureBody(initialUrl, error),
+                    StandardCharsets.UTF_8
+                );
+                _webView.post(() -> {
+                    if (_webView == null) {
+                        return;
+                    }
+                    _webView.loadDataWithBaseURL(initialUrl, failureBody, "text/plain", "utf-8", initialUrl);
+                });
             }
         });
     }
@@ -5971,6 +6005,17 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         response.setStatusCodeAndReasonPhrase(204, "No Content");
         response.setResponseHeaders(new HashMap<>());
         return response;
+    }
+
+    private WebResourceResponse createProxiedNativeFailureResponse(
+        String requestUrl,
+        boolean bridgeBackedRequest,
+        IOException error
+    ) {
+        if (!ProxyRequestSupport.shouldReturnSyntheticNativeFailure(bridgeBackedRequest, _options, requestUrl)) {
+            return null;
+        }
+        return createNativeFailureResponse(requestUrl, error);
     }
 
     private WebResourceResponse createNativeFailureResponse(String requestUrl, IOException error) {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -6007,11 +6007,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         return response;
     }
 
-    private WebResourceResponse createProxiedNativeFailureResponse(
-        String requestUrl,
-        boolean bridgeBackedRequest,
-        IOException error
-    ) {
+    private WebResourceResponse createProxiedNativeFailureResponse(String requestUrl, boolean bridgeBackedRequest, IOException error) {
         if (!ProxyRequestSupport.shouldReturnSyntheticNativeFailure(bridgeBackedRequest, _options, requestUrl)) {
             return null;
         }

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupportTest.java
@@ -303,27 +303,9 @@ public class ProxyRequestSupportTest {
             List.of(new NativeProxyRule(null, null, null, null, null, null, null, null, false, NativeProxyRule.Action.CONTINUE))
         );
 
-        assertTrue(
-            ProxyRequestSupport.shouldReturnSyntheticNativeFailure(
-                false,
-                options,
-                "https://example.com/main"
-            )
-        );
-        assertFalse(
-            ProxyRequestSupport.shouldReturnSyntheticNativeFailure(
-                false,
-                new Options(),
-                "https://example.com/main"
-            )
-        );
-        assertTrue(
-            ProxyRequestSupport.shouldReturnSyntheticNativeFailure(
-                true,
-                new Options(),
-                "https://example.com/main"
-            )
-        );
+        assertTrue(ProxyRequestSupport.shouldReturnSyntheticNativeFailure(false, options, "https://example.com/main"));
+        assertFalse(ProxyRequestSupport.shouldReturnSyntheticNativeFailure(false, new Options(), "https://example.com/main"));
+        assertTrue(ProxyRequestSupport.shouldReturnSyntheticNativeFailure(true, new Options(), "https://example.com/main"));
     }
 
     @Test

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupportTest.java
@@ -268,6 +268,65 @@ public class ProxyRequestSupportTest {
     }
 
     @Test
+    public void shouldBootstrapInitialProxyLoadForNativeRules() {
+        Options options = new Options();
+        options.setUrl("https://example.com/app");
+        options.setOutboundProxyRules(
+            List.of(new NativeProxyRule(null, null, null, null, null, null, null, null, false, NativeProxyRule.Action.CONTINUE))
+        );
+
+        assertTrue(ProxyRequestSupport.shouldBootstrapInitialProxyLoad(options));
+    }
+
+    @Test
+    public void shouldBootstrapInitialProxyLoadForLegacyRegexMatches() {
+        Options options = new Options();
+        options.setUrl("https://api.example.com/app");
+        options.setProxyRequestsPattern(Pattern.compile("api\\.example\\.com"));
+
+        assertTrue(ProxyRequestSupport.shouldBootstrapInitialProxyLoad(options));
+    }
+
+    @Test
+    public void shouldNotBootstrapInitialProxyLoadWhenLegacyRegexMisses() {
+        Options options = new Options();
+        options.setUrl("https://cdn.example.com/app");
+        options.setProxyRequestsPattern(Pattern.compile("api\\.example\\.com"));
+
+        assertFalse(ProxyRequestSupport.shouldBootstrapInitialProxyLoad(options));
+    }
+
+    @Test
+    public void shouldReturnSyntheticNativeFailureForHandledNonBridgeRequests() {
+        Options options = new Options();
+        options.setOutboundProxyRules(
+            List.of(new NativeProxyRule(null, null, null, null, null, null, null, null, false, NativeProxyRule.Action.CONTINUE))
+        );
+
+        assertTrue(
+            ProxyRequestSupport.shouldReturnSyntheticNativeFailure(
+                false,
+                options,
+                "https://example.com/main"
+            )
+        );
+        assertFalse(
+            ProxyRequestSupport.shouldReturnSyntheticNativeFailure(
+                false,
+                new Options(),
+                "https://example.com/main"
+            )
+        );
+        assertTrue(
+            ProxyRequestSupport.shouldReturnSyntheticNativeFailure(
+                true,
+                new Options(),
+                "https://example.com/main"
+            )
+        );
+    }
+
+    @Test
     public void shouldHandleNonBridgeRequestKeepsNativeRulesActiveWhenLegacyRegexMisses() {
         Options options = new Options();
         options.setProxyRequestsPattern(Pattern.compile("api\\.example\\.com"));


### PR DESCRIPTION
## Summary
- Bootstrap initial WebView loads for native proxy rules so the `proxyRequest` interceptor runs before native replay (same path legacy proxy already used).
- Return synthetic native failure responses for proxied non-bridge requests when network replay fails, instead of falling back to the WebView network error page.
- Fall back to direct WebView loading when bootstrap content is non-HTML, and surface bootstrap network failures via `loadDataWithBaseURL` instead of rejecting `openWebView`.

Fixes #551

## Test plan
- [x] `bun run verify`
- [ ] Manual: open a proxied WebView with native rules, disable network, confirm `proxyRequest` fires on initial load and cached interceptor response is shown
- [ ] Manual: confirm online passthrough still loads remote HTML when the interceptor returns null


Made with [Cursor](https://cursor.com)