### PR TITLE
fix(android): apply safe-area insets as container padding for Android 15

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupport.java
@@ -94,4 +94,40 @@ final class SafeAreaInsetsSupport {
 
         return fallbackTopInset;
     }
+
+    /**
+     * Bottom padding to apply to the WebView container (a SwipeRefreshLayout, which honours its own
+     * padding but ignores child margins). Combines the resolved safe bottom inset with a compensation
+     * term: on Android 15+ the AppBarLayout is pushed down by the status-bar height, which shifts the
+     * container's bottom edge off-screen by that same amount, so it must be added back as padding
+     * regardless of the safe-margin option.
+     */
+    static int resolveContainerBottomPadding(
+        boolean enabledSafeBottomMargin,
+        int safeBottomInset,
+        boolean appBarHandlesTopInset,
+        int statusBarTop
+    ) {
+        int base = enabledSafeBottomMargin ? Math.max(0, safeBottomInset) : 0;
+        int appBarCompensation = appBarHandlesTopInset ? Math.max(0, statusBarTop) : 0;
+        return base + appBarCompensation;
+    }
+
+    /**
+     * Top padding for the WebView container. When the AppBarLayout handles the top inset it already
+     * sits below the status bar, so no additional padding is needed; otherwise the status-bar height
+     * is applied when the safe-top options request it.
+     */
+    static int resolveContainerTopPadding(
+        boolean enabledSafeTopMargin,
+        boolean useTopInset,
+        int statusBarTop,
+        boolean appBarHandlesTopInset
+    ) {
+        if (appBarHandlesTopInset || !enabledSafeTopMargin || !useTopInset) {
+            return 0;
+        }
+
+        return Math.max(0, statusBarTop);
+    }
 }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -3147,6 +3147,9 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         }
 
         requestSafeAreaInsets();
+
+        mainHandler.postDelayed(this::applyContainerInsetsSnapshot, 300);
+        mainHandler.postDelayed(this::applyContainerInsetsSnapshot, 1200);
     }
 
     private void applySafeAreaMargins(
@@ -3202,6 +3205,81 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         mlp.rightMargin = bars.right;
         _webView.setLayoutParams(mlp);
         injectSafeAreaCssVariables(navTop, bottomMargin, bars.left, bars.right);
+        applyContainerInsetsSnapshot();
+    }
+
+    private void applyContainerInsetsSnapshot() {
+        if (_options == null || _webView == null) {
+            return;
+        }
+
+        View container = findViewById(R.id.content_browser_layout);
+        if (container == null) {
+            return;
+        }
+
+        Window window = getWindow();
+        View decorView = window != null ? window.getDecorView() : null;
+        WindowInsetsCompat windowInsets = decorView != null ? ViewCompat.getRootWindowInsets(decorView) : null;
+
+        Insets bars = windowInsets != null ? windowInsets.getInsets(WindowInsetsCompat.Type.systemBars()) : Insets.NONE;
+        Insets navigationBars = windowInsets != null
+            ? windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars())
+            : Insets.NONE;
+        Insets systemGestures = windowInsets != null
+            ? windowInsets.getInsets(WindowInsetsCompat.Type.systemGestures())
+            : Insets.NONE;
+        Insets mandatoryGestures = windowInsets != null
+            ? windowInsets.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures())
+            : Insets.NONE;
+
+        boolean isAndroid15Plus = Build.VERSION.SDK_INT >= 35;
+        View toolbarView = findViewById(R.id.tool_bar);
+        boolean appBarHandlesTopInset =
+            isAndroid15Plus &&
+            !TextUtils.equals(_options.getToolbarType(), "blank") &&
+            toolbarView != null &&
+            toolbarView.getVisibility() == View.VISIBLE &&
+            toolbarView.getParent() instanceof com.google.android.material.appbar.AppBarLayout;
+
+        int statusBarTop = bars.top > 0 ? bars.top : getSystemStatusBarHeight();
+        int fallbackBottomInset = _options.getEnabledSafeMargin() ? getSystemNavigationBarHeight() : 0;
+        int safeBottomInset = SafeAreaInsetsSupport.resolveSafeBottomInsetWithFallback(
+            bars.bottom,
+            navigationBars.bottom,
+            systemGestures.bottom,
+            mandatoryGestures.bottom,
+            bars.left,
+            bars.right,
+            navigationBars.left,
+            navigationBars.right,
+            fallbackBottomInset,
+            _options.getEnabledSafeMargin()
+        );
+
+        int padTop = SafeAreaInsetsSupport.resolveContainerTopPadding(
+            _options.getEnabledSafeTopMargin(),
+            _options.getUseTopInset(),
+            statusBarTop,
+            appBarHandlesTopInset
+        );
+        int padBottom = SafeAreaInsetsSupport.resolveContainerBottomPadding(
+            _options.getEnabledSafeMargin(),
+            safeBottomInset,
+            appBarHandlesTopInset,
+            statusBarTop
+        );
+
+        if (
+            container.getPaddingLeft() == bars.left &&
+            container.getPaddingTop() == padTop &&
+            container.getPaddingRight() == bars.right &&
+            container.getPaddingBottom() == padBottom
+        ) {
+            return;
+        }
+
+        container.setPadding(bars.left, padTop, bars.right, padBottom);
     }
 
     private void configureBlankToolbarLayout() {
@@ -3285,7 +3363,10 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         }
 
         ViewCompat.requestApplyInsets(insetsSourceView);
