### PR TITLE
fix(ios): stop openWebView double-resolve from presentView

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -611,7 +611,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
            webViewController.shouldPresentAsFramedOverlay {
             dismissActiveKeyboard()
             if presentNavigationControllerAsFramedOverlay(id: resolvedId) {
-                self.currentPluginCall?.resolve()
+                // openWebView resolves with the webView id; do not resolve here.
                 return true
             }
             self.currentPluginCall?.reject("Failed to present webview")
@@ -625,9 +625,9 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
         dismissActiveKeyboard()
         let presenter = self.bridge?.viewController?.presentedViewController ?? self.bridge?.viewController
         presentNavigationControllerSafely(navigationController, from: presenter, animated: isAnimated) { presented in
-            if presented {
-                self.currentPluginCall?.resolve()
-            } else {
+            if !presented {
+                // openWebView already resolves with the webView id on success.
+                // Resolving here caused a double-resolve (empty, then with id). See #631.
                 self.currentPluginCall?.reject("Failed to present webview")
             }
         }
@@ -1619,6 +1619,8 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
                 }
             }
             call.resolve(["id": webViewId])
+            // Prevent deferred presentView (isPresentAfterPageLoad) from touching a completed call.
+            self.currentPluginCall = nil
         }
     }
 

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -1619,8 +1619,10 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
                 }
             }
             call.resolve(["id": webViewId])
-            // Prevent deferred presentView (isPresentAfterPageLoad) from touching a completed call.
-            self.currentPluginCall = nil
+            // Only clear if this call still owns the slot (overlapping openWebView races).
+            if self.currentPluginCall === call {
+                self.currentPluginCall = nil
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- `presentView` no longer empty-resolves `currentPluginCall` on success; `openWebView` is the sole success resolver and returns `{ id }`.
- Clear `currentPluginCall` after that resolve so deferred presentation (`isPresentAfterPageLoad`) cannot touch a completed call.
- Fixes #631

## Test plan
- [ ] iOS: call `InAppBrowser.openWebView({ url })` and confirm the promise resolves once with a non-empty `id`
- [ ] iOS: same with `isPresentAfterPageLoad: true` — still a single resolve with `id`, browser presents after load
- [ ] iOS: custom frame / framed overlay open still returns `id` once
- [ ] CI `bun run verify` / test workflow green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

