### PR TITLE
feat: page load start and progress events

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,8 @@ The W3C Payment Request API (used by Google Pay) requires Android WebView 120+. 
 * [`addListener('messageFromWebview', ...)`](#addlistenermessagefromwebview-)
 * [`addListener('screenshotTaken', ...)`](#addlistenerscreenshottaken-)
 * [`addListener('browserPageLoaded', ...)`](#addlistenerbrowserpageloaded-)
+* [`addListener('browserPageLoadStart', ...)`](#addlistenerbrowserpageloadstart-)
+* [`addListener('browserPageLoadProgress', ...)`](#addlistenerbrowserpageloadprogress-)
 * [`addListener('pageLoadError', ...)`](#addlistenerpageloaderror-)
 * [`addListener('customSchemeIntercepted', ...)`](#addlistenercustomschemeintercepted-)
 * [`addListener('downloadCompleted', ...)`](#addlistenerdownloadcompleted-)
@@ -1074,6 +1076,47 @@ Will be triggered when page is loaded
 | **`listenerFunc`** | <code>(event: { id?: string; }) =&gt; void</code> |
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+--------------------
+
+
+### addListener('browserPageLoadStart', ...)
+
+```typescript
+addListener(eventName: 'browserPageLoadStart', listenerFunc: (event: { id?: string; }) => void) => Promise<PluginListenerHandle>
+```
+
+Will be triggered when a main-frame page load starts (link navigation, reload, etc.).
+
+| Param              | Type                                              |
+| ------------------ | ------------------------------------------------- |
+| **`eventName`**    | <code>'browserPageLoadStart'</code>               |
+| **`listenerFunc`** | <code>(event: { id?: string; }) =&gt; void</code> |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+**Since:** 8.11.0
+
+--------------------
+
+
+### addListener('browserPageLoadProgress', ...)
+
+```typescript
+addListener(eventName: 'browserPageLoadProgress', listenerFunc: (event: { id?: string; progress: number; }) => void) => Promise<PluginListenerHandle>
+```
+
+Will be triggered as a main-frame page load progresses.
+`progress` is a value from `0` to `1`.
+
+| Param              | Type                                                                |
+| ------------------ | ------------------------------------------------------------------- |
+| **`eventName`**    | <code>'browserPageLoadProgress'</code>                              |
+| **`listenerFunc`** | <code>(event: { id?: string; progress: number; }) =&gt; void</code> |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+**Since:** 8.11.0
 
 --------------------
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
@@ -184,6 +184,16 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
             }
 
             @Override
+            public void pageLoadStart() {
+                notifyListeners("browserPageLoadStart", new JSObject().put("id", webViewId));
+            }
+
+            @Override
+            public void pageLoadProgress(double progress) {
+                notifyListeners("browserPageLoadProgress", new JSObject().put("id", webViewId).put("progress", progress));
+            }
+
+            @Override
             public void pageLoadError() {
                 notifyListeners("pageLoadError", new JSObject().put("id", webViewId));
             }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCallbacks.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCallbacks.java
@@ -11,6 +11,10 @@ public interface WebViewCallbacks {
 
     public void pageLoaded();
 
+    public void pageLoadStart();
+
+    public void pageLoadProgress(double progress);
+
     public void pageLoadError();
 
     public void customSchemeIntercepted(String url, boolean opened);

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -2625,6 +2625,10 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                 public void onProgressChanged(WebView view, int newProgress) {
                     super.onProgressChanged(view, newProgress);
 
+                    if (_options.getCallbacks() != null) {
+                        _options.getCallbacks().pageLoadProgress(newProgress / 100.0);
+                    }
+
                     // When the page is almost loaded, inject our date picker customization
                     // Only if materialPicker option is enabled
                     if (newProgress > 75 && !datePickerInjected && _options.getMaterialPicker()) {
@@ -5430,6 +5434,9 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                     super.onPageStarted(view, url, favicon);
                     if (view == null || _webView == null) {
                         return;
+                    }
+                    if (_options.getCallbacks() != null) {
+                        _options.getCallbacks().pageLoadStart();
                     }
                     if (ProxyRequestSupport.shouldInjectBridge(_options) && proxyBridgeScript != null && proxyAccessToken != null) {
                         String preparedProxyBridgeScript = prepareProxyBridgeScript();

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -110,7 +110,6 @@ enum CustomSchemeOpenSupport {
     }
 }
 
-
 protocol ProxyRequestLocating {
     func hasPendingProxyRequest(_ requestId: String) -> Bool
 }
@@ -148,7 +147,6 @@ enum ProxyResponseRoutingSupport {
         return .matched(matchedHandler)
     }
 }
-
 
 enum StatusBarBackgroundLayoutSupport {
     enum Placement: Equatable {
@@ -2117,7 +2115,6 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
-
     /// Keep PassThroughView clear so custom y-offsets show the host app behind the gap.
     private func applyBlankToolbarBackground(_ color: UIColor, to navigationController: UINavigationController?) {
         guard let navigationController else { return }
@@ -2414,7 +2411,6 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
             call.resolve()
         }
     }
-
 
     private func showPrivacyScreen() {
         if privacyScreen == nil {

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -2431,6 +2431,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
                 }
                 self.progressView?.alpha = 1
                 self.progressView?.setProgress(Float(estimatedProgress), animated: true)
+                self.emit("browserPageLoadProgress", data: ["progress": estimatedProgress])
 
                 if estimatedProgress >= 1.0 {
                     UIView.animate(withDuration: 0.3, delay: 0.3, options: .curveEaseOut, animations: {
@@ -3451,6 +3452,7 @@ extension WKWebViewController: WKNavigationDelegate {
             self.url = urlValue
             delegate?.webViewController?(self, didStart: urlValue)
         }
+        emit("browserPageLoadStart")
     }
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         if !didpageInit && self.capBrowserPlugin?.isPresentAfterPageLoad == true {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1588,6 +1588,27 @@ export interface InAppBrowserPlugin {
   ): Promise<PluginListenerHandle>;
 
   /**
+   * Will be triggered when a main-frame page load starts (link navigation, reload, etc.).
+   *
+   * @since 8.11.0
+   */
+  addListener(
+    eventName: 'browserPageLoadStart',
+    listenerFunc: (event: { id?: string }) => void,
+  ): Promise<PluginListenerHandle>;
+
+  /**
+   * Will be triggered as a main-frame page load progresses.
+   * `progress` is a value from `0` to `1`.
+   *
+   * @since 8.11.0
+   */
+  addListener(
+    eventName: 'browserPageLoadProgress',
+    listenerFunc: (event: { id?: string; progress: number }) => void,
+  ): Promise<PluginListenerHandle>;
+
+  /**
    * Will be triggered when page load error
    */
   addListener(


### PR DESCRIPTION
## Summary
- Adds `browserPageLoadStart` (`{ id? }`) and `browserPageLoadProgress` (`{ id?, progress: 0..1 }`) listeners for `openWebView`
- iOS: start on `didStartProvisionalNavigation`, progress from existing `estimatedProgress` KVO
- Android: start on `onPageStarted`, progress from existing `WebChromeClient.onProgressChanged`
- Closes #627

## Test plan
- [ ] Open a webview and confirm `browserPageLoadStart` fires when navigating (initial load + in-page link click)
- [ ] Confirm `browserPageLoadProgress` emits values from `0` toward `1` during load
- [ ] Confirm existing `browserPageLoaded` still fires on successful load
- [ ] Confirm `pageLoadError` still fires on failure
- [ ] Smoke both iOS and Android


Made with [Cursor](https://cursor.com)