### PR TITLE
feat: add bring-to-front animation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,15 +784,16 @@ Use `dispatchInputEvent()` to forward overlay gestures to the browser while it i
 ### bringToFront(...)
 
 ```typescript
-bringToFront(options?: { id?: string | undefined; } | undefined) => Promise<void>
+bringToFront(options?: BringToFrontOptions | undefined) => Promise<void>
 ```
 
 Moves a browser that was behind the host WebView back to the front.
+On iOS, set `isAnimated` to `false` to skip the presentation animation.
 When `id` is omitted, targets the active webview.
 
-| Param         | Type                          |
-| ------------- | ----------------------------- |
-| **`options`** | <code>{ id?: string; }</code> |
+| Param         | Type                                                                |
+| ------------- | ------------------------------------------------------------------- |
+| **`options`** | <code><a href="#bringtofrontoptions">BringToFrontOptions</a></code> |
 
 --------------------
 
@@ -1435,6 +1436,14 @@ And in the AndroidManifest.xml file:
 | --------------------------- | -------------------- | ------------------------------------------------------------------------------------ | ----------------- |
 | **`id`**                    | <code>string</code>  | Target webview id. If omitted, targets the active webview.                           |                   |
 | **`transparentBackground`** | <code>boolean</code> | Makes the Capacitor host WebView transparent while this native webview is behind it. | <code>true</code> |
+
+
+#### BringToFrontOptions
+
+| Prop             | Type                 | Description                                                   | Default           |
+| ---------------- | -------------------- | ------------------------------------------------------------- | ----------------- |
+| **`id`**         | <code>string</code>  | Target webview id. If omitted, targets the active webview.    |                   |
+| **`isAnimated`** | <code>boolean</code> | Whether bringing the webview to the front is animated on iOS. | <code>true</code> |
 
 
 #### DispatchPointerInputEventOptions

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -1667,6 +1667,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func bringToFront(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
+            let isAnimated = call.getBool("isAnimated", true)
             let targetId = call.getString("id") ?? self.activeWebViewId
             guard let resolvedId = targetId,
                   let webViewController = self.resolveWebViewController(for: resolvedId),
@@ -1684,7 +1685,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
             self.setActiveWebView(id: resolvedId, webView: webViewController, navigationController: navigationController)
             if navigationController.presentingViewController == nil {
                 let presenter = self.bridge?.viewController?.presentedViewController ?? self.bridge?.viewController
-                presenter?.present(navigationController, animated: true, completion: {
+                presenter?.present(navigationController, animated: isAnimated, completion: {
                     call.resolve()
                 })
                 return

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -163,6 +163,19 @@ export interface LayerOptions {
   transparentBackground?: boolean;
 }
 
+export interface BringToFrontOptions {
+  /**
+   * Target webview id. If omitted, targets the active webview.
+   */
+  id?: string;
+  /**
+   * Whether bringing the webview to the front is animated on iOS.
+   *
+   * @default true
+   */
+  isAnimated?: boolean;
+}
+
 export interface DispatchPointerInputEventOptions {
   /**
    * Target webview id. If omitted, targets the active webview.
@@ -1446,9 +1459,10 @@ export interface InAppBrowserPlugin {
   sendToBack(options?: LayerOptions): Promise<void>;
   /**
    * Moves a browser that was behind the host WebView back to the front.
+   * On iOS, set `isAnimated` to `false` to skip the presentation animation.
    * When `id` is omitted, targets the active webview.
    */
-  bringToFront(options?: { id?: string }): Promise<void>;
+  bringToFront(options?: BringToFrontOptions): Promise<void>;
   /**
    * Dispatches a click, touch, or scroll event to a managed browser.
    * Coordinates are relative to the browser viewport in CSS pixels.

--- a/src/web.ts
+++ b/src/web.ts
@@ -6,6 +6,7 @@ import type {
   OpenOptions,
   GetCookieOptions,
   ClearCookieOptions,
+  BringToFrontOptions,
   DimensionOptions,
   DispatchInputEventOptions,
   OpenSecureWindowOptions,
@@ -71,7 +72,7 @@ export class InAppBrowserWeb extends WebPlugin implements InAppBrowserPlugin {
     return;
   }
 
-  async bringToFront(options?: { id?: string }): Promise<void> {
+  async bringToFront(options?: BringToFrontOptions): Promise<void> {
     console.log('bringToFront not supported on web', options);
     return;
   }


### PR DESCRIPTION
## What
- Adds an optional `isAnimated` option to `bringToFront()`.
- Regenerates the API reference with the new iOS-only option.

## Why
- iOS always presented a layered browser with `animated: true`, making `bringToFront()` noticeably slower than `sendToBack()`.
- Callers can now use `bringToFront({ id, isAnimated: false })` for an immediate restoration while existing callers stay animated.

## How
- Read `isAnimated` from the plugin call with a default of `true`.
- Pass that value to UIKit presentation.
- Reuse the existing `isAnimated` naming used by open and close options.

## Testing
- `bun run build`
- `bun run fmt`
- `bun run verify:android`
- `bun run verify:web` (18 tests passed)
- `bun run check:wiring`

## Not Tested
- Local `bun run verify:ios` cannot select an iOS destination because this Mac lacks the required iOS 26.4 platform/runtime; CI will run the iOS build and packed example checks.
- Local repository-wide `bun run lint` is blocked by pre-existing SwiftLint violations in installed dependency trees; no changed line was reported.
- Manual iOS timing validation requires a compatible simulator or connected device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `isAnimated` option to control iOS “bring to front” presentation animations.
  * Animations are enabled by default and can be disabled when bringing a webview to the front.

* **Documentation**
  * Updated API documentation with the new options type and its available fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->