### PR TITLE
fix(android): respect preShowScriptInjectionTime "documentStart"

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
@@ -1143,6 +1143,7 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
 
         options.setShareDisclaimer(call.getObject("shareDisclaimer", null));
         options.setPreShowScript(call.getString("preShowScript", null));
+        options.setPreShowScriptInjectionTime(call.getString("preShowScriptInjectionTime", "pageLoad"));
         options.setShareSubject(call.getString("shareSubject", null));
         options.setToolbarType(call.getString("toolbarType", ""));
         options.setPreventDeeplink(Boolean.TRUE.equals(call.getBoolean("preventDeeplink", false)));

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
@@ -168,6 +168,7 @@ public class Options {
     private boolean ignoreUntrustedSSLError;
     private boolean clientCertificatePrompt;
     private String preShowScript;
+    private String preShowScriptInjectionTime = "pageLoad";
     private String toolbarTextColor;
     private Pattern proxyRequestsPattern = null;
     private boolean proxyRequests = false;
@@ -617,6 +618,14 @@ public class Options {
         this.preShowScript = preLoadScript;
     }
 
+    public String getPreShowScriptInjectionTime() {
+        return preShowScriptInjectionTime;
+    }
+
+    public void setPreShowScriptInjectionTime(String preShowScriptInjectionTime) {
+        this.preShowScriptInjectionTime = preShowScriptInjectionTime != null ? preShowScriptInjectionTime : "pageLoad";
+    }
+
     public boolean getPreventDeeplink() {
         return preventDeeplink;
     }
@@ -753,6 +762,7 @@ public class Options {
         copy.setIgnoreUntrustedSSLError(ignoreUntrustedSSLError);
         copy.setClientCertificatePrompt(clientCertificatePrompt);
         copy.setPreShowScript(preShowScript);
+        copy.setPreShowScriptInjectionTime(preShowScriptInjectionTime);
         copy.setToolbarTextColor(toolbarTextColor);
         copy.setProxyRequestsPattern(proxyRequestsPattern);
         copy.setProxyRequests(proxyRequests);

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -377,6 +377,9 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
 
     Semaphore preShowSemaphore = null;
     String preShowError = null;
+    // True when preShowScript was registered via WebViewCompat.addDocumentStartJavaScript;
+    // the blocking evaluateJavascript injection in onPageFinished is skipped in that case.
+    private boolean preShowInjectedAtDocumentStart = false;
 
     public PermissionRequest currentPermissionRequest;
     public static final int FILE_CHOOSER_REQUEST_CODE = 1000;
@@ -3409,6 +3412,14 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         try {
             injectDocumentStartPostMessageBridge();
             WebViewCompat.addDocumentStartJavaScript(_webView, createMobileAppBridgeScript(), Collections.singleton("*"));
+            // Honor preShowScriptInjectionTime: "documentStart" (matches iOS WKUserScript
+            // .atDocumentStart). Runs before page scripts and persists across navigations,
+            // so the blocking semaphore injection in onPageFinished is not needed.
+            String preShowScript = _options.getPreShowScript();
+            if (preShowScript != null && !preShowScript.isEmpty() && "documentStart".equals(_options.getPreShowScriptInjectionTime())) {
+                WebViewCompat.addDocumentStartJavaScript(_webView, preShowScript, Collections.singleton("*"));
+                preShowInjectedAtDocumentStart = true;
+            }
         } catch (Exception e) {
             Log.e("InAppBrowser", "Error injecting document-start JavaScript interface: " + e.getMessage());
         }
@@ -5392,7 +5403,10 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                         isInitialized = true;
                         _webView.clearHistory();
                         if (_options.isPresentAfterPageLoad()) {
-                            boolean usePreShowScript = _options.getPreShowScript() != null && !_options.getPreShowScript().isEmpty();
+                            boolean usePreShowScript =
+                                _options.getPreShowScript() != null &&
+                                !_options.getPreShowScript().isEmpty() &&
+                                !preShowInjectedAtDocumentStart;
                             if (!usePreShowScript) {
                                 showAccordingToLayerModeOrFallback();
                                 resolveOpenWebViewIfNeeded();
@@ -5419,7 +5433,9 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                                 );
                             }
                         }
-                    } else if (_options.getPreShowScript() != null && !_options.getPreShowScript().isEmpty()) {
+                    } else if (
+                        _options.getPreShowScript() != null && !_options.getPreShowScript().isEmpty() && !preShowInjectedAtDocumentStart
+                    ) {
                         executorService.execute(
                             new Runnable() {
                                 @Override


### PR DESCRIPTION
## What

Android ignores the documented `preShowScriptInjectionTime: "documentStart"` option. The `preShowScript` is always injected at the first `onPageFinished` via `evaluateJavascript`, and `show()` blocks on a semaphore for up to 10 seconds waiting for `PreShowScriptInterface.success()`:

https://github.com/Cap-go/capacitor-inappbrowser/blob/99ce17f9/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java#L3560-L3617

If the page navigates or redirects right after the first page-finish, the injected script's callbacks never run and every open stalls for the full 10s timeout before the webview appears (with `isPresentAfterPageLoad: true` the user stares at the previous screen the whole time). iOS already handles this correctly via `WKUserScript(.atDocumentStart)`.

## Fix

When `preShowScriptInjectionTime` is `"documentStart"` and `WebViewFeature.DOCUMENT_START_SCRIPT` is supported, register the `preShowScript` with `WebViewCompat.addDocumentStartJavaScript` during webview setup (next to the existing document-start bridge script) and skip the blocking `injectPreShowScript()` paths in `onPageFinished`. Document-start scripts run before any page JavaScript and persist across navigations, so re-injection per page load is unnecessary.

The existing semaphore-based injection remains the fallback for `"pageLoad"` (default) and for WebViews without `DOCUMENT_START_SCRIPT` support, so behavior is unchanged unless the option is explicitly set.

- `Options.java`: new `preShowScriptInjectionTime` field (default `"pageLoad"`), included in `copy()`
- `CapgoInAppBrowserPlugin.java`: parse the option in `openWebView`
- `WebViewDialog.java`: document-start registration + skip flag for the blocking injection

## Testing

Verified on a real app (Android emulator API 36 + physical Android 13 device): with `isPresentAfterPageLoad: true` + a ~300KB provider script, webview presents at first page finish (~2.8s network-bound instead of 10s+ semaphore timeout), the injected provider is available before page scripts run (matching iOS), and `"pageLoad"` behavior is untouched. Java formatted with `prettier-plugin-java`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to control when pre-show JavaScript is injected, with support for injecting at page load or at document start.
* **Bug Fixes**
  * Prevented pre-show scripts from being injected twice when the earlier injection time is selected.
  * Improved consistency of in-app browser behavior when opening web content with pre-show scripts enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->