### PR TITLE
fix(android): stop black gap above keyboard on Android 14

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
@@ -54,6 +54,19 @@ final class SafeAreaInsetsSupport {
         );
     }
 
+    /**
+     * Absolute IME insets from the window decor must only be applied as layout margins when the
+     * dialog is edge-to-edge. Pre-Android 15 windows still fit system windows and are resized for
+     * the soft keyboard; applying decor IME height again leaves a black gap above the keyboard.
+     */
+    static int resolveImeBottomInset(boolean keyboardVisible, int imeBottom, boolean applyImeAsLayoutMargin) {
+        if (!keyboardVisible || !applyImeAsLayoutMargin || imeBottom <= 0) {
+            return 0;
+        }
+
+        return imeBottom;
+    }
+
     static int resolveBottomMargin(boolean enabledSafeBottomMargin, int safeBottomInset, int imeBottom) {
         int bottomInset = enabledSafeBottomMargin ? safeBottomInset : 0;
         return Math.max(bottomInset, imeBottom);

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -3056,7 +3056,16 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                 toolbarView != null &&
                 toolbarView.getVisibility() == View.VISIBLE &&
                 toolbarView.getParent() instanceof com.google.android.material.appbar.AppBarLayout;
-            applySafeAreaMargins(bars, navigationBars, systemGestures, mandatoryGestures, ime, keyboardVisible, appBarHandlesTopInset);
+            applySafeAreaMargins(
+                bars,
+                navigationBars,
+                systemGestures,
+                mandatoryGestures,
+                ime,
+                keyboardVisible,
+                appBarHandlesTopInset,
+                isAndroid15Plus
+            );
 
             return windowInsets;
         });
@@ -3139,7 +3148,8 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         Insets mandatoryGestures,
         Insets ime,
         boolean keyboardVisible,
-        boolean appBarHandlesTopInset
+        boolean appBarHandlesTopInset,
+        boolean applyImeAsLayoutMargin
     ) {
         if (_webView == null || _options == null) {
             return;
@@ -3163,7 +3173,9 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             fallbackBottomInset,
             _options.getEnabledSafeMargin()
         );
-        int imeBottom = keyboardVisible ? ime.bottom : 0;
+        // Android 15+ uses edge-to-edge (decorFitsSystemWindows=false) and needs IME as margin.
+        // Older dialogs still resize for the keyboard; re-applying decor IME creates a black gap (#622).
+        int imeBottom = SafeAreaInsetsSupport.resolveImeBottomInset(keyboardVisible, ime.bottom, applyImeAsLayoutMargin);
         boolean applyTopFallback = _options.getEnabledSafeTopMargin() && _options.getUseTopInset();
         int fallbackTopInset = applyTopFallback ? getSystemStatusBarHeight() : 0;
         int navTop = SafeAreaInsetsSupport.resolveTopMarginWithFallback(

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupportTest.java
@@ -53,6 +53,14 @@ public class SafeAreaInsetsSupportTest {
     }
 
     @Test
+    public void imeBottomInsetOnlyAppliedForEdgeToEdgeWindows() {
+        assertEquals(0, SafeAreaInsetsSupport.resolveImeBottomInset(true, 280, false));
+        assertEquals(280, SafeAreaInsetsSupport.resolveImeBottomInset(true, 280, true));
+        assertEquals(0, SafeAreaInsetsSupport.resolveImeBottomInset(false, 280, true));
+        assertEquals(0, SafeAreaInsetsSupport.resolveImeBottomInset(true, 0, true));
+    }
+
+    @Test
     public void topMarginRequiresSafeTopAndExplicitTopInsetWithoutAppBarHandling() {
         assertEquals(48, SafeAreaInsetsSupport.resolveTopMargin(true, true, 48, false));
         assertEquals(0, SafeAreaInsetsSupport.resolveTopMargin(false, true, 48, false));


### PR DESCRIPTION
## Summary
- Fixes #622: black empty area above the Android keyboard when focusing an input in the InAppBrowser on Android 14 (regression vs Android 16 / edge-to-edge).
- Root cause: safe-area code reads absolute IME insets from the dialog decor and applies them as WebView bottom margin. On pre-Android 15 the dialog window still fits system windows and is resized for the soft keyboard, so applying decor IME height again double-counts and leaves a black gap.
- Fix: only apply IME as a layout margin on Android 15+ (edge-to-edge / `setDecorFitsSystemWindows(false)`). Older APIs keep relying on the window resize path.

## Test plan
- [x] `bunx prettier --write ... --plugin=prettier-plugin-java`
- [x] `./gradlew testDebugUnitTest --tests ee.forgr.capacitor_inappbrowser.SafeAreaInsetsSupportTest`
- [ ] CI `bun run verify` / Android unit tests
- [ ] Manual: Android 14 device/emulator — open InAppBrowser, focus an input, confirm no black gap above keyboard
- [ ] Manual: Android 15/16 — confirm keyboard still pushes WebView correctly with edge-to-edge


Made with [Cursor](https://cursor.com)