### PR TITLE
fix(ios): blank toolbar crash and custom y-offset gap

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -1622,7 +1622,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
                     // Color the webview controller only — never paint PassThroughView or the
                     // y-offset gap would hide the host Capacitor app.
                     webViewController.view.backgroundColor = color
-                    applyBlankToolbarBackground(color, to: self.navigationWebViewController)
+                    self.applyBlankToolbarBackground(color, to: self.navigationWebViewController)
                 } else {
                     // Follow system appearance if no specific color
                     let isDarkMode = UITraitCollection.current.userInterfaceStyle == .dark
@@ -1633,7 +1633,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
                     // Apply status bar background color via the special view
                     webViewController.setupStatusBarBackground(color: backgroundColor)
 
-                    applyBlankToolbarBackground(backgroundColor, to: self.navigationWebViewController)
+                    self.applyBlankToolbarBackground(backgroundColor, to: self.navigationWebViewController)
                 }
 
             }
@@ -2083,7 +2083,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
 
 
     /// Keep PassThroughView clear so custom y-offsets show the host app behind the gap.
-    private func applyBlankToolbarBackground(_ color: UIColor, to navigationController: UINavigationController?) {
+    private func self.applyBlankToolbarBackground(_ color: UIColor, to navigationController: UINavigationController?) {
         guard let navigationController else { return }
 
         if let passThrough = navigationController.view as? PassThroughView {

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -115,6 +115,42 @@ enum ProxyResponseRoutingSupport {
     }
 }
 
+
+enum StatusBarBackgroundLayoutSupport {
+    enum Placement: Equatable {
+        case skip
+        case host(pinToNavigationBar: Bool)
+    }
+
+    /// Decide where/how to pin the status-bar chrome without painting a PassThroughView gap.
+    static func placement(
+        isPassThroughOverlay: Bool,
+        blankNavigationTab: Bool,
+        navigationBarInHostHierarchy: Bool
+    ) -> Placement {
+        if isPassThroughOverlay && blankNavigationTab {
+            // Custom-frame blank overlays must stay transparent in the y-offset gap.
+            return .skip
+        }
+
+        if blankNavigationTab || !navigationBarInHostHierarchy {
+            return .host(pinToNavigationBar: false)
+        }
+
+        return .host(pinToNavigationBar: true)
+    }
+
+    static func hostView(
+        navigationControllerView: UIView,
+        framedContentView: UIView?
+    ) -> UIView? {
+        if let passThrough = navigationControllerView as? PassThroughView {
+            return framedContentView ?? passThrough.framedContentView
+        }
+        return navigationControllerView
+    }
+}
+
 enum CustomWebViewFrameSupport {
     static func resolvedFrame(
         width: CGFloat?,
@@ -1583,14 +1619,10 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
                     // Apply status bar background color via the special view
                     webViewController.setupStatusBarBackground(color: color)
 
-                    // Apply background color to whole view to ensure no gaps
+                    // Color the webview controller only — never paint PassThroughView or the
+                    // y-offset gap would hide the host Capacitor app.
                     webViewController.view.backgroundColor = color
-                    self.navigationWebViewController?.view.backgroundColor = color
-
-                    // Apply status bar background color
-                    if let navController = self.navigationWebViewController {
-                        navController.view.backgroundColor = color
-                    }
+                    applyBlankToolbarBackground(color, to: self.navigationWebViewController)
                 } else {
                     // Follow system appearance if no specific color
                     let isDarkMode = UITraitCollection.current.userInterfaceStyle == .dark
@@ -1601,10 +1633,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
                     // Apply status bar background color via the special view
                     webViewController.setupStatusBarBackground(color: backgroundColor)
 
-                    // Set appropriate background color
-                    if let navController = self.navigationWebViewController {
-                        navController.view.backgroundColor = backgroundColor
-                    }
+                    applyBlankToolbarBackground(backgroundColor, to: self.navigationWebViewController)
                 }
 
             }
@@ -2050,6 +2079,20 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
                 }
             }
         }