-        insetsSourceView.post(() -> ViewCompat.requestApplyInsets(insetsSourceView));
+        insetsSourceView.post(() -> {
+            ViewCompat.requestApplyInsets(insetsSourceView);
+            applyContainerInsetsSnapshot();
+        });
     }
 
     public void postMessageToJS(Object detail) {

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/SafeAreaInsetsSupportTest.java
@@ -84,4 +84,48 @@ public class SafeAreaInsetsSupportTest {
         assertEquals(0, SafeAreaInsetsSupport.resolveTopMarginWithFallback(false, true, 0, false, 48, true));
         assertEquals(0, SafeAreaInsetsSupport.resolveTopMarginWithFallback(true, false, 0, false, 48, true));
     }
+
+    @Test
+    public void containerBottomPaddingAddsAppBarDisplacementToNavigationBarInset() {
+        // Android 15 device: 126px navigation bar + 87px status-bar appbar displacement = 213px.
+        assertEquals(213, SafeAreaInsetsSupport.resolveContainerBottomPadding(true, 126, true, 87));
+    }
+
+    @Test
+    public void containerBottomPaddingOmitsCompensationWhenAppBarDoesNotHandleTopInset() {
+        assertEquals(126, SafeAreaInsetsSupport.resolveContainerBottomPadding(true, 126, false, 87));
+    }
+
+    @Test
+    public void containerBottomPaddingCompensatesAppBarEvenWhenSafeMarginDisabled() {
+        // The appbar top-margin displaces the WebView bottom regardless of the safe-margin option,
+        // so the displacement must still be compensated to keep bottom content on-screen.
+        assertEquals(87, SafeAreaInsetsSupport.resolveContainerBottomPadding(false, 126, true, 87));
+    }
+
+    @Test
+    public void containerBottomPaddingIsZeroWithoutSafeMarginOrAppBarDisplacement() {
+        assertEquals(0, SafeAreaInsetsSupport.resolveContainerBottomPadding(false, 126, false, 87));
+    }
+
+    @Test
+    public void containerBottomPaddingClampsNegativeInputsToZero() {
+        assertEquals(0, SafeAreaInsetsSupport.resolveContainerBottomPadding(true, -10, true, -5));
+    }
+
+    @Test
+    public void containerTopPaddingIsZeroWhenAppBarHandlesTopInset() {
+        assertEquals(0, SafeAreaInsetsSupport.resolveContainerTopPadding(true, true, 87, true));
+    }
+
+    @Test
+    public void containerTopPaddingUsesStatusBarWhenAppBarDoesNotHandleTop() {
+        assertEquals(87, SafeAreaInsetsSupport.resolveContainerTopPadding(true, true, 87, false));
+    }
+
+    @Test
+    public void containerTopPaddingRequiresBothSafeTopAndExplicitTopInset() {
+        assertEquals(0, SafeAreaInsetsSupport.resolveContainerTopPadding(false, true, 87, false));
+        assertEquals(0, SafeAreaInsetsSupport.resolveContainerTopPadding(true, false, 87, false));
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android safe-area padding for top and bottom content.
  * Prevented content from being obscured by status bars, navigation bars, or app-bar positioning.
  * Added safeguards to prevent invalid negative inset values from affecting layout.

* **Tests**
  * Added coverage for safe-area padding across supported app-bar and inset configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

