### PR TITLE
fix(ios): respect isInspectable option instead of forcing inspectable webviews

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -1227,7 +1227,7 @@ public class CapgoInAppBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
         let titleFontFamily = call.getString("titleFontFamily")
-        let isInspectable = call.getBool("isInspectable", false)
+        let isInspectable = call.getBool("isInspectable", self.bridge?.config.isWebDebuggable ?? false)
         let preventDeeplink = call.getBool("preventDeeplink", false)
         let openBlankTargetInWebView = call.getBool("openBlankTargetInWebView", false)
         let isAnimated = call.getBool("isAnimated", true)

--- a/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebViewController.swift
@@ -439,6 +439,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
     open var httpMethod: String?
     open var httpBody: String?
     open var capBrowserPlugin: CapgoInAppBrowserPlugin?
+    open var isInspectable: Bool = false
     var instanceId: String = ""
     var shareDisclaimer: [String: Any]?
     var shareSubject: String?
@@ -2032,11 +2033,12 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
         }
     }
 
-    open func initWebview(isInspectable: Bool = true) {
+    open func initWebview(isInspectable: Bool = false) {
         if self.isWebViewInitialized {
             return
         }
         self.isWebViewInitialized = true
+        self.isInspectable = isInspectable
         self.startObservingKeyboardViewportChanges()
         self.view.backgroundColor = UIColor.white
 
@@ -2183,9 +2185,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
         //        }
 
         if #available(iOS 16.4, *) {
-            webView.isInspectable = true
-        } else {
-            // Fallback on earlier versions
+            webView.isInspectable = isInspectable
         }
 
         // First add the webView to view hierarchy
@@ -2341,7 +2341,7 @@ open class WKWebViewController: UIViewController, WKScriptMessageHandler {
         self.view.backgroundColor = parent.view.backgroundColor
         self.title = parent.title ?? request.url?.host ?? "Popup Window"
         self.navigationItem.title = self.title
-        self.initWebview()
+        self.initWebview(isInspectable: parent.isInspectable)
         return self.capableWebView
     }
 


### PR DESCRIPTION
## What                                                                                                                                                                                                                   
                                                                                                                                                                                                                            
  Assigns the `isInspectable` option to `webView.isInspectable` in `WKWebViewController.initWebview`,                                                                                                                       
  instead of the hardcoded `true` that has been there since 5bba983. When the option is omitted,                                                                                                                            
  it now falls back to the app's `webContentsDebuggingEnabled` Capacitor config                                                                                                                                             
  (`bridge.config.isWebDebuggable`) rather than a plain `false`.
  
## Why                                                                                                                                                                                                                    
                                                                                                                                                                                                                            
  `initWebview()` parses the `isInspectable` option (documented default: `false`) and passes it all                                                                                                                         
  the way down, then ignores it and forces `webView.isInspectable = true`. On iOS 16.4+ that makes                                                                                                                          
  every webview opened with `openWebView` inspectable via Safari Web Inspector in every build,                                                                                                                              
  including production/App Store ones — so on a shipped app anyone can attach the inspector to in-app                                                                                                                       
  content such as login or payment pages and read the DOM, cookies and network traffic.                                                                                                                                     
                                                                                                                                                                                                                            
  The commented-out block right above it (the `setInspectable:` selector) used the parameter; it was                                                                                                                        
  lost when that selector was swapped for the `isInspectable` property and replaced with a literal.                                                                                                                         
                                                                                                                                                                                                                            
  Defaulting to `bridge.config.isWebDebuggable` (rather than `false`) keeps existing behaviour in debug                                                                                                                     
  builds — Capacitor sets `webContentsDebuggingEnabled` to `true` only in DEBUG by default — while                                                                                                                          
  release builds stop being inspectable. This is exactly what Capacitor core does for its own webview                                                                                                                       
  in `CapacitorBridge.setupWebDebugging` (`capacitor/ios`), so pages inside the InAppBrowser WebView now                                                                                                                    
  behave like pages in the main Capacitor WebView. Callers passing `isInspectable: true` explicitly are                                                                                                                     
  unaffected.         
  
 ## Platform parity                                                                                                                                                                                                        
                                                                                                                                                                                                                            
  - On Android the plugin's WebView already follows the app's setting: `WebView.setWebContentsDebuggingEnabled`                                                                                                             
    is process-global and Capacitor's Bridge sets it from `webContentsDebuggingEnabled` (default: the app's                                                                                                                 
    debuggable flag). iOS was the gap, because `isInspectable` is a per-WKWebView property the plugin has to                                                                                                                
    set itself.                                                                                                                                                                                                             
  - Geolocation on iOS is already deferred to the OS by this class (`requestGeolocationPermissionFor`);                                                                                                                     
    this mirrors how the main Capacitor WebView resolves inspectability, including the log-line style.                                                                                                                      
                                                                                         
                                                                                         
## Testing                                                                                                                                                                                                                
                                                                                                                                                                                                                            
  Verified on an iOS 18 simulator in a Capacitor 8 app (via a local patch), opening a webview without the                                                                                                                   
  `isInspectable` option and reading `WKWebView.isInspectable` at runtime:                                                                                                                                                  
                                                                                                                                                                                                                            
  | build   | before             | after           |                                                                                                                                                                        
  |---------|--------------------|-----------------|                                                                                                                                                                        
  | debug   | inspectable        | inspectable     |                                                                                                                                                                        
  | release | inspectable (leak) | not inspectable |                                                                                                                                                                        
                                                                                                                                                                                                                            
  In the release build the app's own webview was already correctly not inspectable; only the plugin's                                                                                                                       
  webview stayed inspectable, which this change fixes.     

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Web content inspection now correctly follows the configured debuggability setting when the caller doesn’t explicitly set an option.
  * On supported iOS versions, the web view’s inspection state now respects the provided setting (including for popup/inherited web views) instead of using a fixed default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->