+    }
+
+
+    /// Keep PassThroughView clear so custom y-offsets show the host app behind the gap.
+    private func applyBlankToolbarBackground(_ color: UIColor, to navigationController: UINavigationController?) {
+        guard let navigationController else { return }
+
+        if let passThrough = navigationController.view as? PassThroughView {
+            passThrough.backgroundColor = .clear
+            passThrough.framedContentView?.backgroundColor = color
+            return
+        }
+
+        navigationController.view.backgroundColor = color
     }
 
     private func normalizedAuthorizedHosts(from links: [String]) -> [String] {

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -2083,7 +2083,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
 
 
     /// Keep PassThroughView clear so custom y-offsets show the host app behind the gap.
-    private func self.applyBlankToolbarBackground(_ color: UIColor, to navigationController: UINavigationController?) {
+    private func applyBlankToolbarBackground(_ color: UIColor, to navigationController: UINavigationController?) {
         guard let navigationController else { return }
 
         if let passThrough = navigationController.view as? PassThroughView {

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -1101,7 +1101,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
     open var statusBarStyle: UIStatusBarStyle = .default
 
     // Status bar background view
-    private var statusBarBackgroundView: UIView?
+    var statusBarBackgroundView: UIView?
 
     // Status bar height
     private var statusBarHeight: CGFloat {
@@ -1151,25 +1151,60 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
     // Make status bar background with colored view underneath
     open func setupStatusBarBackground(color: UIColor) {
         statusBarBackgroundView?.removeFromSuperview()
-        statusBarBackgroundView = UIView()
+        statusBarBackgroundView = nil
 
-        guard let navController = navigationController,
-              let navView = navController.view,
-              let statusBarBackgroundView else {
+        guard let navController = navigationController else {
             return
         }
-        navView.insertSubview(statusBarBackgroundView, at: 0)
-        statusBarBackgroundView.translatesAutoresizingMaskIntoConstraints = false
-        statusBarBackgroundView.backgroundColor = color
 
-        NSLayoutConstraint.activate([
-            statusBarBackgroundView.topAnchor.constraint(equalTo: navView.topAnchor),
-            statusBarBackgroundView.leadingAnchor.constraint(equalTo: navView.leadingAnchor),
-            statusBarBackgroundView.trailingAnchor.constraint(equalTo: navView.trailingAnchor),
-            statusBarBackgroundView.bottomAnchor.constraint(equalTo: navController.navigationBar.bottomAnchor, constant: 1)
-        ])
+        if let passThrough = navController.view as? PassThroughView {
+            // Never paint the full-screen overlay — that fills the custom y-offset gap.
+            passThrough.backgroundColor = .clear
+        }
 
-        applyNavigationBarBackground(color: color)
+        let navigationBar = navController.navigationBar
+        let hostCandidate = StatusBarBackgroundLayoutSupport.hostView(
+            navigationControllerView: navController.view,
+            framedContentView: (navController.view as? PassThroughView)?.framedContentView
+        )
+        let navigationBarInHost = hostCandidate.map { navigationBar.isDescendant(of: $0) } ?? false
+        let placement = StatusBarBackgroundLayoutSupport.placement(
+            isPassThroughOverlay: navController.view is PassThroughView,
+            blankNavigationTab: blankNavigationTab,
+            navigationBarInHostHierarchy: navigationBarInHost
+        )
+
+        guard case .host(let pinToNavigationBar) = placement,
+              let hostView = hostCandidate else {
+            return
+        }
+
+        let backgroundView = UIView()
+        statusBarBackgroundView = backgroundView
+        hostView.insertSubview(backgroundView, at: 0)
+        backgroundView.translatesAutoresizingMaskIntoConstraints = false
+        backgroundView.backgroundColor = color
+
+        var constraints = [
+            backgroundView.topAnchor.constraint(equalTo: hostView.topAnchor),
+            backgroundView.leadingAnchor.constraint(equalTo: hostView.leadingAnchor),
+            backgroundView.trailingAnchor.constraint(equalTo: hostView.trailingAnchor)
+        ]
+
+        if pinToNavigationBar {
+            constraints.append(
+                backgroundView.bottomAnchor.constraint(equalTo: navigationBar.bottomAnchor, constant: 1)
+            )
+            applyNavigationBarBackground(color: color)
+        } else {
+            // Blank toolbar / detached nav bar: cover status-bar height only.
+            // Avoid pinning to a hidden UINavigationBar (removed from hierarchy → crash).
+            constraints.append(
+                backgroundView.heightAnchor.constraint(equalToConstant: max(statusBarHeight, 20))
+            )
+        }
+
+        NSLayoutConstraint.activate(constraints)
     }
 
     // Override to use our custom status bar style

--- a/ios/Tests/InAppBrowserPluginTests/StatusBarBackgroundLayoutSupportTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/StatusBarBackgroundLayoutSupportTests.swift
@@ -3,6 +3,8 @@ import XCTest
 @testable import InappbrowserPlugin
 
 final class StatusBarBackgroundLayoutSupportTests: XCTestCase {
+    private let exampleURL = URL(string: "https://example.com")!
+
     func testStatusBarBackgroundPlacementSkipsBlankPassThrough() {
         XCTAssertEqual(
             StatusBarBackgroundLayoutSupport.placement(
@@ -51,7 +53,7 @@ final class StatusBarBackgroundLayoutSupportTests: XCTestCase {
 
     func testSetupStatusBarBackgroundDoesNotCrashForBlankHiddenNavBar() {
         let controller = WKWebViewController(
-            source: .remote(URL(string: "https://example.com")!)
+            source: .remote(exampleURL)
         )
         controller.blankNavigationTab = true
         let navigationController = UINavigationController(rootViewController: controller)
@@ -72,7 +74,7 @@ final class StatusBarBackgroundLayoutSupportTests: XCTestCase {
 
     func testSetupStatusBarBackgroundKeepsPassThroughClearWithCustomOffset() {
         let controller = WKWebViewController(
-            source: .remote(URL(string: "https://example.com")!)
+            source: .remote(exampleURL)
         )
         let navigationController = UINavigationController(rootViewController: controller)
         navigationController.loadViewIfNeeded()
@@ -96,7 +98,7 @@ final class StatusBarBackgroundLayoutSupportTests: XCTestCase {
 
     func testSetupStatusBarBackgroundSkipsBlankPassThroughOverlay() {
         let controller = WKWebViewController(
-            source: .remote(URL(string: "https://example.com")!)
+            source: .remote(exampleURL)
         )
         controller.blankNavigationTab = true
         let navigationController = UINavigationController(rootViewController: controller)

--- a/ios/Tests/InAppBrowserPluginTests/StatusBarBackgroundLayoutSupportTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/StatusBarBackgroundLayoutSupportTests.swift
@@ -1,0 +1,118 @@
+import UIKit
+import XCTest
+@testable import InappbrowserPlugin
+
+final class StatusBarBackgroundLayoutSupportTests: XCTestCase {
+    func testStatusBarBackgroundPlacementSkipsBlankPassThrough() {
+        XCTAssertEqual(
+            StatusBarBackgroundLayoutSupport.placement(
+                isPassThroughOverlay: true,
+                blankNavigationTab: true,
+                navigationBarInHostHierarchy: false
+            ),
+            .skip
+        )
+    }
+
+    func testStatusBarBackgroundPlacementPinsCompactPassThroughToNavBar() {
+        XCTAssertEqual(
+            StatusBarBackgroundLayoutSupport.placement(
+                isPassThroughOverlay: true,
+                blankNavigationTab: false,
+                navigationBarInHostHierarchy: true
+            ),
+            .host(pinToNavigationBar: true)
+        )
+    }
+
+    func testStatusBarBackgroundPlacementUsesHeightWhenBlankFullscreen() {
+        XCTAssertEqual(
+            StatusBarBackgroundLayoutSupport.placement(
+                isPassThroughOverlay: false,
+                blankNavigationTab: true,
+                navigationBarInHostHierarchy: false
+            ),
+            .host(pinToNavigationBar: false)
+        )
+    }
+
+    func testStatusBarBackgroundHostPrefersFramedContentForPassThrough() {
+        let passThrough = PassThroughView(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        let framed = UIView(frame: CGRect(x: 0, y: 70, width: 390, height: 600))
+        passThrough.framedContentView = framed
+
+        let host = StatusBarBackgroundLayoutSupport.hostView(
+            navigationControllerView: passThrough,
+            framedContentView: framed
+        )
+
+        XCTAssertTrue(host === framed)
+    }
+
+    func testSetupStatusBarBackgroundDoesNotCrashForBlankHiddenNavBar() {
+        let controller = WKWebViewController(
+            source: .remote(URL(string: "https://example.com")!)
+        )
+        controller.blankNavigationTab = true
+        let navigationController = UINavigationController(rootViewController: controller)
+        navigationController.setNavigationBarHidden(true, animated: false)
+        navigationController.loadViewIfNeeded()
+        controller.loadViewIfNeeded()
+
+        controller.setupStatusBarBackground(color: .white)
+
+        XCTAssertNotNil(controller.statusBarBackgroundView)
+        XCTAssertEqual(controller.statusBarBackgroundView?.superview, navigationController.view)
+        let pinnedToNavBar = controller.statusBarBackgroundView?.constraints.contains {
+            ($0.secondItem as? UINavigationBar) === navigationController.navigationBar
+                || ($0.firstItem as? UINavigationBar) === navigationController.navigationBar
+        } ?? false
+        XCTAssertFalse(pinnedToNavBar)
+    }
+
+    func testSetupStatusBarBackgroundKeepsPassThroughClearWithCustomOffset() {
+        let controller = WKWebViewController(
+            source: .remote(URL(string: "https://example.com")!)
+        )
+        let navigationController = UINavigationController(rootViewController: controller)
+        navigationController.loadViewIfNeeded()
+        controller.loadViewIfNeeded()
+
+        let passThrough = PassThroughView(frame: UIScreen.main.bounds)
+        passThrough.backgroundColor = .clear
+        let originalView = navigationController.view!
+        navigationController.view = passThrough
+        passThrough.addSubview(originalView)
+        passThrough.framedContentView = originalView
+        passThrough.targetFrame = CGRect(x: 0, y: 200, width: 390, height: 600)
+        originalView.frame = passThrough.targetFrame!
+
+        controller.setupStatusBarBackground(color: .white)
+
+        XCTAssertEqual(passThrough.backgroundColor, UIColor.clear)
+        XCTAssertEqual(controller.statusBarBackgroundView?.superview, originalView)
+        XCTAssertFalse(passThrough.subviews.contains { $0 === controller.statusBarBackgroundView })
+    }
+
+    func testSetupStatusBarBackgroundSkipsBlankPassThroughOverlay() {
+        let controller = WKWebViewController(
+            source: .remote(URL(string: "https://example.com")!)
+        )
+        controller.blankNavigationTab = true
+        let navigationController = UINavigationController(rootViewController: controller)
+        navigationController.loadViewIfNeeded()
+        controller.loadViewIfNeeded()
+
+        let passThrough = PassThroughView(frame: UIScreen.main.bounds)
+        let originalView = navigationController.view!
+        navigationController.view = passThrough
+        passThrough.addSubview(originalView)
+        passThrough.framedContentView = originalView
+        navigationController.setNavigationBarHidden(true, animated: false)
+
+        controller.setupStatusBarBackground(color: .white)
+
+        XCTAssertNil(controller.statusBarBackgroundView)
+        XCTAssertEqual(passThrough.backgroundColor, UIColor.clear)
+    }
+}


### PR DESCRIPTION
## Summary
- Fix iOS crash when `toolbarType: blank` hides the navigation bar, then `setupStatusBarBackground` pins constraints to a detached `UINavigationBar` ("no common ancestor").
- Keep custom `x`/`y`/`width`/`height` overlays transparent above the webview: status-bar chrome now hosts on PassThroughView framed content instead of painting the full-screen gap (so the host Capacitor/Ionic UI stays visible).
- Add unit/integration coverage in `StatusBarBackgroundLayoutSupportTests`.

## Test plan
- [ ] `toolbarType: ToolBarType.BLANK` opens without crashing (fullscreen)
- [ ] `toolbarType: BLANK` + custom `y`/`height` shows host app in the top gap
- [ ] `toolbarType: COMPACT` + `y: 200` shows host app above the toolbar (no opaque white dock fill)
- [ ] Default toolbar modes still color status bar + nav bar as before
- [ ] CI `verify:ios` / package tests pass


Made with [Cursor](https://cursor.com)