### PR TITLE
feat: add screenshot on hide event

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,19 +150,20 @@ await InAppBrowser.show({ id: second.id });
 
 #### Hide from the native close button and brand the toolbar title
 
-Use `closeAction: CloseAction.HIDE` when the toolbar close button should hide the WebView instead of destroying it. Listen to `hideEvent` if your app needs to update Ionic state, then call `show()` later to bring the same browser session back.
+Use `closeAction: CloseAction.HIDE` when the toolbar close button should hide the WebView instead of destroying it. Listen to `hideEvent` if your app needs to update Ionic state, then call `show()` later to bring the same browser session back. Set `screenshotOnHide` to receive one last visible-page screenshot in that event.
 
 ```js
 import { CloseAction, InAppBrowser } from '@capgo/capacitor-inappbrowser';
 
-await InAppBrowser.addListener('hideEvent', ({ id, url }) => {
-  console.log('Browser hidden', id, url);
+await InAppBrowser.addListener('hideEvent', ({ id, url, screenshot }) => {
+  console.log('Browser hidden', id, url, screenshot?.dataUrl);
 });
 
 const { id } = await InAppBrowser.openWebView({
   url: 'https://example.com/checkout',
   title: 'Secure checkout',
   closeAction: CloseAction.HIDE,
+  screenshotOnHide: true,
   titleFontFamily: 'Inter',
   titleIcon: {
     ios: { iconType: 'sf-symbol', icon: 'lock.fill' },
@@ -975,15 +976,15 @@ Listen for close click only for openWebView
 ### addListener('hideEvent', ...)
 
 ```typescript
