### PR TITLE
fix(android): prevent ANR from Custom Tabs bind on resume

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
@@ -678,10 +678,16 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
         currentPermissionNeedsMicrophone = false;
     }
 
+    private final Object customTabsClientLock = new Object();
+    private static final long CUSTOM_TABS_CONNECTION_TIMEOUT_MS = 2000;
+
     CustomTabsServiceConnection connection = new CustomTabsServiceConnection() {
         @Override
         public void onCustomTabsServiceConnected(ComponentName name, CustomTabsClient client) {
             customTabsClient = client;
+            synchronized (customTabsClientLock) {
+                customTabsClientLock.notifyAll();
+            }
         }
 
         @Override
@@ -777,8 +783,10 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
 
         if (TextUtils.isEmpty(url)) {
             call.reject("Invalid URL");
+            return;
         }
         currentUrl = url;
+        awaitCustomTabsClientIfNeeded();
         CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(getCustomTabsSession());
 
         // --- Chrome Custom Tab UI customization ---
@@ -1879,6 +1887,28 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
 
     protected void handleOnPause() {
         customTabsLifecycleSupport.onPause(customTabsBinder);
+    }
+
+    private void awaitCustomTabsClientIfNeeded() {
+        if (customTabsClient != null || !customTabsLifecycleSupport.isBindingOrBound()) {
+            return;
+        }
+
+        synchronized (customTabsClientLock) {
+            long deadline = System.currentTimeMillis() + CUSTOM_TABS_CONNECTION_TIMEOUT_MS;
+            while (customTabsClient == null && customTabsLifecycleSupport.isBindingOrBound() && System.currentTimeMillis() < deadline) {
+                long remaining = deadline - System.currentTimeMillis();
+                if (remaining <= 0) {
+                    break;
+                }
+                try {
+                    customTabsClientLock.wait(remaining);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
     }
 
     public CustomTabsSession getCustomTabsSession() {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
@@ -76,6 +76,14 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
         }
     );
 
+    private static final ExecutorService CUSTOM_TABS_LIFECYCLE_EXECUTOR = Executors.newSingleThreadExecutor((runnable) -> {
+        Thread thread = new Thread(runnable, "CapgoInAppBrowser-CustomTabsLifecycle");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    private final CustomTabsLifecycleSupport customTabsLifecycleSupport = new CustomTabsLifecycleSupport(CUSTOM_TABS_LIFECYCLE_EXECUTOR);
+
     private final String pluginVersion = "8.6.17";
 
     private boolean resolveClientCertificatePrompt(PluginCall call) {
@@ -679,6 +687,27 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
         @Override
         public void onServiceDisconnected(ComponentName name) {
             customTabsClient = null;
+        }
+    };
+
+    private final CustomTabsLifecycleSupport.Binder customTabsBinder = new CustomTabsLifecycleSupport.Binder() {
+        @Override
+        public boolean bindCustomTabsService() {
+            try {
+                boolean ok = CustomTabsClient.bindCustomTabsService(getContext(), CUSTOM_TAB_PACKAGE_NAME, connection);
+                if (!ok) {
+                    Log.e(getLogTag(), "Error binding to custom tabs service");
+                }
+                return ok;
+            } catch (RuntimeException e) {
+                Log.e(getLogTag(), "Error binding to custom tabs service", e);
+                return false;
+            }
+        }
+
+        @Override
+        public void unbindCustomTabsService() {
+            getContext().unbindService(connection);
         }
     };
 
@@ -1839,10 +1868,8 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
     }
 
     protected void handleOnResume() {
-        boolean ok = CustomTabsClient.bindCustomTabsService(getContext(), CUSTOM_TAB_PACKAGE_NAME, connection);
-        if (!ok) {
-            Log.e(getLogTag(), "Error binding to custom tabs service");
-        }
+        customTabsLifecycleSupport.onResume(customTabsBinder);
+
         // If we have a saved call and user returned without callback, reject
         if (openSecureWindowSavedCall != null) {
             openSecureWindowSavedCall.reject("OAuth cancelled or no callback received");
@@ -1851,7 +1878,7 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
     }
 
     protected void handleOnPause() {
-        getContext().unbindService(connection);
+        customTabsLifecycleSupport.onPause(customTabsBinder);
     }
 
     public CustomTabsSession getCustomTabsSession() {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CustomTabsLifecycleSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CustomTabsLifecycleSupport.java
@@ -25,7 +25,25 @@ final class CustomTabsLifecycleSupport {
     }
 
     void onPause(Binder binder) {
+        synchronized (lock) {
+            if (bindInProgress) {
+                unbindPending = true;
+                return;
+            }
+        }
         executor.execute(() -> performUnbind(binder));
+    }
+
+    boolean isBindingOrBound() {
+        synchronized (lock) {
+            return bindInProgress || bound;
+        }
+    }
+
+    boolean isUnbindPending() {
+        synchronized (lock) {
+            return unbindPending;
+        }
     }
 
     private void performBind(Binder binder) {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CustomTabsLifecycleSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CustomTabsLifecycleSupport.java
@@ -1,0 +1,86 @@
+package ee.forgr.capacitor_inappbrowser;
+
+import java.util.concurrent.Executor;
+
+final class CustomTabsLifecycleSupport {
+
+    interface Binder {
+        boolean bindCustomTabsService();
+
+        void unbindCustomTabsService();
+    }
+
+    private final Executor executor;
+    private final Object lock = new Object();
+    private boolean bound = false;
+    private boolean bindInProgress = false;
+    private boolean unbindPending = false;
+
+    CustomTabsLifecycleSupport(Executor executor) {
+        this.executor = executor;
+    }
+
+    void onResume(Binder binder) {
+        executor.execute(() -> performBind(binder));
+    }
+
+    void onPause(Binder binder) {
+        executor.execute(() -> performUnbind(binder));
+    }
+
+    private void performBind(Binder binder) {
+        synchronized (lock) {
+            if (bound || bindInProgress) {
+                return;
+            }
+            bindInProgress = true;
+            unbindPending = false;
+        }
+
+        boolean ok = false;
+        try {
+            ok = binder.bindCustomTabsService();
+        } catch (RuntimeException ignored) {
+            // Caller logs bind failures.
+        }
+
+        synchronized (lock) {
+            bindInProgress = false;
+            if (!ok) {
+                return;
+            }
+
+            if (unbindPending) {
+                unbindPending = false;
+                try {
+                    binder.unbindCustomTabsService();
+                } catch (RuntimeException ignored) {
+                    // Service may already be unbound.
+                }
+                bound = false;
+                return;
+            }
+
+            bound = true;
+        }
+    }
+
+    private void performUnbind(Binder binder) {
+        synchronized (lock) {
+            if (bindInProgress) {
+                unbindPending = true;
+                return;
+            }
+            if (!bound) {
+                return;
+            }
+            bound = false;
+        }
+
+        try {
+            binder.unbindCustomTabsService();
+        } catch (RuntimeException ignored) {
+            // Service may already be unbound.
+        }
+    }
+}

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CustomTabsLifecycleSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CustomTabsLifecycleSupport.java
@@ -14,7 +14,6 @@ final class CustomTabsLifecycleSupport {
     private final Object lock = new Object();
     private boolean bound = false;
     private boolean bindInProgress = false;
-    private boolean unbindPending = false;
 
     CustomTabsLifecycleSupport(Executor executor) {
         this.executor = executor;
@@ -25,12 +24,6 @@ final class CustomTabsLifecycleSupport {
     }
 
     void onPause(Binder binder) {
-        synchronized (lock) {
-            if (bindInProgress) {
-                unbindPending = true;
-                return;
-            }
-        }
         executor.execute(() -> performUnbind(binder));
     }
 
@@ -40,9 +33,9 @@ final class CustomTabsLifecycleSupport {
         }
     }
 
-    boolean isUnbindPending() {
+    boolean isBound() {
         synchronized (lock) {
-            return unbindPending;
+            return bound;
         }
     }
 
@@ -52,7 +45,6 @@ final class CustomTabsLifecycleSupport {
                 return;
             }
             bindInProgress = true;
-            unbindPending = false;
         }
 
         boolean ok = false;
@@ -68,17 +60,6 @@ final class CustomTabsLifecycleSupport {
                 return;
             }
 
-            if (unbindPending) {
-                unbindPending = false;
-                try {
-                    binder.unbindCustomTabsService();
-                } catch (RuntimeException ignored) {
-                    // Service may already be unbound.
-                }
-                bound = false;
-                return;
-            }
-
             bound = true;
         }
     }
@@ -86,7 +67,6 @@ final class CustomTabsLifecycleSupport {
     private void performUnbind(Binder binder) {
         synchronized (lock) {
             if (bindInProgress) {
-                unbindPending = true;
                 return;
             }
             if (!bound) {

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/CustomTabsLifecycleSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/CustomTabsLifecycleSupportTest.java
@@ -1,5 +1,6 @@
 package ee.forgr.capacitor_inappbrowser;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -8,6 +9,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
 import org.junit.Test;
 
@@ -23,12 +25,11 @@ public class CustomTabsLifecycleSupportTest {
     }
 
     @Test
-    public void pauseWhileBindInProgressDefersUnbindUntilBindCompletes() throws Exception {
+    public void pauseWhileBindInProgressUnbindsAfterBindCompletes() throws Exception {
         executor = Executors.newSingleThreadExecutor();
         CustomTabsLifecycleSupport support = new CustomTabsLifecycleSupport(executor);
         CountDownLatch bindStarted = new CountDownLatch(1);
         CountDownLatch releaseBind = new CountDownLatch(1);
-        AtomicBoolean bound = new AtomicBoolean(false);
         AtomicBoolean unbound = new AtomicBoolean(false);
 
         CustomTabsLifecycleSupport.Binder binder = new CustomTabsLifecycleSupport.Binder() {
@@ -41,7 +42,6 @@ public class CustomTabsLifecycleSupportTest {
                     Thread.currentThread().interrupt();
                     return false;
                 }
-                bound.set(true);
                 return true;
             }
 
@@ -58,16 +58,59 @@ public class CustomTabsLifecycleSupportTest {
         pauseThread.start();
         pauseThread.join(1000);
 
-        assertTrue(support.isUnbindPending());
         assertFalse(unbound.get());
 
         releaseBind.countDown();
 
         executor.shutdown();
         assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS));
-        assertTrue(bound.get());
         assertTrue(unbound.get());
-        assertFalse(support.isUnbindPending());
+        assertFalse(support.isBound());
+    }
+
+    @Test
+    public void resumePauseResumePauseWhileBindBlockedEndsUnbound() throws Exception {
+        executor = Executors.newSingleThreadExecutor();
+        CustomTabsLifecycleSupport support = new CustomTabsLifecycleSupport(executor);
+        CountDownLatch bindStarted = new CountDownLatch(1);
+        CountDownLatch releaseBind = new CountDownLatch(1);
+        AtomicInteger bindCount = new AtomicInteger();
+        AtomicInteger unbindCount = new AtomicInteger();
+
+        CustomTabsLifecycleSupport.Binder binder = new CustomTabsLifecycleSupport.Binder() {
+            @Override
+            public boolean bindCustomTabsService() {
+                bindCount.incrementAndGet();
+                bindStarted.countDown();
+                try {
+                    releaseBind.await(1, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return false;
+                }
+                return true;
+            }
+
+            @Override
+            public void unbindCustomTabsService() {
+                unbindCount.incrementAndGet();
+            }
+        };
+
+        support.onResume(binder);
+        assertTrue(bindStarted.await(1, TimeUnit.SECONDS));
+
+        support.onPause(binder);
+        support.onResume(binder);
+        support.onPause(binder);
+
+        releaseBind.countDown();
+
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS));
+        assertEquals(2, bindCount.get());
+        assertEquals(2, unbindCount.get());
+        assertFalse(support.isBound());
     }
 
     @Test

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/CustomTabsLifecycleSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/CustomTabsLifecycleSupportTest.java
@@ -1,0 +1,91 @@
+package ee.forgr.capacitor_inappbrowser;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.After;
+import org.junit.Test;
+
+public class CustomTabsLifecycleSupportTest {
+
+    private ExecutorService executor;
+
+    @After
+    public void tearDown() {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void pauseWhileBindInProgressUnbindsAfterBindCompletes() throws Exception {
+        executor = Executors.newSingleThreadExecutor();
+        CustomTabsLifecycleSupport support = new CustomTabsLifecycleSupport(executor);
+        CountDownLatch bindStarted = new CountDownLatch(1);
+        CountDownLatch releaseBind = new CountDownLatch(1);
+        AtomicBoolean bound = new AtomicBoolean(false);
+        AtomicBoolean unbound = new AtomicBoolean(false);
+
+        CustomTabsLifecycleSupport.Binder binder = new CustomTabsLifecycleSupport.Binder() {
+            @Override
+            public boolean bindCustomTabsService() {
+                bindStarted.countDown();
+                try {
+                    releaseBind.await(1, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return false;
+                }
+                bound.set(true);
+                return true;
+            }
+
+            @Override
+            public void unbindCustomTabsService() {
+                unbound.set(true);
+            }
+        };
+
+        support.onResume(binder);
+        assertTrue(bindStarted.await(1, TimeUnit.SECONDS));
+
+        support.onPause(binder);
+        releaseBind.countDown();
+
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS));
+        assertTrue(bound.get());
+        assertTrue(unbound.get());
+    }
+
+    @Test
+    public void failedBindDoesNotMarkServiceAsBound() throws Exception {
+        executor = Executors.newSingleThreadExecutor();
+        CustomTabsLifecycleSupport support = new CustomTabsLifecycleSupport(executor);
+        AtomicBoolean unbound = new AtomicBoolean(false);
+
+        CustomTabsLifecycleSupport.Binder binder = new CustomTabsLifecycleSupport.Binder() {
+            @Override
+            public boolean bindCustomTabsService() {
+                return false;
+            }
+
+            @Override
+            public void unbindCustomTabsService() {
+                unbound.set(true);
+            }
+        };
+
+        support.onResume(binder);
+        support.onPause(binder);
+
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS));
+        assertFalse(unbound.get());
+    }
+}

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/CustomTabsLifecycleSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/CustomTabsLifecycleSupportTest.java
@@ -23,7 +23,7 @@ public class CustomTabsLifecycleSupportTest {
     }
 
     @Test
-    public void pauseWhileBindInProgressUnbindsAfterBindCompletes() throws Exception {
+    public void pauseWhileBindInProgressDefersUnbindUntilBindCompletes() throws Exception {
         executor = Executors.newSingleThreadExecutor();
         CustomTabsLifecycleSupport support = new CustomTabsLifecycleSupport(executor);
         CountDownLatch bindStarted = new CountDownLatch(1);
@@ -54,13 +54,20 @@ public class CustomTabsLifecycleSupportTest {
         support.onResume(binder);
         assertTrue(bindStarted.await(1, TimeUnit.SECONDS));
 
-        support.onPause(binder);
+        Thread pauseThread = new Thread(() -> support.onPause(binder));
+        pauseThread.start();
+        pauseThread.join(1000);
+
+        assertTrue(support.isUnbindPending());
+        assertFalse(unbound.get());
+
         releaseBind.countDown();
 
         executor.shutdown();
         assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS));
         assertTrue(bound.get());
         assertTrue(unbound.get());
+        assertFalse(support.isUnbindPending());
     }
 
     @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Move `CustomTabsClient.bindCustomTabsService` and `unbindService` off the main thread in `handleOnResume` / `handleOnPause`.
- Add `CustomTabsLifecycleSupport` to serialize bind/unbind on a background executor and handle pause-during-bind races safely.

Fixes #613

## Why
- `bindCustomTabsService` performs synchronous Binder IPC that can block the main thread during `Activity.onResume`, triggering ANRs (see stack trace in #613).

## How
- Introduced a dedicated single-thread executor (`CapgoInAppBrowser-CustomTabsLifecycle`) for Custom Tabs service lifecycle work.
- `CustomTabsLifecycleSupport` tracks bind state and defers unbind when pause happens while bind is still in progress.
- Bind failures and runtime exceptions are logged and handled without crashing; OAuth cancellation logic in `handleOnResume` stays on the main thread.

## Testing
- `bun run fmt`
- `bun run verify:web`
- `./gradlew test` (all Android unit tests, including new `CustomTabsLifecycleSupportTest`)

## Not Tested
- On-device ANR reproduction (requires slow Chrome Custom Tabs binder on a physical device).
- iOS (no changes).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4c181cc-4ca9-48d7-a5c7-a59f29880b55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4c181cc-4ca9-48d7-a5c7-a59f29880b55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-inappbrowser/pr/658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789145020&installation_model_id=430928&pr_number=658&repository=Cap-go%2Fcapacitor-inappbrowser&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-inappbrowser%2Fpull%2F658&signature=1960170bd75a045a4cbbc9ff2ebbb3ff40f948fe1ac2a9d2228474283c82754f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

