### PR TITLE
fix: preserve blank toolbar after show

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -1835,6 +1835,11 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
         return self.capableWebView
     }
 
+    private func applyNavigationVisibility() {
+        navigationController?.setNavigationBarHidden(blankNavigationTab, animated: false)
+        navigationController?.setToolbarHidden(true, animated: false)
+    }
+
     override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         if !self.viewWasPresented {
@@ -1847,8 +1852,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
         }
 
         // Reapply presentation state after hide/show re-presents the same controller.
-        navigationController?.setNavigationBarHidden(blankNavigationTab, animated: false)
-        navigationController?.setToolbarHidden(true, animated: false)
+        applyNavigationVisibility()
 
         // Force update button appearances
         updateButtonTintColors()
@@ -2297,11 +2301,7 @@ fileprivate extension WKWebViewController {
     }
 
     func setUpState() {
-        navigationController?.setNavigationBarHidden(blankNavigationTab, animated: false)
-
-        // Always hide toolbar since we never want it
-        navigationController?.setToolbarHidden(true, animated: false)
-
+        applyNavigationVisibility()
         // Set tint colors but don't override specific colors
         if tintColor == nil {
             // Use system appearance if no specific tint color is set

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -1846,6 +1846,10 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
             applyCustomDimensions()
         }
 
+        // Reapply presentation state after hide/show re-presents the same controller.
+        navigationController?.setNavigationBarHidden(blankNavigationTab, animated: false)
+        navigationController?.setToolbarHidden(true, animated: false)
+
         // Force update button appearances
         updateButtonTintColors()
 
@@ -2317,7 +2321,10 @@ fileprivate extension WKWebViewController {
 
         navigationController?.navigationBar.tintColor = previousNavigationBarState.tintColor
 
-        navigationController?.setNavigationBarHidden(previousNavigationBarState.hidden, animated: true)
+        navigationController?.setNavigationBarHidden(
+            blankNavigationTab || previousNavigationBarState.hidden,
+            animated: true
+        )
     }
 
     func checkRequestCookies(_ request: URLRequest, cookies: [HTTPCookie]) -> Bool {

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -1837,6 +1837,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
 
     private func applyNavigationVisibility() {
         navigationController?.setNavigationBarHidden(blankNavigationTab, animated: false)
+        // Always hide toolbar since we never want it.
         navigationController?.setToolbarHidden(true, animated: false)
     }
 


### PR DESCRIPTION
## Summary

- Reapply the native navigation visibility state every time the iOS webview controller appears.
- Keep `toolbarType: 'blank'` from rolling back to a visible navigation bar when `hide()` dismisses the controller.
- Fixes the reported flow: open with `toolbarType: 'blank'`, call `hide()`, then call `show()` and keep the toolbar blank instead of returning as compact.

## Test plan

- `bun run fmt`
- `bun run verify:ios`

## Visual evidence

Not included. This is an iOS native presentation-state restoration fix for the existing `hide()` / `show()` flow, and I verified it with the iOS build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-app browser view restoration after reopening, ensuring the navigation bar and toolbar visibility remain consistent across hide/show re-presentations.
  * Fixed navigation bar rollback behavior so blank tab views reliably keep the navigation bar hidden when appropriate, matching the prior recorded state.
  * Toolbar visibility is consistently forced to remain hidden during these transitions for a stable in-app browsing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->