-addListener(eventName: 'hideEvent', listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
+addListener(eventName: 'hideEvent', listenerFunc: HideListener) => Promise<PluginListenerHandle>
 ```
 
 Listen for webviews hidden by the toolbar close button when closeAction is <a href="#closeaction">CloseAction.HIDE</a>.
 
-| Param              | Type                                                            |
-| ------------------ | --------------------------------------------------------------- |
-| **`eventName`**    | <code>'hideEvent'</code>                                        |
-| **`listenerFunc`** | <code><a href="#urlchangelistener">UrlChangeListener</a></code> |
+| Param              | Type                                                  |
+| ------------------ | ----------------------------------------------------- |
+| **`eventName`**    | <code>'hideEvent'</code>                              |
+| **`listenerFunc`** | <code><a href="#hidelistener">HideListener</a></code> |
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
 
@@ -1489,6 +1490,7 @@ And in the AndroidManifest.xml file:
 | **`isAnimated`**                       | <code>boolean</code>                                                                                                                                                   | Whether the webview opening is animated or not, ios only                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | <code>true</code>                                             |        |
 | **`showReloadButton`**                 | <code>boolean</code>                                                                                                                                                   | Shows a reload button that reloads the web page                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | <code>false</code>                                            | 1.0.15 |
 | **`closeAction`**                      | <code><a href="#closeaction">CloseAction</a></code>                                                                                                                    | closeAction controls what happens when the native toolbar close button is pressed. This does not change the behavior of close(), JavaScript window.mobileApp.close(), or native back navigation.                                                                                                                                                                                                                                                                                                                                                           | <code>CloseAction.CLOSE</code>                                | 8.7.7  |
+| **`screenshotOnHide`**                 | <code>boolean</code>                                                                                                                                                   | Captures the visible webview and includes it as `screenshot` in `hideEvent` before the toolbar close button hides the webview. Only applies when `closeAction` is <a href="#closeaction">`CloseAction.HIDE`</a>.                                                                                                                                                                                                                                                                                                                                           | <code>false</code>                                            | 8.7.10 |
 | **`closeModal`**                       | <code>boolean</code>                                                                                                                                                   | CloseModal: if true a confirm will be displayed when user clicks on close button, if false the browser will be closed immediately.                                                                                                                                                                                                                                                                                                                                                                                                                         | <code>false</code>                                            | 1.1.0  |
 | **`closeModalTitle`**                  | <code>string</code>                                                                                                                                                    | CloseModalTitle: title of the confirm when user clicks on close button                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | <code>"Close"</code>                                          | 1.1.0  |
 | **`closeModalDescription`**            | <code>string</code>                                                                                                                                                    | CloseModalDescription: description of the confirm when user clicks on close button                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | <code>"Are you sure you want to close this window?"</code>    | 1.1.0  |
@@ -1610,6 +1612,15 @@ Any regex property that is omitted is treated as a wildcard.
 | Prop     | Type                | Description          | Since  |
 | -------- | ------------------- | -------------------- | ------ |
 | **`id`** | <code>string</code> | Webview instance id. | 8.6.36 |
+
+
+#### HideEvent
+
+| Prop             | Type                                                          | Description                                                                                                                                              |
+| ---------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`id`**         | <code>string</code>                                           | Webview instance id.                                                                                                                                     |
+| **`url`**        | <code>string</code>                                           | URL active when the webview was hidden.                                                                                                                  |
+| **`screenshot`** | <code><a href="#screenshotresult">ScreenshotResult</a></code> | Screenshot captured immediately before the toolbar close button hides the webview. Present only when `screenshotOnHide` is enabled and capture succeeds. |
 
 
 #### BtnEvent
@@ -1835,6 +1846,11 @@ Construct a type with a set of properties K of type T
 #### ButtonNearListener
 
 <code>(state: <a href="#buttonneardoneevent">ButtonNearDoneEvent</a>): void</code>
+
+
+#### HideListener
+
+<code>(state: <a href="#hideevent">HideEvent</a>): void</code>
 
 
 #### ConfirmBtnListener

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
@@ -170,8 +170,12 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
             }
 
             @Override
-            public void hideEvent(String url) {
-                notifyListeners("hideEvent", new JSObject().put("id", webViewId).put("url", url));
+            public void hideEvent(String url, JSObject screenshot) {
+                JSObject event = new JSObject().put("id", webViewId).put("url", url);
+                if (screenshot != null) {
+                    event.put("screenshot", screenshot);
+                }
+                notifyListeners("hideEvent", event);
             }
 
             @Override
@@ -1064,6 +1068,7 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
         options.setIgnoreUntrustedSSLError(Boolean.TRUE.equals(call.getBoolean("ignoreUntrustedSSLError", false)));
         options.setClientCertificatePrompt(resolveClientCertificatePrompt(call));
         options.setShowScreenshotButton(Boolean.TRUE.equals(call.getBoolean("showScreenshotButton", false)));
+        options.setScreenshotOnHide(Boolean.TRUE.equals(call.getBoolean("screenshotOnHide", false)));
         options.setAllowScreenshotsFromWebPage(Boolean.TRUE.equals(call.getBoolean("allowScreenshotsFromWebPage", false)));
         options.setCaptureConsoleLogs(Boolean.TRUE.equals(call.getBoolean("captureConsoleLogs", false)));
         options.setHandleDownloads(Boolean.TRUE.equals(call.getBoolean("handleDownloads", false)));

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
@@ -193,6 +193,7 @@ public class Options {
     private boolean toBack = false;
     private boolean transparentBackground = true;
     private boolean showScreenshotButton = false;
+    private boolean screenshotOnHide = false;
     private boolean allowWebViewJsVisibilityControl = false;
     private boolean allowScreenshotsFromWebPage = false;
     private boolean captureConsoleLogs = false;
@@ -270,6 +271,14 @@ public class Options {
 
     public void setShowScreenshotButton(boolean showScreenshotButton) {
         this.showScreenshotButton = showScreenshotButton;
+    }
+
+    public boolean getScreenshotOnHide() {
+        return screenshotOnHide;
+    }
+
+    public void setScreenshotOnHide(boolean screenshotOnHide) {
+        this.screenshotOnHide = screenshotOnHide;
     }
 
     public boolean getAllowScreenshotsFromWebPage() {
@@ -787,6 +796,7 @@ public class Options {
         copy.setY(y);
         copy.setHidden(hidden || hiddenPopupWindow);
         copy.setShowScreenshotButton(showScreenshotButton);
+        copy.setScreenshotOnHide(screenshotOnHide);
         copy.setAllowWebViewJsVisibilityControl(allowWebViewJsVisibilityControl);
         copy.setAllowScreenshotsFromWebPage(allowScreenshotsFromWebPage);
         copy.setCaptureConsoleLogs(captureConsoleLogs);

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCallbacks.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCallbacks.java
@@ -7,7 +7,7 @@ public interface WebViewCallbacks {
 
     public void closeEvent(String url);
 
-    public void hideEvent(String url);
+    public void hideEvent(String url, JSObject screenshot);
 
     public void pageLoaded();
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -352,6 +352,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
     private Drawable cachedTitleIconDrawable;
     private boolean cachedTitleIconResolved;
     private boolean isHiddenModeActive = false;
+    private boolean toolbarHideInProgress = false;
     private WindowManager.LayoutParams previousWindowAttributes;
     private Drawable previousWindowBackground;
     private ViewGroup.LayoutParams previousWebViewLayoutParams;
@@ -2912,6 +2913,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                 }
             }
         } else {
+            toolbarHideInProgress = false;
             if (isHiddenModeActive) {
                 restoreVisibleMode();
             }
@@ -3886,6 +3888,10 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
 
     private void performToolbarCloseAction(String currentUrl) {
         if (_options != null && "hide".equals(_options.getCloseAction())) {
+            if (toolbarHideInProgress) {
+                return;
+            }
+            toolbarHideInProgress = true;
             if (_options.getScreenshotOnHide()) {
                 takeScreenshot(
                     new ScreenshotResultCallback() {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -3886,9 +3886,23 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
 
     private void performToolbarCloseAction(String currentUrl) {
         if (_options != null && "hide".equals(_options.getCloseAction())) {
-            setHidden(true);
-            if (_options.getCallbacks() != null) {
-                _options.getCallbacks().hideEvent(currentUrl);
+            if (_options.getScreenshotOnHide()) {
+                takeScreenshot(
+                    new ScreenshotResultCallback() {
+                        @Override
+                        public void onSuccess(JSObject screenshot) {
+                            hideAndEmit(currentUrl, screenshot);
+                        }
+
+                        @Override
+                        public void onError(String message) {
+                            Log.e("InAppBrowser", "Failed to capture screenshot before hiding: " + message);
+                            hideAndEmit(currentUrl, null);
+                        }
+                    }
+                );
+            } else {
+                hideAndEmit(currentUrl, null);
             }
             return;
         }
@@ -3896,6 +3910,13 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         dismiss();
         if (_options != null && _options.getCallbacks() != null) {
             _options.getCallbacks().closeEvent(currentUrl);
+        }
+    }
+
+    private void hideAndEmit(String currentUrl, JSObject screenshot) {
+        setHidden(true);
+        if (_options != null && _options.getCallbacks() != null) {
+            _options.getCallbacks().hideEvent(currentUrl, screenshot);
         }
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -3302,6 +3302,10 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
     }
 
     public void takeScreenshot(ScreenshotResultCallback callback) {
+        takeScreenshot(true, callback);
+    }
+
+    private void takeScreenshot(boolean emitEvent, ScreenshotResultCallback callback) {
         if (_webView == null) {
             callback.onError("WebView is not initialized");
             return;
@@ -3346,7 +3350,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                     result.put("width", width);
                     result.put("height", height);
 
-                    postScreenshotSuccess(callback, result);
+                    postScreenshotSuccess(callback, result, emitEvent);
                 } catch (IOException e) {
                     postScreenshotError(callback, "Failed to encode screenshot: " + e.getMessage());
                 } finally {
@@ -3356,13 +3360,13 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         });
     }
 
-    private void postScreenshotSuccess(ScreenshotResultCallback callback, JSObject result) {
+    private void postScreenshotSuccess(ScreenshotResultCallback callback, JSObject result, boolean emitEvent) {
         if (_webView == null) {
             callback.onError("WebView is not initialized");
             return;
         }
         _webView.post(() -> {
-            if (_options != null && _options.getCallbacks() != null) {
+            if (emitEvent && _options != null && _options.getCallbacks() != null) {
                 _options.getCallbacks().screenshotTaken(result);
             }
             callback.onSuccess(result);
@@ -3894,6 +3898,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             toolbarHideInProgress = true;
             if (_options.getScreenshotOnHide()) {
                 takeScreenshot(
+                    false,
                     new ScreenshotResultCallback() {
                         @Override
                         public void onSuccess(JSObject screenshot) {

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/ConsoleMessageEventHelperTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/ConsoleMessageEventHelperTest.java
@@ -28,16 +28,18 @@ public class ConsoleMessageEventHelperTest {
     }
 
     @Test
-    public void copyForPopupPreservesConsoleCaptureFlag() {
+    public void copyForPopupPreservesHiddenOptions() {
         Options options = new Options();
         options.setHidden(true);
         options.setHiddenPopupWindow(true);
         options.setCaptureConsoleLogs(true);
+        options.setScreenshotOnHide(true);
 
         Options popupCopy = options.copyForPopup();
 
         assertTrue(popupCopy.isPopupWindowMode());
         assertTrue(popupCopy.isHidden());
         assertTrue(popupCopy.getCaptureConsoleLogs());
+        assertTrue(popupCopy.getScreenshotOnHide());
     }
 }

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -687,14 +687,20 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         self.navigationWebViewController = nil
     }
 
-    func handleWebViewDidHide(id: String, url: String) {
+    func handleWebViewDidHide(id: String, url: String, screenshot: [String: Any]? = nil) {
+        var payload: [String: Any] = ["url": url]
+        if let screenshot {
+            payload["screenshot"] = screenshot
+        }
+
         if !id.isEmpty {
-            self.notifyListeners("hideEvent", data: ["id": id, "url": url])
+            payload["id"] = id
+            self.notifyListeners("hideEvent", data: payload)
             self.setHiddenState(true, targetId: id, call: nil)
             return
         }
 
-        self.notifyListeners("hideEvent", data: ["url": url])
+        self.notifyListeners("hideEvent", data: payload)
         self.setHiddenState(true, targetId: activeWebViewId, call: nil)
     }
 
@@ -992,6 +998,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         let hiddenPopupWindow = call.getBool("hiddenPopupWindow", false)
         let allowWebViewJsVisibilityControl = self.getConfig().getBoolean("allowWebViewJsVisibilityControl", false)
         let allowScreenshotsFromWebPage = call.getBool("allowScreenshotsFromWebPage", false)
+        let screenshotOnHide = call.getBool("screenshotOnHide", false)
         let captureConsoleLogs = call.getBool("captureConsoleLogs", false)
         let handleDownloads = call.getBool("handleDownloads", false)
         let persistWebViewData = call.getBool("persistWebViewData", true)
@@ -1288,6 +1295,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
             webViewController.capBrowserPlugin = self
             webViewController.title = call.getString("title", "New Window")
             webViewController.closeAction = closeAction
+            webViewController.screenshotOnHide = screenshotOnHide
             webViewController.titleFontFamily = titleFontFamily
             webViewController.titleIcon = titleIcon
             // Only set shareSubject if not already set for activity mode

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -1586,6 +1586,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
                 }
                 self.dismissNavigationControllerIfPresented(navigationController)
             } else {
+                webViewController.toolbarHideInProgress = false
                 if webView.superview !== webViewController.view {
                     self.attachWebViewToController(webViewController, webView: webView)
                 }

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -1650,7 +1650,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
         }
     }
 
-    func takeScreenshot(completion: @escaping (Result<[String: Any], Error>) -> Void) {
+    func takeScreenshot(emitEvent: Bool = true, completion: @escaping (Result<[String: Any], Error>) -> Void) {
         DispatchQueue.main.async {
             guard let webView = self.webView else {
                 completion(.failure(NSError(domain: "InAppBrowser", code: 1, userInfo: [NSLocalizedDescriptionKey: "WebView is not initialized"])))
@@ -1688,7 +1688,9 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
                     "width": Int(image.size.width * image.scale),
                     "height": Int(image.size.height * image.scale)
                 ]
-                self.emit("screenshotTaken", data: result)
+                if emitEvent {
+                    self.emit("screenshotTaken", data: result)
+                }
                 completion(.success(result))
             }
         }
@@ -3051,7 +3053,7 @@ fileprivate extension WKWebViewController {
                 }
                 toolbarHideInProgress = true
                 if screenshotOnHide {
-                    takeScreenshot { result in
+                    takeScreenshot(emitEvent: false) { result in
                         switch result {
                         case .success(let screenshot):
                             self.capBrowserPlugin?.handleWebViewDidHide(id: self.instanceId, url: currentUrl, screenshot: screenshot)

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -417,6 +417,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
     open var closeModal = false
     open var closeAction = "close"
     open var screenshotOnHide = false
+    var toolbarHideInProgress = false
     open var titleFontFamily: String?
     open var titleIcon: UIImage?
     open var closeModalTitle = ""
@@ -3045,6 +3046,10 @@ fileprivate extension WKWebViewController {
         if canDismiss {
             let currentUrl = webView?.url?.absoluteString ?? ""
             if closeAction == "hide" {
+                if toolbarHideInProgress {
+                    return
+                }
+                toolbarHideInProgress = true
                 if screenshotOnHide {
                     takeScreenshot { result in
                         switch result {

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -416,6 +416,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
     var didpageInit = false
     open var closeModal = false
     open var closeAction = "close"
+    open var screenshotOnHide = false
     open var titleFontFamily: String?
     open var titleIcon: UIImage?
     open var closeModalTitle = ""
@@ -2216,6 +2217,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
         self.enableGooglePaySupport = parent.enableGooglePaySupport
         self.preventDeeplink = parent.preventDeeplink
         self.closeAction = parent.closeAction
+        self.screenshotOnHide = parent.screenshotOnHide
         self.titleFontFamily = parent.titleFontFamily
         self.titleIcon = parent.titleIcon
         self.openBlankTargetInWebView = parent.openBlankTargetInWebView
@@ -3043,7 +3045,19 @@ fileprivate extension WKWebViewController {
         if canDismiss {
             let currentUrl = webView?.url?.absoluteString ?? ""
             if closeAction == "hide" {
-                self.capBrowserPlugin?.handleWebViewDidHide(id: instanceId, url: currentUrl)
+                if screenshotOnHide {
+                    takeScreenshot { result in
+                        switch result {
+                        case .success(let screenshot):
+                            self.capBrowserPlugin?.handleWebViewDidHide(id: self.instanceId, url: currentUrl, screenshot: screenshot)
+                        case .failure(let error):
+                            print("[InAppBrowser] Failed to capture screenshot before hiding: \(error.localizedDescription)")
+                            self.capBrowserPlugin?.handleWebViewDidHide(id: self.instanceId, url: currentUrl)
+                        }
+                    }
+                } else {
+                    self.capBrowserPlugin?.handleWebViewDidHide(id: instanceId, url: currentUrl)
+                }
                 return
             }
             cleanupWebView()

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -597,6 +597,24 @@ export interface ScreenshotResult {
   height: number;
 }
 
+export interface HideEvent {
+  /**
+   * Webview instance id.
+   */
+  id?: string;
+  /**
+   * URL active when the webview was hidden.
+   */
+  url: string;
+  /**
+   * Screenshot captured immediately before the toolbar close button hides the webview.
+   * Present only when `screenshotOnHide` is enabled and capture succeeds.
+   */
+  screenshot?: ScreenshotResult;
+}
+
+export type HideListener = (state: HideEvent) => void;
+
 export interface CloseWebviewOptions {
   /**
    * Target webview id to close. If omitted, closes the active webview.
@@ -904,6 +922,16 @@ export interface OpenWebViewOptions {
    * closeAction: CloseAction.HIDE
    */
   closeAction?: CloseAction;
+  /**
+   * Captures the visible webview and includes it as `screenshot` in `hideEvent`
+   * before the toolbar close button hides the webview.
+   *
+   * Only applies when `closeAction` is `CloseAction.HIDE`.
+   *
+   * @default false
+   * @since 8.7.10
+   */
+  screenshotOnHide?: boolean;
   /**
    * CloseModal: if true a confirm will be displayed when user clicks on close button, if false the browser will be closed immediately.
    * @since 1.1.0
@@ -1491,7 +1519,7 @@ export interface InAppBrowserPlugin {
    *
    * @since 8.7.7
    */
-  addListener(eventName: 'hideEvent', listenerFunc: UrlChangeListener): Promise<PluginListenerHandle>;
+  addListener(eventName: 'hideEvent', listenerFunc: HideListener): Promise<PluginListenerHandle>;
   /**
    * Will be triggered when user clicks on confirm button when disclaimer is required,
    * works with openWebView shareDisclaimer and closeModal


### PR DESCRIPTION
## Summary
- add `screenshotOnHide` for WebViews using `closeAction: CloseAction.HIDE`
- capture the visible WebView before the toolbar hide path runs and include the result as `hideEvent.screenshot`
- update TypeScript definitions, README API docs, Android option copying, and native iOS/Android event payloads

## Why
Apps that model Safari-style tab lists need the last visible page snapshot when the native close button hides a WebView. Taking a screenshot from `hideEvent` is too late because the WebView may already be hidden or resized.

## Validation
- `bun run build`
- `bun run test:web`
- `bun run eslint`
- `bun run prettier -- --check`
- `bun run verify:android`

Local iOS verification is blocked on this machine because Xcode has no eligible iOS destination for this scheme; the Mac Catalyst fallback also cannot build because the Capacitor/Cordova xcframeworks do not include Catalyst slices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional screenshot capture when hiding a web view (`closeAction: "hide"`).
  * `hideEvent` can now include the web view `id`, current `url`, and an optional `screenshot`.

* **API Updates**
  * Introduced `screenshotOnHide` in `openWebView` options (only applies when hide is used).
  * Updated the `hideEvent` listener to use a dedicated, strongly-typed payload.

* **Documentation**
  * Refreshed README usage and API references, including updated examples and the new `HideEvent` details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->