### PR TITLE
fix(proxy): parallel proxy request throughput (#548)

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
@@ -51,6 +51,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.regex.PatternSyntaxException;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -65,6 +67,15 @@ import org.json.JSONObject;
     requestCodes = { WebViewDialog.FILE_CHOOSER_REQUEST_CODE }
 )
 public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.PermissionHandler {
+
+    private static final ExecutorService PROXY_RESPONSE_EXECUTOR = Executors.newFixedThreadPool(
+        Math.max(4, Runtime.getRuntime().availableProcessors()),
+        runnable -> {
+            Thread thread = new Thread(runnable, "CapgoInAppBrowser-ProxyResponse");
+            thread.setDaemon(true);
+            return thread;
+        }
+    );
 
     private final String pluginVersion = "8.6.17";
 
@@ -1684,8 +1695,10 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
             return;
         }
 
-        dialog.handleProxyResponse(requestId, decision);
-        call.resolve();
+        PROXY_RESPONSE_EXECUTOR.execute(() -> {
+            dialog.handleProxyResponse(requestId, decision);
+            call.resolve();
+        });
     }
 
     @PluginMethod

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
@@ -50,9 +50,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.regex.Pattern;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -70,7 +70,7 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
 
     private static final ExecutorService PROXY_RESPONSE_EXECUTOR = Executors.newFixedThreadPool(
         Math.max(4, Runtime.getRuntime().availableProcessors()),
-        runnable -> {
+        (runnable) -> {
             Thread thread = new Thread(runnable, "CapgoInAppBrowser-ProxyResponse");
             thread.setDaemon(true);
             return thread;

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyBridge.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyBridge.java
@@ -58,11 +58,10 @@ public class ProxyBridge {
         if (requestId == null) {
             return null;
         }
-        StoredRequest storedRequest = storedRequests.remove(requestId);
-        if (storedRequest != null) {
-            storedRequestOrder.remove(requestId);
-        }
-        return storedRequest;
+        // Do not scan storedRequestOrder here: ConcurrentLinkedQueue.remove is O(n) and
+        // serializes parallel bridge-backed proxy requests. Stale queue ids are purged lazily
+        // in cleanupExpiredRequests().
+        return storedRequests.remove(requestId);
     }
 
     private void cleanupExpiredRequests(long now) {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -334,12 +334,13 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
     private boolean datePickerInjected = false; // Track if we've injected date picker fixes
     private final WebView capacitorWebView;
     private String instanceId = "";
-    private final Map<String, ProxiedRequest> proxiedRequestsHashmap = new HashMap<>();
+    private final Map<String, ProxiedRequest> proxiedRequestsHashmap = new ConcurrentHashMap<>();
     private ProxyBridge proxyBridge;
     private String proxyBridgeScript;
     private String proxyAccessToken;
     private final ExecutorService executorService = Executors.newCachedThreadPool();
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private final AtomicBoolean cookieFlushScheduled = new AtomicBoolean(false);
     private final Map<String, BlobDownloadSession> blobDownloadSessions = new ConcurrentHashMap<>();
     private final Map<String, ClientCertificateIdentity> clientCertificateIdentities = new ConcurrentHashMap<>();
     private int iconColor = Color.BLACK; // Default icon color
@@ -4906,7 +4907,9 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                         }
                         String initiatorUrl = request.getRequestHeaders().get("Referer");
                         if (initiatorUrl == null || initiatorUrl.isBlank()) {
-                            initiatorUrl = getWebViewUrlOnMainThread(originalUrl);
+                            initiatorUrl = getWebViewUrlOrFallback(
+                                _options != null && _options.getUrl() != null ? _options.getUrl() : originalUrl
+                            );
                         }
                         String targetCookies = CookieManager.getInstance().getCookie(originalUrl);
                         if (
@@ -5538,9 +5541,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         shutdownExecutorServiceAsync();
 
         // Clear any remaining proxied requests
-        synchronized (proxiedRequestsHashmap) {
-            proxiedRequestsHashmap.clear();
-        }
+        proxiedRequestsHashmap.clear();
 
         try {
             super.dismiss();
@@ -6155,15 +6156,22 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             wroteCookie = true;
         }
         if (wroteCookie) {
-            cookieManager.flush();
+            scheduleCookieFlush();
         }
     }
 
-    public void handleProxyResponse(String requestId, JSObject response) {
-        ProxiedRequest proxiedRequest;
-        synchronized (proxiedRequestsHashmap) {
-            proxiedRequest = proxiedRequestsHashmap.get(requestId);
+    private void scheduleCookieFlush() {
+        if (!cookieFlushScheduled.compareAndSet(false, true)) {
+            return;
         }
+        mainHandler.post(() -> {
+            cookieFlushScheduled.set(false);
+            CookieManager.getInstance().flush();
+        });
+    }
+
+    public void handleProxyResponse(String requestId, JSObject response) {
+        ProxiedRequest proxiedRequest = proxiedRequestsHashmap.get(requestId);
         if (proxiedRequest == null) {
             Log.e("InAppBrowserProxy", "No pending request for id: " + requestId);
             return;
@@ -6175,9 +6183,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         }
 
         if (response == null) {
-            synchronized (proxiedRequestsHashmap) {
-                proxiedRequestsHashmap.remove(requestId);
-            }
+            proxiedRequestsHashmap.remove(requestId);
             proxiedRequest.semaphore.release();
             return;
         }
@@ -6279,17 +6285,13 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             }
         }
 
-        synchronized (proxiedRequestsHashmap) {
-            proxiedRequestsHashmap.remove(requestId);
-        }
+        proxiedRequestsHashmap.remove(requestId);
         proxiedRequest.semaphore.release();
     }
 
     @Override
     public boolean hasPendingProxyRequest(String requestId) {
-        synchronized (proxiedRequestsHashmap) {
-            return proxiedRequestsHashmap.containsKey(requestId);
-        }
+        return proxiedRequestsHashmap.containsKey(requestId);
     }
 
     private void shareUrl() {

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/ProxyBridgeTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/ProxyBridgeTest.java
@@ -21,6 +21,19 @@ public class ProxyBridgeTest {
     }
 
     @Test
+    public void getAndRemoveDoesNotRequireQueueRemoval() {
+        ProxyBridge bridge = new ProxyBridge("token");
+
+        for (int index = 0; index < 512; index += 1) {
+            bridge.storeRequest("token", "request-" + index, "GET", "{}", "", "same-origin");
+        }
+
+        for (int index = 0; index < 512; index += 1) {
+            assertNotNull(bridge.getAndRemove("request-" + index));
+        }
+    }
+
+    @Test
     public void storeRequestDropsExpiredPayloadsBeforeAddingNewOnes() {
         AtomicLong now = new AtomicLong(1_000L);
         ProxyBridge bridge = new ProxyBridge("token", now::get);

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -2129,7 +2129,9 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
             responseDict = dict
         }
 
-        proxyHandler.handleResponse(requestId: requestId, phase: phase, responseData: responseDict)
+        DispatchQueue.global(qos: .userInitiated).async { [proxyHandler] in
+            proxyHandler.handleResponse(requestId: requestId, phase: phase, responseData: responseDict)
+        }
         call.resolve()
     }
 

--- a/ios/Sources/InAppBrowserPlugin/ProxyBridge.swift
+++ b/ios/Sources/InAppBrowserPlugin/ProxyBridge.swift
@@ -51,11 +51,8 @@ public final class ProxyBridge {
     func getAndRemove(requestId: String) -> ProxyBridgeStoredRequest? {
         lock.lock()
         defer { lock.unlock() }
-        guard let storedRequest = storedRequests.removeValue(forKey: requestId) else {
-            return nil
-        }
-        storedRequestOrder.removeAll { $0 == requestId }
-        return storedRequest
+        // Avoid O(n) queue scans on every parallel bridge request; stale ids are purged lazily.
+        return storedRequests.removeValue(forKey: requestId)
     }
 
     private func cleanupExpiredRequests(now: Date) {


### PR DESCRIPTION
## Summary
- Remove O(n) `ProxyBridge` queue scans on every bridge-backed request (Android/iOS), which degraded badly under parallel load.
- Handle `handleProxyRequest` / proxy response work off the Capacitor plugin queue (Android) and bridge thread (iOS) so multiple in-flight proxies can complete concurrently.
- Reduce Android intercept overhead: coalesce `CookieManager.flush()` on the main looper, use `ConcurrentHashMap` for pending proxy requests, and avoid a main-thread WebView URL hop when resolving cookie credentials.

Fixes #548

## Test plan
- [x] `bun run verify` (iOS build, Android Gradle test/lint, web tests)
- [ ] Manual: open in-app browser with outbound/inbound `DELEGATE_TO_JS` rules and fire parallel fetch/XHR; confirm responses return without linear slowdown


Made with [Cursor](https://cursor.com)