### PR TITLE
fix(android): keep full accept list in file chooser and open document picker for non-media types

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -2350,6 +2350,8 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                     }
 
                     mFilePathCallback = filePathCallback;
+                    mPendingAcceptTypes = fileChooserParams.getAcceptTypes();
+                    mPendingMultiple = fileChooserParams.getMode() == FileChooserParams.MODE_OPEN_MULTIPLE;
 
                     // Direct check for capture attribute in URL (fallback method)
                     boolean isCaptureInUrl;
@@ -2607,12 +2609,19 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                     }
                 }
 
+                private String[] mPendingAcceptTypes;
+                private boolean mPendingMultiple;
+
                 /**
                  * Fall back to file picker when camera launch fails
                  */
                 private void fallbackToFilePicker() {
                     if (mFilePathCallback != null) {
-                        openFileChooser(mFilePathCallback, "image/*", false);
+                        openFileChooser(
+                            mFilePathCallback,
+                            mPendingAcceptTypes != null ? mPendingAcceptTypes : new String[] { "image/*" },
+                            mPendingMultiple
+                        );
                     }
                 }
 
@@ -4065,6 +4074,9 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         if (accept == null || accept.isEmpty() || accept.equals("undefined")) {
             return null;
         }
+        // MIME types are case-insensitive — normalize so classification and EXTRA_MIME_TYPES
+        // always work on lowercase values
+        accept = accept.toLowerCase(java.util.Locale.ROOT);
         if (accept.contains("/")) {
             // Already a MIME type
             return accept;
@@ -4172,6 +4184,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             // If no app can handle the specific MIME type, try with a more generic one
             Log.e("InAppBrowser", "No app available for types: " + java.util.Arrays.toString(acceptTypes) + ", trying with */*");
             intent.setType("*/*");
+            intent.removeExtra(Intent.EXTRA_MIME_TYPES);
             try {
                 if (activity instanceof androidx.activity.ComponentActivity) {
                     androidx.activity.ComponentActivity componentActivity = (androidx.activity.ComponentActivity) activity;

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -2368,8 +2368,11 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                         isCaptureInUrl = false;
                     }
 
-                    // For image inputs, try to detect capture attribute using JavaScript
-                    if (acceptType.equals("image/*")) {
+                    // For image-only inputs, try to detect capture attribute using JavaScript.
+                    // Mixed accept lists (e.g. "image/*,application/pdf") must skip the camera
+                    // path entirely — the camera can only produce images, so routing a mixed
+                    // request to it would make the non-image types unselectable.
+                    if (acceptType.equals("image/*") && !hasNonImageAcceptType(fileChooserParams.getAcceptTypes())) {
                         // Check if HTML content contains capture attribute on file inputs (synchronous check)
                         webView.evaluateJavascript(
                             "document.querySelector('input[type=\"file\"][capture]') !== null",
@@ -4068,6 +4071,24 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             preShowSemaphore = null;
             preShowError = null;
         }
+    }
+
+    private static boolean hasNonImageAcceptType(String[] acceptTypes) {
+        if (acceptTypes == null) {
+            return false;
+        }
+        for (String entry : acceptTypes) {
+            if (entry == null) {
+                continue;
+            }
+            for (String part : entry.split(",")) {
+                String mime = acceptEntryToMimeType(part.trim());
+                if (mime != null && !mime.startsWith("image/")) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private static String acceptEntryToMimeType(String accept) {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -2469,7 +2469,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                                 Log.d("InAppBrowser", "No capture attribute detected, using file picker");
                                 openFileChooser(
                                     filePathCallback,
-                                    acceptType,
+                                    fileChooserParams.getAcceptTypes(),
                                     fileChooserParams.getMode() == FileChooserParams.MODE_OPEN_MULTIPLE
                                 );
                             });
@@ -2478,7 +2478,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                     }
 
                     // For non-image types, use regular file picker
-                    openFileChooser(filePathCallback, acceptType, fileChooserParams.getMode() == FileChooserParams.MODE_OPEN_MULTIPLE);
+                    openFileChooser(filePathCallback, fileChooserParams.getAcceptTypes(), fileChooserParams.getMode() == FileChooserParams.MODE_OPEN_MULTIPLE);
                     return true;
                 }
 
@@ -4061,44 +4061,75 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         }
     }
 
-    private void openFileChooser(ValueCallback<Uri[]> filePathCallback, String acceptType, boolean isMultiple) {
-        mFilePathCallback = filePathCallback;
-        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
-        intent.addCategory(Intent.CATEGORY_OPENABLE);
+    private static String acceptEntryToMimeType(String accept) {
+        if (accept == null || accept.isEmpty() || accept.equals("undefined")) {
+            return null;
+        }
+        if (accept.contains("/")) {
+            // Already a MIME type
+            return accept;
+        }
+        if (!accept.startsWith(".")) {
+            // Unknown token — ignore
+            return null;
+        }
+        return android.webkit.MimeTypeMap.getSingleton()
+            .getMimeTypeFromExtension(accept.substring(1).toLowerCase(java.util.Locale.ROOT));
+    }
 
-        // Fix MIME type handling
-        if (acceptType == null || acceptType.isEmpty() || acceptType.equals("undefined")) {
-            acceptType = "*/*";
-        } else {
-            // Handle common web input accept types
-            if (acceptType.equals("image/*")) {
-                // Keep as is - image/*
-            } else if (acceptType.contains("image/")) {
-                // Specific image type requested but keep it general for better compatibility
-                acceptType = "image/*";
-            } else if (acceptType.equals("audio/*") || acceptType.contains("audio/")) {
-                acceptType = "audio/*";
-            } else if (acceptType.equals("video/*") || acceptType.contains("video/")) {
-                acceptType = "video/*";
-            } else if (acceptType.startsWith(".") || acceptType.contains(",")) {
-                // Handle file extensions like ".pdf, .docx" by using a general mime type
-                if (acceptType.contains(".pdf")) {
-                    acceptType = "application/pdf";
-                } else if (acceptType.contains(".doc") || acceptType.contains(".docx")) {
-                    acceptType = "application/msword";
-                } else if (acceptType.contains(".xls") || acceptType.contains(".xlsx")) {
-                    acceptType = "application/vnd.ms-excel";
-                } else if (acceptType.contains(".txt") || acceptType.contains(".text")) {
-                    acceptType = "text/plain";
-                } else {
-                    // Default for extension lists
-                    acceptType = "*/*";
+    private void openFileChooser(ValueCallback<Uri[]> filePathCallback, String acceptType, boolean isMultiple) {
+        openFileChooser(filePathCallback, new String[] { acceptType }, isMultiple);
+    }
+
+    private void openFileChooser(ValueCallback<Uri[]> filePathCallback, String[] acceptTypes, boolean isMultiple) {
+        mFilePathCallback = filePathCallback;
+
+        // Preserve the page's FULL accept list: normalize every entry to a MIME type and
+        // advertise all of them via EXTRA_MIME_TYPES. Truncating to the first entry made
+        // mixed inputs (e.g. "image/png,...,application/pdf") image-only, which Android's
+        // photo-picker GET_CONTENT takeover then routes to the photo picker, so documents
+        // could never be selected.
+        java.util.LinkedHashSet<String> mimeTypes = new java.util.LinkedHashSet<>();
+        if (acceptTypes != null) {
+            for (String entry : acceptTypes) {
+                if (entry == null) {
+                    continue;
+                }
+                for (String part : entry.split(",")) {
+                    String mime = acceptEntryToMimeType(part.trim());
+                    if (mime != null) {
+                        mimeTypes.add(mime);
+                    }
                 }
             }
         }
+        if (mimeTypes.contains("*/*")) {
+            mimeTypes.clear();
+        }
 
-        Log.d("InAppBrowser", "File picker using MIME type: " + acceptType);
-        intent.setType(acceptType);
+        // Media-only requests keep GET_CONTENT so the system photo picker/gallery handles
+        // them; anything else uses OPEN_DOCUMENT, whose SAF picker cannot be intercepted by
+        // the photo-picker takeover or OEM galleries.
+        boolean mediaOnly = !mimeTypes.isEmpty();
+        for (String mime : mimeTypes) {
+            if (!(mime.startsWith("image/") || mime.startsWith("video/") || mime.startsWith("audio/"))) {
+                mediaOnly = false;
+                break;
+            }
+        }
+        Intent intent = new Intent(mediaOnly ? Intent.ACTION_GET_CONTENT : Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+
+        if (mimeTypes.size() == 1) {
+            intent.setType(mimeTypes.iterator().next());
+        } else {
+            intent.setType("*/*");
+            if (!mimeTypes.isEmpty()) {
+                intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes.toArray(new String[0]));
+            }
+        }
+
+        Log.d("InAppBrowser", "File picker using action: " + intent.getAction() + ", MIME types: " + mimeTypes);
         intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, isMultiple);
 
         try {
@@ -4139,7 +4170,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             }
         } catch (ActivityNotFoundException e) {
             // If no app can handle the specific MIME type, try with a more generic one
-            Log.e("InAppBrowser", "No app available for type: " + acceptType + ", trying with */*");
+            Log.e("InAppBrowser", "No app available for types: " + java.util.Arrays.toString(acceptTypes) + ", trying with */*");
             intent.setType("*/*");
             try {
                 if (activity instanceof androidx.activity.ComponentActivity) {


### PR DESCRIPTION
Fixes #661

### Problem

`onShowFileChooser` keeps only `getAcceptTypes()[0]` and widens any `image/...` value to `image/*`, firing `ACTION_GET_CONTENT` with a single type and no `EXTRA_MIME_TYPES`. For mixed accept lists like `image/png,image/jpeg,application/pdf` the request becomes image-only, which Android's photo-picker GET_CONTENT takeover routes to the photo picker — documents can never be selected (see issue for logs and details).

### Change

- `openFileChooser` now receives the **full** `fileChooserParams.getAcceptTypes()` array (a single-type overload keeps the existing camera-fallback call site unchanged).
- Every accept entry is normalized to a MIME type (`.ext` entries via `MimeTypeMap`, MIME entries passed through, unknown tokens ignored, empty list → `*/*`), de-duplicated, and exposed via `EXTRA_MIME_TYPES`.
- **Media-only** lists (`image/*`, `video/*`, `audio/*`) keep `ACTION_GET_CONTENT`, so image inputs still get the friendly system photo picker.
- Lists containing **any non-media type** (or no usable types) use `ACTION_OPEN_DOCUMENT` — the SAF document picker, which the photo-picker takeover and OEM galleries cannot intercept, so behavior is deterministic across devices while all declared types stay selectable.
- Result handling, multiple-selection (`EXTRA_ALLOW_MULTIPLE`) and the camera/capture detection path are unchanged.

This also replaces the previous hardcoded extension mapping (only `.pdf`/`.doc`/`.xls`/`.txt`) with `MimeTypeMap`, so e.g. `.docx`/`.xlsx` resolve to their real MIME types.

### Testing

Verified in a Capacitor 8 app on an Android 16 emulator against a production web page with `accept="image/png,image/jpeg,image/heif,image/heic,application/pdf"`:

before — photo picker opens, PDFs unselectable:

```
D InAppBrowser: File picker using MIME type: image/*
```

after — document picker opens with all types:

```
D InAppBrowser: File picker using action: android.intent.action.OPEN_DOCUMENT, MIME types: [image/png, image/jpeg, image/heif, image/heic, application/pdf]
```

A pure `accept="image/*"` input still opens the photo picker (unchanged UX).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-inappbrowser/pr/662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789298913&installation_model_id=430928&pr_number=662&repository=Cap-go%2Fcapacitor-inappbrowser&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-inappbrowser%2Fpull%2F662&signature=a39236d189c7cdd35fb0f774a248b53e8afd2703f61fbba983471f75615200d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file selection from web pages by preserving all requested file types.
  * Added better support for MIME types, file extensions, duplicate entries, and wildcard selections.
  * Improved handling of media, document, and mixed file requests.
  * Camera fallback and file-selection errors now handle multiple requested types correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->