### PR TITLE
fix(ios): auto-grant WKWebView media capture permission

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -3349,6 +3349,19 @@ extension WKWebViewController: WKUIDelegate {
         // This allows websites to access location when opened with openWebView
         decisionHandler(.grant)
     }
+
+    @available(iOS 15.0, *)
+    public func webView(_ webView: WKWebView, requestMediaCapturePermissionFor origin: WKSecurityOrigin, initiatedByFrame frame: WKFrameInfo, type: WKMediaCaptureType, decisionHandler: @escaping (WKPermissionDecision) -> Void) {
+        print("[InAppBrowser] Media capture permission requested for origin: \(origin.host)")
+
+        // Grant media capture permission automatically, matching Capacitor core's
+        // WebViewDelegationHandler. The OS-level camera/microphone permission
+        // (Info.plist usage description + system prompt) still applies — this only
+        // suppresses WebKit's extra per-origin prompt, which is not persisted
+        // across app launches (WebKit bug 220416) and would otherwise re-prompt
+        // users on every cold start.
+        decisionHandler(.grant)
+    }
 }
 
 // MARK: - Host Blocking Utilities


### PR DESCRIPTION
### What

Implements `webView(_:requestMediaCapturePermissionFor:initiatedByFrame:type:decisionHandler:)`
(iOS 15+) on the `WKUIDelegate` in `WKWebViewController`, auto-granting media capture the same
way the plugin already auto-grants geolocation.

### Why

When a page opened with `openWebView` calls `getUserMedia` (microphone/camera):

1. iOS shows the **system** permission prompt (from the host app's Info.plist usage description) — correct, once ever.
2. WebKit then shows its **own per-origin prompt** ("example.com would like to access the microphone") on top of it.

That second prompt is not persisted across app launches for WKWebView
(WebKit bug [220416](https://bugs.webkit.org/show_bug.cgi?id=220416)), so users are re-prompted
**every cold start** of the host app. For apps embedding a voice/WebRTC experience this breaks the UX.

`decisionHandler(.grant)` defers entirely to the OS-level permission: if the app doesn't have
microphone/camera permission, capture still fails and the system prompt still governs access.
This is exactly what Capacitor core does in its own `WebViewDelegationHandler`
([capacitor/ios WebViewDelegationHandler.swift](https://github.com/ionic-team/capacitor/blob/main/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift)),
so pages running inside the InAppBrowser WebView now behave like pages in the main Capacitor WebView.

### Platform parity

- **Android** already grants WebView permission requests via `onPermissionRequest` in `WebViewDialog.java` — iOS was the gap.
- **Geolocation** on iOS is already auto-granted by this class (`requestGeolocationPermissionFor`); this mirrors that handler, including the log line style.

### Testing

Running in production inside a Capacitor 8 conference app (via `patch-package`) that embeds a
WebRTC push-to-talk web app: with the patch, the mic prompt appears exactly once (system prompt);
without it, WebKit re-prompts on every app relaunch.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera and microphone access handling in the in-app browser.
  * Prevented additional per-site permission prompts when media capture is requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->