### PR TITLE
fix: support data:text/html;base64 URLs in webview

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CustomSchemeInterceptSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CustomSchemeInterceptSupport.java
@@ -7,7 +7,9 @@ import java.util.Set;
 
 final class CustomSchemeInterceptSupport {
 
-    private static final Set<String> EXCLUDED_SCHEMES = new HashSet<>(Arrays.asList("http", "https", "file", "data", "tel", "mailto", "sms"));
+    private static final Set<String> EXCLUDED_SCHEMES = new HashSet<>(
+        Arrays.asList("http", "https", "file", "data", "tel", "mailto", "sms")
+    );
 
     private CustomSchemeInterceptSupport() {}
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CustomSchemeInterceptSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CustomSchemeInterceptSupport.java
@@ -7,7 +7,7 @@ import java.util.Set;
 
 final class CustomSchemeInterceptSupport {
 
-    private static final Set<String> EXCLUDED_SCHEMES = new HashSet<>(Arrays.asList("http", "https", "file", "tel", "mailto", "sms"));
+    private static final Set<String> EXCLUDED_SCHEMES = new HashSet<>(Arrays.asList("http", "https", "file", "data", "tel", "mailto", "sms"));
 
     private CustomSchemeInterceptSupport() {}
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/HtmlDataUrlSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/HtmlDataUrlSupport.java
@@ -1,0 +1,49 @@
+package ee.forgr.capacitor_inappbrowser;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Locale;
+
+final class HtmlDataUrlSupport {
+
+    private static final String MIME_PREFIX = "data:text/html";
+    private static final String BASE64_MARKER = ";base64,";
+
+    private HtmlDataUrlSupport() {}
+
+    static boolean isHtmlBase64DataUrl(String url) {
+        return parseHtml(url) != null;
+    }
+
+    static boolean isDataUrl(String url) {
+        return url != null && url.toLowerCase(Locale.ROOT).startsWith("data:");
+    }
+
+    static String parseHtml(String url) {
+        if (url == null || url.isEmpty()) {
+            return null;
+        }
+
+        String lower = url.toLowerCase(Locale.ROOT);
+        if (!lower.startsWith(MIME_PREFIX)) {
+            return null;
+        }
+
+        int base64Marker = lower.indexOf(BASE64_MARKER);
+        if (base64Marker < 0) {
+            return null;
+        }
+
+        String payload = url.substring(base64Marker + BASE64_MARKER.length());
+        if (payload.isEmpty()) {
+            return null;
+        }
+
+        try {
+            byte[] decoded = Base64.getDecoder().decode(payload);
+            return new String(decoded, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+}

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/ProxyRequestSupport.java
@@ -120,6 +120,9 @@ final class ProxyRequestSupport {
         if (initialUrl == null || initialUrl.isBlank()) {
             return false;
         }
+        if (HtmlDataUrlSupport.isDataUrl(initialUrl)) {
+            return false;
+        }
         if (!options.shouldEnableNativeProxy()) {
             return false;
         }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -5810,7 +5810,6 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             return;
         }
 
-
         Map<String, String> headers = requestHeaders != null ? requestHeaders : new HashMap<>();
         if (supportsRequestBody(httpMethod) && httpBody != null) {
             byte[] postData = httpBody.getBytes(StandardCharsets.UTF_8);

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -2718,7 +2718,9 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         String httpBody = _options.getHttpBody();
 
         if (!_options.isPopupWindowMode()) {
-            if (shouldBootstrapInitialLegacyProxyLoad()) {
+            if (loadHtmlDataUrlIfNeeded(this._options.getUrl())) {
+                // Inline HTML loaded from data:text/html;base64 URL.
+            } else if (shouldBootstrapInitialLegacyProxyLoad()) {
                 loadInitialLegacyProxyContent(requestHeaders, httpMethod, httpBody);
             } else if (supportsRequestBody(httpMethod) && httpBody != null) {
                 // For POST/PUT/PATCH requests with body
@@ -3832,6 +3834,10 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         }
 
         try {
+            if (loadHtmlDataUrlIfNeeded(url)) {
+                return;
+            }
+
             Map<String, String> requestHeaders = new HashMap<>();
             if (_options.getHeaders() != null) {
                 Iterator<String> keys = _options.getHeaders().keys();
@@ -4662,6 +4668,10 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                     Context context = view.getContext();
                     String url = request.getUrl().toString();
                     Log.d("InAppBrowser", "shouldOverrideUrlLoading: " + url);
+
+                    if (HtmlDataUrlSupport.isDataUrl(url)) {
+                        return false;
+                    }
 
                     boolean isNotHttpOrHttps = !url.startsWith("https://") && !url.startsWith("http://");
 
@@ -5769,6 +5779,20 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             .replace("___CAPGO_PROXY_REGEX___", escapeJavaScriptLiteral(proxyRegexSource));
     }
 
+    private boolean loadHtmlDataUrlIfNeeded(String url) {
+        if (_webView == null) {
+            return false;
+        }
+
+        String html = HtmlDataUrlSupport.parseHtml(url);
+        if (html == null) {
+            return false;
+        }
+
+        _webView.loadDataWithBaseURL("about:blank", html, "text/html", "utf-8", null);
+        return true;
+    }
+
     private boolean shouldUseNativeProxy() {
         return _options != null && _options.shouldEnableNativeProxy();
     }
@@ -5781,6 +5805,11 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         if (_webView == null || _options == null) {
             return;
         }
+
+        if (loadHtmlDataUrlIfNeeded(_options.getUrl())) {
+            return;
+        }
+
 
         Map<String, String> headers = requestHeaders != null ? requestHeaders : new HashMap<>();
         if (supportsRequestBody(httpMethod) && httpBody != null) {

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/CustomSchemeInterceptSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/CustomSchemeInterceptSupportTest.java
@@ -19,6 +19,7 @@ public class CustomSchemeInterceptSupportTest {
         assertFalse(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("https://example.com"));
         assertFalse(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("http://example.com"));
         assertFalse(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("file:///android_asset/index.html"));
+        assertFalse(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("data:text/html;base64,PGh0bWw+PC9odG1sPg=="));
         assertFalse(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("tel:+15555550123"));
         assertFalse(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("MAILTO:test@example.com"));
         assertFalse(CustomSchemeInterceptSupport.shouldEmitInterceptEvent("sms:+15555550123"));

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/HtmlDataUrlSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/HtmlDataUrlSupportTest.java
@@ -1,0 +1,26 @@
+package ee.forgr.capacitor_inappbrowser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class HtmlDataUrlSupportTest {
+
+    @Test
+    public void parsesHtmlBase64DataUrl() {
+        String html = "<html><body><form id=\"loginForm\"></form></body></html>";
+        String url = "data:text/html;base64,PGh0bWw+PGJvZHk+PGZvcm0gaWQ9ImxvZ2luRm9ybSI+PC9mb3JtPjwvYm9keT48L2h0bWw+";
+
+        assertTrue(HtmlDataUrlSupport.isHtmlBase64DataUrl(url));
+        assertEquals(html, HtmlDataUrlSupport.parseHtml(url));
+    }
+
+    @Test
+    public void rejectsNonHtmlDataUrls() {
+        assertFalse(HtmlDataUrlSupport.isHtmlBase64DataUrl("data:image/png;base64,abc"));
+        assertNull(HtmlDataUrlSupport.parseHtml("https://example.com"));
+    }
+}

--- a/ios/Sources/InAppBrowserPlugin/HtmlDataUrlSupport.swift
+++ b/ios/Sources/InAppBrowserPlugin/HtmlDataUrlSupport.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+enum HtmlDataUrlSupport {
+    private static let mimePrefix = "data:text/html"
+    private static let base64Marker = ";base64,"
+
+    static func isHtmlBase64DataUrl(_ urlString: String) -> Bool {
+        parseHtml(from: urlString) != nil
+    }
+
+    static func isDataUrl(_ urlString: String) -> Bool {
+        urlString.lowercased().hasPrefix("data:")
+    }
+
+    static func parseHtml(from urlString: String) -> String? {
+        let lowercased = urlString.lowercased()
+        guard lowercased.hasPrefix(mimePrefix) else {
+            return nil
+        }
+
+        guard let base64Range = lowercased.range(of: base64Marker) else {
+            return nil
+        }
+
+        let payloadStart = urlString.index(
+            urlString.startIndex,
+            offsetBy: lowercased.distance(from: lowercased.startIndex, to: base64Range.upperBound)
+        )
+        let payload = String(urlString[payloadStart...])
+        guard !payload.isEmpty, let data = Data(base64Encoded: payload) else {
+            return nil
+        }
+
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -832,6 +832,18 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
 
     }
 
+
+    private func webSource(for urlString: String) -> WKWebSource? {
+        if let html = HtmlDataUrlSupport.parseHtml(from: urlString) {
+            return .string(html, base: nil)
+        }
+
+        guard let url = URL(string: urlString) else {
+            return nil
+        }
+
+        return .remote(url)
+    }
     @objc func openWebView(_ call: CAPPluginCall) {
         if !self.isSetupDone {
             self.setup()
@@ -1087,7 +1099,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         }
 
         DispatchQueue.main.async {
-            guard let url = URL(string: urlString) else {
+            guard let webSource = self.webSource(for: urlString) else {
                 call.reject("Invalid URL format")
                 return
             }
@@ -1116,7 +1128,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
             webViewController.blankNavigationTab = toolbarType == "blank"
             webViewController.enabledSafeBottomMargin = enabledSafeBottomMargin
             webViewController.enabledSafeTopMargin = enabledSafeTopMargin
-            webViewController.source = .remote(url)
+            webViewController.source = webSource
             webViewController.setCredentials(credentials: credentials)
             webViewController.allowWebViewJsVisibilityControl = allowWebViewJsVisibilityControl
             webViewController.allowScreenshotsFromWebPage = allowScreenshotsFromWebPage
@@ -1185,7 +1197,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
                 }
             }
 
-            webViewController.source = .remote(url)
+            webViewController.source = webSource
             webViewController.leftNavigationBarItemTypes = []
 
             // Configure close button based on showArrow
@@ -1505,17 +1517,25 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
-        guard let url = URL(string: urlString) else {
-            call.reject("Invalid URL")
-            return
-        }
-
         let targetId = call.getString("id")
         guard let webViewController = self.resolveWebViewController(for: targetId) else {
             call.reject("WebView is not initialized")
             return
         }
 
+        if let html = HtmlDataUrlSupport.parseHtml(from: urlString) {
+            webViewController.source = .string(html, base: nil)
+            webViewController.load(string: html, base: nil)
+            call.resolve()
+            return
+        }
+
+        guard let url = URL(string: urlString) else {
+            call.reject("Invalid URL")
+            return
+        }
+
+        webViewController.source = .remote(url)
         webViewController.load(remote: url)
         call.resolve()
     }
@@ -1985,12 +2005,14 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         let credentials = self.readCredentials(call)
 
         DispatchQueue.main.async {
-            guard let url = URL(string: urlString) else {
+            guard let webSource = self.webSource(for: urlString) else {
                 call.reject("Invalid URL format")
                 return
             }
 
-            self.webViewController = WKWebViewController.init(url: url, headers: headers, isInspectable: isInspectable, credentials: credentials, preventDeeplink: preventDeeplink, blankNavigationTab: true, enabledSafeBottomMargin: false, enabledSafeTopMargin: true)
+            let initialUrl = webSource.remoteURL ?? URL(string: "about:blank")!
+
+            self.webViewController = WKWebViewController.init(url: initialUrl, headers: headers, isInspectable: isInspectable, credentials: credentials, preventDeeplink: preventDeeplink, blankNavigationTab: true, enabledSafeBottomMargin: false, enabledSafeTopMargin: true)
 
             guard let webViewController = self.webViewController else {
                 call.reject("Failed to initialize WebViewController")
@@ -2007,7 +2029,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
                 }
             }
 
-            webViewController.source = .remote(url)
+            webViewController.source = webSource
             webViewController.leftNavigationBarItemTypes = [.back, .forward, .reload]
             webViewController.capBrowserPlugin = self
             webViewController.hasDynamicTitle = true

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -832,7 +832,6 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
 
     }
 
-
     private func webSource(for urlString: String) -> WKWebSource? {
         if let html = HtmlDataUrlSupport.parseHtml(from: urlString) {
             return .string(html, base: nil)

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -16,7 +16,7 @@ private let cookieKey = "Cookie"
 
 enum CustomSchemeInterceptSupport {
     static let standardHandledSchemes = ["tel", "mailto", "sms"]
-    private static let webSchemes = ["http", "https", "file"]
+    private static let webSchemes = ["http", "https", "file", "data"]
 
     static func shouldEmitInterceptEvent(for url: URL) -> Bool {
         guard let scheme = url.scheme?.lowercased(), !scheme.isEmpty else {

--- a/ios/Tests/InAppBrowserPluginTests/CustomSchemeInterceptSupportTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/CustomSchemeInterceptSupportTests.swift
@@ -20,9 +20,9 @@ final class CustomSchemeInterceptSupportTests: XCTestCase {
         )
         XCTAssertFalse(
             CustomSchemeInterceptSupport.shouldEmitInterceptEvent(for: try XCTUnwrap(URL(string: "file:///tmp/index.html")))
-        XCTAssertFalse(
-            CustomSchemeInterceptSupport.shouldEmitInterceptEvent(for: try XCTUnwrap(URL(string: "data:text/html;base64,PGh0bWw+PC9odG1sPg==")))
-        )
+            XCTAssertFalse(
+                CustomSchemeInterceptSupport.shouldEmitInterceptEvent(for: try XCTUnwrap(URL(string: "data:text/html;base64,PGh0bWw+PC9odG1sPg==")))
+            )
         )
         XCTAssertFalse(
             CustomSchemeInterceptSupport.shouldEmitInterceptEvent(for: try XCTUnwrap(URL(string: "tel:+15555550123")))

--- a/ios/Tests/InAppBrowserPluginTests/CustomSchemeInterceptSupportTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/CustomSchemeInterceptSupportTests.swift
@@ -20,6 +20,9 @@ final class CustomSchemeInterceptSupportTests: XCTestCase {
         )
         XCTAssertFalse(
             CustomSchemeInterceptSupport.shouldEmitInterceptEvent(for: try XCTUnwrap(URL(string: "file:///tmp/index.html")))
+        XCTAssertFalse(
+            CustomSchemeInterceptSupport.shouldEmitInterceptEvent(for: try XCTUnwrap(URL(string: "data:text/html;base64,PGh0bWw+PC9odG1sPg==")))
+        )
         )
         XCTAssertFalse(
             CustomSchemeInterceptSupport.shouldEmitInterceptEvent(for: try XCTUnwrap(URL(string: "tel:+15555550123")))

--- a/ios/Tests/InAppBrowserPluginTests/HtmlDataUrlSupportTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/HtmlDataUrlSupportTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import InAppBrowserPlugin
+
+final class HtmlDataUrlSupportTests: XCTestCase {
+    func testParsesHtmlBase64DataUrl() {
+        let html = "<html><body><form id=\"loginForm\"></form></body></html>"
+        let payload = Data(html.utf8).base64EncodedString()
+        let url = "data:text/html;base64,\(payload)"
+
+        XCTAssertTrue(HtmlDataUrlSupport.isHtmlBase64DataUrl(url))
+        XCTAssertEqual(HtmlDataUrlSupport.parseHtml(from: url), html)
+    }
+
+    func testRejectsNonHtmlDataUrls() {
+        XCTAssertFalse(HtmlDataUrlSupport.isHtmlBase64DataUrl("data:image/png;base64,abc"))
+        XCTAssertNil(HtmlDataUrlSupport.parseHtml(from: "https://example.com"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add `HtmlDataUrlSupport` on Android and iOS to decode `data:text/html;base64,...` URLs
- Load decoded HTML via `loadDataWithBaseURL` / `loadHTMLString` in `openWebView`, `open`, and `setUrl`
- Treat `data:` as an internal web scheme so navigation is not intercepted as a custom deeplink
- Skip native proxy bootstrap for initial `data:` URLs

Fixes Cap-go/capacitor-inappbrowser#24

## Test plan
- [x] `bun run verify` (iOS build, Android build+tests, web build+tests)
- [ ] Open example app and call `openWebView` with a `data:text/html;base64,...` auto-submit form URL
- [ ] Confirm form submit/navigation works on Android and iOS


Made with [Cursor](https://cursor.com)