### PR TITLE
fix(ios): derive openSecureWindow callbackURLScheme from redirectUri

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -129,6 +129,13 @@ enum SecureWindowRedirectSupport {
 
         let expectedItems = expected.percentEncodedQueryItems ?? []
         let receivedItems = received.percentEncodedQueryItems ?? []
+        let configuredDecodedNames = Set((expected.queryItems ?? []).map(\.name))
+        let configuredReceivedItemCount = (received.queryItems ?? []).filter {
+            configuredDecodedNames.contains($0.name)
+        }.count
+        guard configuredReceivedItemCount == expectedItems.count else {
+            return false
+        }
         return Set(expectedItems.map(\.name)).allSatisfy { name in
             receivedItems.filter { $0.name == name } == expectedItems.filter { $0.name == name }
         }

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -119,26 +119,23 @@ enum SecureWindowRedirectSupport {
         guard let expected = URLComponents(string: redirectUri),
               let received = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
               received.scheme?.lowercased() == expected.scheme?.lowercased(),
-              received.user == expected.user,
-              received.password == expected.password,
-              received.host?.lowercased() == expected.host?.lowercased(),
+              received.percentEncodedUser == expected.percentEncodedUser,
+              received.percentEncodedPassword == expected.percentEncodedPassword,
+              received.percentEncodedHost?.lowercased() == expected.percentEncodedHost?.lowercased(),
               received.port == expected.port,
-              normalizedPath(received.path) == normalizedPath(expected.path) else {
+              normalizedPath(received.percentEncodedPath) == normalizedPath(expected.percentEncodedPath) else {
             return false
         }
 
-        let expectedItems = expected.queryItems ?? []
-        let configuredNames = Set(expectedItems.map(\.name))
-        let receivedItems = (received.queryItems ?? []).filter { configuredNames.contains($0.name) }
-        return occurrences(of: expectedItems) == occurrences(of: receivedItems)
+        let expectedItems = expected.percentEncodedQueryItems ?? []
+        let receivedItems = received.percentEncodedQueryItems ?? []
+        return Set(expectedItems.map(\.name)).allSatisfy { name in
+            receivedItems.filter { $0.name == name } == expectedItems.filter { $0.name == name }
+        }
     }
 
     private static func normalizedPath(_ path: String) -> String {
         path == "/" ? "" : path
-    }
-
-    private static func occurrences(of items: [URLQueryItem]) -> [URLQueryItem: Int] {
-        items.reduce(into: [:]) { counts, item in counts[item, default: 0] += 1 }
     }
 }
 

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -113,25 +113,32 @@ enum CustomSchemeOpenSupport {
 enum SecureWindowRedirectSupport {
     /// The auth session reports any navigation on the callback scheme, so the redirect is
     /// identified component-wise. Query items configured in the redirect URI are matched,
-    /// while any extra items (e.g. provider code, state) are ignored.
+    /// while any extra items (e.g. provider code, state) are ignored, unless they reuse a
+    /// configured name: parsers disagree over which duplicate takes precedence.
     static func matches(_ callbackURL: URL, redirectUri: String) -> Bool {
         guard let expected = URLComponents(string: redirectUri),
               let received = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
               received.scheme?.lowercased() == expected.scheme?.lowercased(),
+              received.user == expected.user,
+              received.password == expected.password,
               received.host?.lowercased() == expected.host?.lowercased(),
               received.port == expected.port,
               normalizedPath(received.path) == normalizedPath(expected.path) else {
             return false
         }
 
-        let receivedItems = received.queryItems ?? []
-        return (expected.queryItems ?? []).allSatisfy { item in
-            receivedItems.contains { $0.name == item.name && $0.value == item.value }
-        }
+        let expectedItems = expected.queryItems ?? []
+        let configuredNames = Set(expectedItems.map(\.name))
+        let receivedItems = (received.queryItems ?? []).filter { configuredNames.contains($0.name) }
+        return occurrences(of: expectedItems) == occurrences(of: receivedItems)
     }
 
     private static func normalizedPath(_ path: String) -> String {
         path == "/" ? "" : path
+    }
+
+    private static func occurrences(of items: [URLQueryItem]) -> [URLQueryItem: Int] {
+        items.reduce(into: [:]) { counts, item in counts[item, default: 0] += 1 }
     }
 }
 

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -2556,9 +2556,11 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
 
         let prefersEphemeral = call.getBool("prefersEphemeralWebBrowserSession") ?? false
 
+        let callbackURLScheme = URL(string: redirectUri)?.scheme ?? url.scheme
+
         // Open the URL in a secure browser window
         DispatchQueue.main.async {
-            let session = ASWebAuthenticationSession(url: url, callbackURLScheme: url.scheme) {
+            let session = ASWebAuthenticationSession(url: url, callbackURLScheme: callbackURLScheme) {
                 callbackURL, error in
 
                 // Clean up the stored call

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -110,6 +110,31 @@ enum CustomSchemeOpenSupport {
     }
 }
 
+enum SecureWindowRedirectSupport {
+    /// The auth session reports any navigation on the callback scheme, so the redirect is
+    /// identified component-wise. Query items configured in the redirect URI are matched,
+    /// while any extra items (e.g. provider code, state) are ignored.
+    static func matches(_ callbackURL: URL, redirectUri: String) -> Bool {
+        guard let expected = URLComponents(string: redirectUri),
+              let received = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
+              received.scheme?.lowercased() == expected.scheme?.lowercased(),
+              received.host?.lowercased() == expected.host?.lowercased(),
+              received.port == expected.port,
+              normalizedPath(received.path) == normalizedPath(expected.path) else {
+            return false
+        }
+
+        let receivedItems = received.queryItems ?? []
+        return (expected.queryItems ?? []).allSatisfy { item in
+            receivedItems.contains { $0.name == item.name && $0.value == item.value }
+        }
+    }
+
+    private static func normalizedPath(_ path: String) -> String {
+        path == "/" ? "" : path
+    }
+}
+
 protocol ProxyRequestLocating {
     func hasPendingProxyRequest(_ requestId: String) -> Bool
 }
@@ -2551,12 +2576,15 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
+        guard let callbackURLScheme = URL(string: redirectUri)?.scheme else {
+            call.reject("Invalid Redirect URI")
+            return
+        }
+
         // Store the call for later resolution
         self.openSecureWindowCall = call
 
         let prefersEphemeral = call.getBool("prefersEphemeralWebBrowserSession") ?? false
-
-        let callbackURLScheme = URL(string: redirectUri)?.scheme ?? url.scheme
 
         // Open the URL in a secure browser window
         DispatchQueue.main.async {
@@ -2577,7 +2605,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
                     return
                 }
 
-                if !callbackURL.absoluteString.hasPrefix(redirectUri) {
+                if !SecureWindowRedirectSupport.matches(callbackURL, redirectUri: redirectUri) {
                     call.reject("Redirect URI does not match, expected " + redirectUri + " but got " + callbackURL.absoluteString)
                     return
                 }

--- a/ios/Tests/InAppBrowserPluginTests/SecureWindowRedirectSupportTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/SecureWindowRedirectSupportTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import InappbrowserPlugin
+
+final class SecureWindowRedirectSupportTests: XCTestCase {
+    private func matches(_ callback: String, _ redirectUri: String) throws -> Bool {
+        let callbackURL = try XCTUnwrap(URL(string: callback))
+        return SecureWindowRedirectSupport.matches(callbackURL, redirectUri: redirectUri)
+    }
+
+    func testAcceptsRedirectWithProviderResponseParameters() throws {
+        XCTAssertTrue(try matches("myapp://callback?code=abc&state=xyz", "myapp://callback"))
+        XCTAssertTrue(try matches("https://example.com/callback?code=abc", "https://example.com/callback"))
+    }
+
+    func testAcceptsConfiguredQueryItemsInAnyOrder() throws {
+        XCTAssertTrue(try matches("myapp://callback?code=abc&type=login", "myapp://callback?type=login"))
+        XCTAssertFalse(try matches("myapp://callback?code=abc", "myapp://callback?type=login"))
+        XCTAssertFalse(try matches("myapp://callback?type=logout", "myapp://callback?type=login"))
+    }
+
+    func testRejectsConflictingDuplicatesOfConfiguredQueryItems() throws {
+        XCTAssertFalse(try matches("myapp://callback?type=login&type=evil", "myapp://callback?type=login"))
+        XCTAssertFalse(try matches("myapp://callback?type=evil&type=login", "myapp://callback?type=login"))
+    }
+
+    func testRequiresEveryOccurrenceOfARepeatedQueryItem() throws {
+        XCTAssertFalse(try matches("myapp://callback?scope=a", "myapp://callback?scope=a&scope=b"))
+        XCTAssertTrue(try matches("myapp://callback?scope=a&scope=b&code=x", "myapp://callback?scope=a&scope=b"))
+        XCTAssertTrue(try matches("myapp://callback?scope=b&scope=a", "myapp://callback?scope=a&scope=b"))
+    }
+
+    func testRejectsCallbacksThatOnlyShareThePrefix() throws {
+        XCTAssertFalse(try matches("myapp://callback-evil?code=abc", "myapp://callback"))
+        XCTAssertFalse(try matches("myapp://callback/evil?code=abc", "myapp://callback"))
+        XCTAssertFalse(try matches("https://example.com/callback.evil.test/x", "https://example.com/callback"))
+    }
+
+    func testRejectsInjectedUserInfo() throws {
+        XCTAssertFalse(try matches("myapp://evil@callback?code=abc", "myapp://callback"))
+        XCTAssertFalse(try matches("https://evil:secret@example.com/callback", "https://example.com/callback"))
+    }
+
+    func testComparesSchemeAndHostCaseInsensitivelyAndPortExactly() throws {
+        XCTAssertTrue(try matches("MYAPP://CALLBACK?code=abc", "myapp://callback"))
+        XCTAssertFalse(try matches("https://example.com:8080/callback", "https://example.com/callback"))
+    }
+
+    func testTreatsRootPathAsEquivalentToEmptyPath() throws {
+        XCTAssertTrue(try matches("myapp://callback/?code=abc", "myapp://callback"))
+        XCTAssertTrue(try matches("myapp://callback?code=abc", "myapp://callback/"))
+    }
+
+    func testRejectsRedirectUriThatCannotBeParsed() throws {
+        XCTAssertFalse(try matches("myapp://callback", ""))
+    }
+}

--- a/ios/Tests/InAppBrowserPluginTests/SecureWindowRedirectSupportTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/SecureWindowRedirectSupportTests.swift
@@ -21,6 +21,7 @@ final class SecureWindowRedirectSupportTests: XCTestCase {
     func testRejectsConflictingDuplicatesOfConfiguredQueryItems() throws {
         XCTAssertFalse(try matches("myapp://callback?type=login&type=evil", "myapp://callback?type=login"))
         XCTAssertFalse(try matches("myapp://callback?type=evil&type=login", "myapp://callback?type=login"))
+        XCTAssertFalse(try matches("myapp://callback?type=login&t%79pe=evil", "myapp://callback?type=login"))
     }
 
     func testRequiresEveryOccurrenceOfARepeatedQueryItemInOrder() throws {

--- a/ios/Tests/InAppBrowserPluginTests/SecureWindowRedirectSupportTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/SecureWindowRedirectSupportTests.swift
@@ -23,16 +23,25 @@ final class SecureWindowRedirectSupportTests: XCTestCase {
         XCTAssertFalse(try matches("myapp://callback?type=evil&type=login", "myapp://callback?type=login"))
     }
 
-    func testRequiresEveryOccurrenceOfARepeatedQueryItem() throws {
+    func testRequiresEveryOccurrenceOfARepeatedQueryItemInOrder() throws {
         XCTAssertFalse(try matches("myapp://callback?scope=a", "myapp://callback?scope=a&scope=b"))
         XCTAssertTrue(try matches("myapp://callback?scope=a&scope=b&code=x", "myapp://callback?scope=a&scope=b"))
-        XCTAssertTrue(try matches("myapp://callback?scope=b&scope=a", "myapp://callback?scope=a&scope=b"))
+        XCTAssertFalse(try matches("myapp://callback?scope=b&scope=a", "myapp://callback?scope=a&scope=b"))
     }
 
     func testRejectsCallbacksThatOnlyShareThePrefix() throws {
         XCTAssertFalse(try matches("myapp://callback-evil?code=abc", "myapp://callback"))
         XCTAssertFalse(try matches("myapp://callback/evil?code=abc", "myapp://callback"))
         XCTAssertFalse(try matches("https://example.com/callback.evil.test/x", "https://example.com/callback"))
+    }
+
+    func testKeepsEncodedAndLiteralComponentsDistinct() throws {
+        XCTAssertFalse(try matches("https://example.com/a%2Fb", "https://example.com/a/b"))
+        XCTAssertFalse(try matches("https://example.com/a/b", "https://example.com/a%2Fb"))
+        XCTAssertTrue(try matches("https://example.com/a%2Fb?code=x", "https://example.com/a%2Fb"))
+        XCTAssertFalse(try matches("myapp://c%61llback", "myapp://callback"))
+        XCTAssertFalse(try matches("myapp://callback?type=b%2Bc", "myapp://callback?type=b+c"))
+        XCTAssertTrue(try matches("myapp://callback?type=b+c&code=x", "myapp://callback?type=b+c"))
     }
 
     func testRejectsInjectedUserInfo() throws {


### PR DESCRIPTION
Currently `openSecureWindow` passes the authEndpoint's scheme (https) as `callbackURLScheme` to `ASWebAuthenticationSession`. Per Apple's documentation, `callbackURLScheme` must be the app's custom scheme for our session to intercept. This PR derives the callback scheme from `redirectUri`, falling back to the old `url.scheme` if it can't parse one.

http(s) works in practice only when the redirect scheme is registered in Info.plist, but this behaviour appears to be undocumented. With the fix, it is no longer necessary to add the scheme to Info.plist.

Issue reproduced and fix verified on iOS 26.5.

See: https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/init(url:callbackurlscheme:completionhandler:)-7fpox

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-app authentication redirect handling by deriving the callback scheme from the configured redirect URI.
  * Rejects invalid redirect URIs that can’t be parsed into a URL with a scheme.
  * Tightened callback validation by comparing URL components (including normalized path) and ensuring configured query parameters match in both presence and occurrence, while rejecting conflicts and injected authority/user info.
* **Tests**
  * Added redirect-validation test coverage for ordering, duplicates, prefix-only matches, path/query encoding differences, and authority/port handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->