### PR TITLE
fix(android): keep WebView scrollable after portrait→landscape rotation

### DIFF
--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -35,7 +35,24 @@ plugin_name="$(bun -e 'console.log(require("./package.json").name)')"
 cp -R example-app/. "$test_app/"
 cd "$test_app"
 bun remove "$plugin_name"
-bun add "${packed_packages[0]}"
+
+max_attempts=3
+attempt=1
+while [ "$attempt" -le "$max_attempts" ]; do
+  if bun add "${packed_packages[0]}"; then
+    break
+  fi
+
+  echo "bun add failed on attempt $attempt/$max_attempts"
+  if [ "$attempt" -eq "$max_attempts" ]; then
+    exit 1
+  fi
+
+  rm -rf node_modules
+  attempt=$((attempt + 1))
+  sleep $((attempt * 15))
+done
+
 bun run build
 
 case "$platform" in

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -3370,7 +3370,8 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
 
         WindowInsetsCompat windowInsets = ViewCompat.getRootWindowInsets(decorView);
         if (windowInsets == null) {
-            applyContainerInsetsSnapshot();
+            // Root insets not ready yet; do not mutate margins/padding (would desync WebView
+            // margins from container padding). Delayed retries and requestApplyInsets will retry.
             return;
         }
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -3013,30 +3013,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         final View insetsSourceView = resolveSafeAreaInsetsSourceView();
 
         ViewCompat.setOnApplyWindowInsetsListener(insetsSourceView, (v, windowInsets) -> {
-            Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-            Insets navigationBars = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars());
-            Insets systemGestures = windowInsets.getInsets(WindowInsetsCompat.Type.systemGestures());
-            Insets mandatoryGestures = windowInsets.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures());
-            Insets ime = windowInsets.getInsets(WindowInsetsCompat.Type.ime());
-            boolean keyboardVisible = windowInsets.isVisible(WindowInsetsCompat.Type.ime());
-
-            boolean appBarHandlesTopInset =
-                isAndroid15Plus &&
-                !TextUtils.equals(_options.getToolbarType(), "blank") &&
-                toolbarView != null &&
-                toolbarView.getVisibility() == View.VISIBLE &&
-                toolbarView.getParent() instanceof com.google.android.material.appbar.AppBarLayout;
-            applySafeAreaMargins(
-                bars,
-                navigationBars,
-                systemGestures,
-                mandatoryGestures,
-                ime,
-                keyboardVisible,
-                appBarHandlesTopInset,
-                isAndroid15Plus
-            );
-
+            applyWindowInsetsToWebView(windowInsets, isAndroid15Plus, toolbarView);
             return windowInsets;
         });
         requestSafeAreaInsets();
@@ -3209,6 +3186,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
 
         if (isHiddenModeActive) {
             requestSafeAreaInsets();
+            reapplyInsetsFromWindowRoot();
             return;
         }
 
@@ -3235,21 +3213,24 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         }
 
         if (swipeRefreshLayout != null) {
+            swipeRefreshLayout.setRefreshing(false);
             swipeRefreshLayout.requestLayout();
         }
 
         _webView.requestLayout();
         _webView.invalidate();
         requestSafeAreaInsets();
+        reapplyInsetsFromWindowRoot();
 
-        mainHandler.post(this::applyContainerInsetsSnapshot);
-        mainHandler.postDelayed(this::applyContainerInsetsSnapshot, 100);
-        mainHandler.postDelayed(this::applyContainerInsetsSnapshot, 300);
+        mainHandler.post(this::reapplyInsetsFromWindowRoot);
+        mainHandler.postDelayed(this::reapplyInsetsFromWindowRoot, 100);
+        mainHandler.postDelayed(this::reapplyInsetsFromWindowRoot, 300);
 
         _webView.post(() -> {
             if (_webView == null) {
                 return;
             }
+            forceWebViewContentRemeasure();
             _webView.evaluateJavascript("(function(){window.dispatchEvent(new Event('resize'));})();", null);
         });
     }
@@ -3338,6 +3319,81 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             }
             appBarLayout.setBackgroundColor(finalBgColor);
         });
+    }
+
+    private void applyWindowInsetsToWebView(WindowInsetsCompat windowInsets, boolean isAndroid15Plus, View toolbarView) {
+        if (windowInsets == null || _options == null) {
+            return;
+        }
+
+        Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+        Insets navigationBars = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars());
+        Insets systemGestures = windowInsets.getInsets(WindowInsetsCompat.Type.systemGestures());
+        Insets mandatoryGestures = windowInsets.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures());
+        Insets ime = windowInsets.getInsets(WindowInsetsCompat.Type.ime());
+        boolean keyboardVisible = windowInsets.isVisible(WindowInsetsCompat.Type.ime());
+
+        boolean appBarHandlesTopInset =
+            isAndroid15Plus &&
+            !TextUtils.equals(_options.getToolbarType(), "blank") &&
+            toolbarView != null &&
+            toolbarView.getVisibility() == View.VISIBLE &&
+            toolbarView.getParent() instanceof com.google.android.material.appbar.AppBarLayout;
+
+        applySafeAreaMargins(
+            bars,
+            navigationBars,
+            systemGestures,
+            mandatoryGestures,
+            ime,
+            keyboardVisible,
+            appBarHandlesTopInset,
+            isAndroid15Plus
+        );
+    }
+
+    /**
+     * Re-read root window insets and apply WebView margins plus container padding.
+     * Dialog windows may not re-dispatch inset listeners after rotation, leaving stale
+     * portrait margins that break vertical scrolling in landscape.
+     */
+    private void reapplyInsetsFromWindowRoot() {
+        if (_webView == null || _options == null) {
+            return;
+        }
+
+        Window window = getWindow();
+        View decorView = window != null ? window.getDecorView() : null;
+        if (decorView == null) {
+            return;
+        }
+
+        WindowInsetsCompat windowInsets = ViewCompat.getRootWindowInsets(decorView);
+        if (windowInsets == null) {
+            return;
+        }
+
+        boolean isAndroid15Plus = Build.VERSION.SDK_INT >= 35;
+        View toolbarView = findViewById(R.id.tool_bar);
+        applyWindowInsetsToWebView(windowInsets, isAndroid15Plus, toolbarView);
+    }
+
+    private void forceWebViewContentRemeasure() {
+        View container = findViewById(R.id.content_browser_layout);
+        if (container == null || _webView == null) {
+            return;
+        }
+
+        int width = container.getWidth();
+        int height = container.getHeight();
+        if (width <= 0 || height <= 0) {
+            return;
+        }
+
+        int widthSpec = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY);
+        int heightSpec = View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY);
+        _webView.measure(widthSpec, heightSpec);
+        _webView.layout(_webView.getLeft(), _webView.getTop(), _webView.getLeft() + width, _webView.getTop() + height);
     }
 
     private void applySafeAreaMargins(
@@ -3554,7 +3610,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         ViewCompat.requestApplyInsets(insetsSourceView);
         insetsSourceView.post(() -> {
             ViewCompat.requestApplyInsets(insetsSourceView);
-            applyContainerInsetsSnapshot();
+            reapplyInsetsFromWindowRoot();
         });
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -3230,7 +3230,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             if (_webView == null) {
                 return;
             }
-            forceWebViewContentRemeasure();
+            requestWebViewContentRelayout();
             _webView.evaluateJavascript("(function(){window.dispatchEvent(new Event('resize'));})();", null);
         });
     }
@@ -3370,6 +3370,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
 
         WindowInsetsCompat windowInsets = ViewCompat.getRootWindowInsets(decorView);
         if (windowInsets == null) {
+            applyContainerInsetsSnapshot();
             return;
         }
 
@@ -3378,22 +3379,19 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         applyWindowInsetsToWebView(windowInsets, isAndroid15Plus, toolbarView);
     }
 
-    private void forceWebViewContentRemeasure() {
+    private void requestWebViewContentRelayout() {
         View container = findViewById(R.id.content_browser_layout);
-        if (container == null || _webView == null) {
+        if (container != null) {
+            container.requestLayout();
+            container.invalidate();
+        }
+
+        if (_webView == null) {
             return;
         }
 
-        int width = container.getWidth();
-        int height = container.getHeight();
-        if (width <= 0 || height <= 0) {
-            return;
-        }
-
-        int widthSpec = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY);
-        int heightSpec = View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY);
-        _webView.measure(widthSpec, heightSpec);
-        _webView.layout(_webView.getLeft(), _webView.getTop(), _webView.getLeft() + width, _webView.getTop() + height);
+        _webView.requestLayout();
+        _webView.invalidate();
     }
 
     private void applySafeAreaMargins(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Harden Android `openWebView()` orientation handling so the managed WebView stays vertically scrollable after portrait→landscape (and other configuration changes).
- Synchronously re-apply safe-area margins from root window insets when inset listeners do not re-fire on dialog windows.
- Force WebView remeasure after rotation and reset `SwipeRefreshLayout` refresh state.

Fixes #647

## Why
- Capacitor activities declare `android:configChanges`, so the host activity and managed WebView dialog are not recreated on rotation.
- PR #652 added configuration-change layout refresh, but dialog windows can still fail to re-dispatch inset listeners. Stale portrait WebView margins leave the content area mis-sized and vertical scroll gestures stop working in landscape.

## How
- Extract `applyWindowInsetsToWebView()` from the inset listener so the same margin/padding logic can run synchronously.
- Add `reapplyInsetsFromWindowRoot()` and call it from `refreshLayoutForConfigurationChange()`, `requestSafeAreaInsets()`, and hidden-mode rotation handling.
- Add `forceWebViewContentRemeasure()` after layout refresh and dispatch a JS `resize` event for viewport-aware pages.

## Testing
- `bun run fmt`
- `bun run lint`
- `bun run verify:web` (proxy-bridge unit tests pass)

## Not Tested
- `bun run verify:android` (no Android SDK in cloud agent environment)
- Physical device portrait→landscape scroll on a tall third-party identity-verification page

### Manual test plan
1. On Android, open a tall page with `InAppBrowser.openWebView({ url })` while in portrait.
2. Confirm vertical scrolling works in portrait.
3. Rotate to landscape and verify vertical scrolling still works.
4. Rotate back to portrait and verify scrolling and toolbar/safe-area insets still look correct.
5. Repeat with `enableReloadGesture: true` and confirm pull-to-refresh does not block normal scrolling after rotation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75e84520-3c2e-4ff4-9621-e878ffddcc51?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75e84520-3c2e-4ff4-9621-e878ffddcc51&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-inappbrowser/pr/659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789145070&installation_model_id=430928&pr_number=659&repository=Cap-go%2Fcapacitor-inappbrowser&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-inappbrowser%2Fpull%2F659&signature=b3119821b4c912af3366b3b36cd60931f10eff57b86463b5330ab31579971ffa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebView layout handling around device safe areas and system bars.
  * Fixed content positioning after screen rotation and other configuration changes.
  * Improved swipe-to-refresh behavior when the window layout changes.
  * Ensured safe-area adjustments are applied reliably when requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->