### PR TITLE
fix(android): isolate overlapping file-chooser requests

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
@@ -574,9 +574,7 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
             }
 
             // Send the result to WebView and clean up
-            webViewDialog.mFilePathCallback.onReceiveValue(results);
-            webViewDialog.mFilePathCallback = null;
-            webViewDialog.tempCameraUri = null;
+            webViewDialog.completeLegacyFileChooserResult(results);
         }
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/FileChooserRequestSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/FileChooserRequestSupport.java
@@ -1,0 +1,57 @@
+package ee.forgr.capacitor_inappbrowser;
+
+import android.net.Uri;
+import android.webkit.ValueCallback;
+
+/**
+ * Request-scoped state for Android WebView file-chooser flows.
+ * Prevents overlapping chooser/camera requests from cross-delivering results.
+ */
+final class FileChooserRequestSupport {
+
+    static final class FileChooserRequest {
+
+        private static long nextId = 0;
+
+        final long id;
+        final ValueCallback<Uri[]> callback;
+        final String acceptType;
+        final boolean multiple;
+        Uri tempCameraUri;
+
+        FileChooserRequest(ValueCallback<Uri[]> callback, String acceptType, boolean multiple) {
+            this.id = ++nextId;
+            this.callback = callback;
+            this.acceptType = acceptType;
+            this.multiple = multiple;
+        }
+    }
+
+    private FileChooserRequestSupport() {}
+
+    static boolean isActive(FileChooserRequest request, FileChooserRequest active) {
+        return request != null && request == active;
+    }
+
+    static void cancel(FileChooserRequest request) {
+        if (request != null && request.callback != null) {
+            request.callback.onReceiveValue(null);
+        }
+    }
+
+    static boolean completeIfActive(FileChooserRequest request, FileChooserRequest active, Uri[] results) {
+        if (!isActive(request, active)) {
+            return false;
+        }
+        request.callback.onReceiveValue(results);
+        return true;
+    }
+
+    static boolean cancelIfActive(FileChooserRequest request, FileChooserRequest active) {
+        if (!isActive(request, active)) {
+            return false;
+        }
+        request.callback.onReceiveValue(null);
+        return true;
+    }
+}

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -412,6 +412,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
     public static final int FILE_CHOOSER_REQUEST_CODE = 1000;
     public ValueCallback<Uri> mUploadMessage;
     public ValueCallback<Uri[]> mFilePathCallback;
+    FileChooserRequestSupport.FileChooserRequest activeFileChooserRequest;
     private boolean openWebViewResolved;
     private boolean isDismissing = false;
     private PermissionRequest pendingCameraLaunchPermissionRequest;
@@ -2348,12 +2349,9 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                     );
 
                     // Check if the file chooser is already open
-                    if (mFilePathCallback != null) {
-                        mFilePathCallback.onReceiveValue(null);
-                        mFilePathCallback = null;
-                    }
-
-                    mFilePathCallback = filePathCallback;
+                    final boolean isMultiple = fileChooserParams.getMode() == FileChooserParams.MODE_OPEN_MULTIPLE;
+                    beginFileChooserRequest(filePathCallback, acceptType, isMultiple);
+                    final FileChooserRequestSupport.FileChooserRequest request = activeFileChooserRequest;
 
                     // Direct check for capture attribute in URL (fallback method)
                     boolean isCaptureInUrl;
@@ -2428,12 +2426,16 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                             """;
 
                         webView.evaluateJavascript(js, (value) -> {
+                            if (!FileChooserRequestSupport.isActive(request, activeFileChooserRequest)) {
+                                return;
+                            }
+
                             Log.d("InAppBrowser", "Capture attribute JS result: " + value);
 
                             // If we already found capture in URL, use that directly
                             if (isCaptureInUrl) {
                                 Log.d("InAppBrowser", "Using capture from URL: " + captureMode);
-                                launchCamera(captureMode.equals("user"));
+                                launchCamera(captureMode.equals("user"), request);
                                 return;
                             }
 
@@ -2444,7 +2446,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                                 Log.d("InAppBrowser", "Found capture attribute: " + captureValue);
 
                                 if (!captureValue.isEmpty()) {
-                                    activity.runOnUiThread(() -> launchCamera(captureValue.equals("user")));
+                                    activity.runOnUiThread(() -> launchCamera(captureValue.equals("user"), request));
                                     return;
                                 }
                             }
@@ -2452,6 +2454,10 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                             // Look for hints in the web page source
                             Log.d("InAppBrowser", "Looking for camera hints in page content");
                             webView.evaluateJavascript("(function() { return document.documentElement.innerHTML; })()", (htmlSource) -> {
+                                if (!FileChooserRequestSupport.isActive(request, activeFileChooserRequest)) {
+                                    return;
+                                }
+
                                 if (htmlSource != null && htmlSource.length() > 10) {
                                     boolean hasCameraOrSelfieKeyword =
                                         htmlSource.contains("capture=") || htmlSource.contains("camera") || htmlSource.contains("selfie");
@@ -2464,25 +2470,21 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                                         (currentUrl.contains("selfie") || currentUrl.contains("camera") || currentUrl.contains("photo"))
                                     ) {
                                         Log.d("InAppBrowser", "URL suggests camera usage, launching camera");
-                                        activity.runOnUiThread(() -> launchCamera(currentUrl.contains("selfie")));
+                                        activity.runOnUiThread(() -> launchCamera(currentUrl.contains("selfie"), request));
                                         return;
                                     }
                                 }
 
                                 // If all detection methods fail, fall back to regular file picker
                                 Log.d("InAppBrowser", "No capture attribute detected, using file picker");
-                                openFileChooser(
-                                    filePathCallback,
-                                    acceptType,
-                                    fileChooserParams.getMode() == FileChooserParams.MODE_OPEN_MULTIPLE
-                                );
+                                openFileChooser(request);
                             });
                         });
                         return true;
                     }
 
                     // For non-image types, use regular file picker
-                    openFileChooser(filePathCallback, acceptType, fileChooserParams.getMode() == FileChooserParams.MODE_OPEN_MULTIPLE);
+                    openFileChooser(request);
                     return true;
                 }
 
@@ -2490,7 +2492,11 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                  * Launch the camera app for capturing images
                  * @param useFrontCamera true to use front camera, false for back camera
                  */
-                private void launchCamera(boolean useFrontCamera) {
+                private void launchCamera(boolean useFrontCamera, FileChooserRequestSupport.FileChooserRequest request) {
+                    if (!FileChooserRequestSupport.isActive(request, activeFileChooserRequest)) {
+                        return;
+                    }
+
                     Log.d("InAppBrowser", "Launching camera, front camera: " + useFrontCamera);
 
                     // First check if we have camera permission
@@ -2514,8 +2520,11 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                                     Log.d("InAppBrowser", "Ignoring delayed camera permission grant during dismiss");
                                     return;
                                 }
+                                if (!FileChooserRequestSupport.isActive(request, activeFileChooserRequest)) {
+                                    return;
+                                }
                                 // Permission granted, now launch the camera
-                                launchCameraWithPermission(useFrontCamera);
+                                launchCameraWithPermission(useFrontCamera, request);
                             }
 
                             @Override
@@ -2525,9 +2534,12 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                                     Log.d("InAppBrowser", "Ignoring delayed camera permission denial during dismiss");
                                     return;
                                 }
+                                if (!FileChooserRequestSupport.isActive(request, activeFileChooserRequest)) {
+                                    return;
+                                }
                                 // Permission denied, fall back to file picker
                                 Log.e("InAppBrowser", "Camera permission denied, falling back to file picker");
-                                fallbackToFilePicker();
+                                fallbackToFilePicker(request);
                             }
                         };
 
@@ -2539,13 +2551,17 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                     }
 
                     // If we can't request permission, try launching directly
-                    launchCameraWithPermission(useFrontCamera);
+                    launchCameraWithPermission(useFrontCamera, request);
                 }
 
                 /**
                  * Launch camera after permission is granted
                  */
-                private void launchCameraWithPermission(boolean useFrontCamera) {
+                private void launchCameraWithPermission(boolean useFrontCamera, FileChooserRequestSupport.FileChooserRequest request) {
+                    if (!FileChooserRequestSupport.isActive(request, activeFileChooserRequest)) {
+                        return;
+                    }
+
                     try {
                         Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
                         if (takePictureIntent.resolveActivity(activity.getPackageManager()) != null) {
@@ -2554,17 +2570,18 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                                 photoFile = createImageFile();
                             } catch (IOException ex) {
                                 Log.e("InAppBrowser", "Error creating image file", ex);
-                                fallbackToFilePicker();
+                                fallbackToFilePicker(request);
                                 return;
                             }
 
                             if (photoFile != null) {
-                                tempCameraUri = FileProvider.getUriForFile(
+                                request.tempCameraUri = FileProvider.getUriForFile(
                                     activity,
                                     activity.getPackageName() + ".fileprovider",
                                     photoFile
                                 );
-                                takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, tempCameraUri);
+                                syncFileChooserPublicFields();
+                                takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, request.tempCameraUri);
 
                                 if (useFrontCamera) {
                                     takePictureIntent.putExtra("android.intent.extras.CAMERA_FACING", 1);
@@ -2580,15 +2597,23 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                                                 "camera_capture",
                                                 new androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult(),
                                                 (result) -> {
-                                                    if (result.getResultCode() == Activity.RESULT_OK) {
-                                                        if (tempCameraUri != null) {
-                                                            mFilePathCallback.onReceiveValue(new Uri[] { tempCameraUri });
-                                                        }
-                                                    } else {
-                                                        mFilePathCallback.onReceiveValue(null);
+                                                    if (!FileChooserRequestSupport.isActive(request, activeFileChooserRequest)) {
+                                                        return;
                                                     }
-                                                    mFilePathCallback = null;
-                                                    tempCameraUri = null;
+                                                    Uri[] results = null;
+                                                    if (result.getResultCode() == Activity.RESULT_OK && request.tempCameraUri != null) {
+                                                        results = new Uri[] { request.tempCameraUri };
+                                                    }
+                                                    if (
+                                                        FileChooserRequestSupport.completeIfActive(
+                                                            request,
+                                                            activeFileChooserRequest,
+                                                            results
+                                                        )
+                                                    ) {
+                                                        request.tempCameraUri = null;
+                                                        clearActiveFileChooserRequest(request);
+                                                    }
                                                 }
                                             )
                                             .launch(takePictureIntent);
@@ -2598,26 +2623,27 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                                     }
                                 } catch (SecurityException e) {
                                     Log.e("InAppBrowser", "Security exception launching camera: " + e.getMessage(), e);
-                                    fallbackToFilePicker();
+                                    fallbackToFilePicker(request);
                                 }
                             } else {
                                 Log.e("InAppBrowser", "Failed to create photo URI, falling back to file picker");
-                                fallbackToFilePicker();
+                                fallbackToFilePicker(request);
                             }
                         }
                     } catch (Exception e) {
                         Log.e("InAppBrowser", "Camera launch failed: " + e.getMessage(), e);
-                        fallbackToFilePicker();
+                        fallbackToFilePicker(request);
                     }
                 }
 
                 /**
                  * Fall back to file picker when camera launch fails
                  */
-                private void fallbackToFilePicker() {
-                    if (mFilePathCallback != null) {
-                        openFileChooser(mFilePathCallback, "image/*", false);
+                private void fallbackToFilePicker(FileChooserRequestSupport.FileChooserRequest request) {
+                    if (!FileChooserRequestSupport.isActive(request, activeFileChooserRequest)) {
+                        return;
                     }
+                    openFileChooser(request);
                 }
 
                 // Grant permissions for cam
@@ -4065,8 +4091,43 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         }
     }
 
-    private void openFileChooser(ValueCallback<Uri[]> filePathCallback, String acceptType, boolean isMultiple) {
-        mFilePathCallback = filePathCallback;
+    private void beginFileChooserRequest(ValueCallback<Uri[]> filePathCallback, String acceptType, boolean isMultiple) {
+        if (activeFileChooserRequest != null) {
+            FileChooserRequestSupport.cancel(activeFileChooserRequest);
+        }
+        activeFileChooserRequest = new FileChooserRequestSupport.FileChooserRequest(filePathCallback, acceptType, isMultiple);
+        syncFileChooserPublicFields();
+    }
+
+    private void clearActiveFileChooserRequest(FileChooserRequestSupport.FileChooserRequest request) {
+        if (activeFileChooserRequest == request) {
+            activeFileChooserRequest = null;
+            syncFileChooserPublicFields();
+        }
+    }
+
+    private void syncFileChooserPublicFields() {
+        mFilePathCallback = activeFileChooserRequest != null ? activeFileChooserRequest.callback : null;
+        tempCameraUri = activeFileChooserRequest != null ? activeFileChooserRequest.tempCameraUri : null;
+    }
+
+    void completeLegacyFileChooserResult(Uri[] results) {
+        FileChooserRequestSupport.FileChooserRequest request = activeFileChooserRequest;
+        if (request == null) {
+            return;
+        }
+        if (FileChooserRequestSupport.completeIfActive(request, activeFileChooserRequest, results)) {
+            request.tempCameraUri = null;
+            clearActiveFileChooserRequest(request);
+        }
+    }
+
+    private void openFileChooser(FileChooserRequestSupport.FileChooserRequest request) {
+        if (!FileChooserRequestSupport.isActive(request, activeFileChooserRequest)) {
+            return;
+        }
+        String acceptType = request.acceptType;
+        boolean isMultiple = request.multiple;
         Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
 
@@ -4114,26 +4175,29 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                         "file_chooser",
                         new androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult(),
                         (result) -> {
+                            if (!FileChooserRequestSupport.isActive(request, activeFileChooserRequest)) {
+                                return;
+                            }
+                            Uri[] results = null;
                             if (result.getResultCode() == Activity.RESULT_OK) {
                                 Intent data = result.getData();
                                 if (data != null) {
                                     if (data.getClipData() != null) {
                                         // Handle multiple files
                                         int count = data.getClipData().getItemCount();
-                                        Uri[] results = new Uri[count];
+                                        results = new Uri[count];
                                         for (int i = 0; i < count; i++) {
                                             results[i] = data.getClipData().getItemAt(i).getUri();
                                         }
-                                        mFilePathCallback.onReceiveValue(results);
                                     } else if (data.getData() != null) {
                                         // Handle single file
-                                        mFilePathCallback.onReceiveValue(new Uri[] { data.getData() });
+                                        results = new Uri[] { data.getData() };
                                     }
                                 }
-                            } else {
-                                mFilePathCallback.onReceiveValue(null);
                             }
-                            mFilePathCallback = null;
+                            if (FileChooserRequestSupport.completeIfActive(request, activeFileChooserRequest, results)) {
+                                clearActiveFileChooserRequest(request);
+                            }
                         }
                     )
                     .launch(Intent.createChooser(intent, "Select File"));
@@ -4154,26 +4218,29 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                             "file_chooser",
                             new androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult(),
                             (result) -> {
+                                if (!FileChooserRequestSupport.isActive(request, activeFileChooserRequest)) {
+                                    return;
+                                }
+                                Uri[] results = null;
                                 if (result.getResultCode() == Activity.RESULT_OK) {
                                     Intent data = result.getData();
                                     if (data != null) {
                                         if (data.getClipData() != null) {
                                             // Handle multiple files
                                             int count = data.getClipData().getItemCount();
-                                            Uri[] results = new Uri[count];
+                                            results = new Uri[count];
                                             for (int i = 0; i < count; i++) {
                                                 results[i] = data.getClipData().getItemAt(i).getUri();
                                             }
-                                            mFilePathCallback.onReceiveValue(results);
                                         } else if (data.getData() != null) {
                                             // Handle single file
-                                            mFilePathCallback.onReceiveValue(new Uri[] { data.getData() });
+                                            results = new Uri[] { data.getData() };
                                         }
                                     }
-                                } else {
-                                    mFilePathCallback.onReceiveValue(null);
                                 }
-                                mFilePathCallback = null;
+                                if (FileChooserRequestSupport.completeIfActive(request, activeFileChooserRequest, results)) {
+                                    clearActiveFileChooserRequest(request);
+                                }
                             }
                         )
                         .launch(Intent.createChooser(intent, "Select File"));
@@ -4184,9 +4251,8 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             } catch (ActivityNotFoundException ex) {
                 // If still failing, report error
                 Log.e("InAppBrowser", "No app can handle file picker", ex);
-                if (mFilePathCallback != null) {
-                    mFilePathCallback.onReceiveValue(null);
-                    mFilePathCallback = null;
+                if (FileChooserRequestSupport.cancelIfActive(request, activeFileChooserRequest)) {
+                    clearActiveFileChooserRequest(request);
                 }
             }
         }
@@ -6258,11 +6324,11 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                 }
 
                 // Clear any pending callbacks to prevent memory leaks
-                if (mFilePathCallback != null) {
-                    mFilePathCallback.onReceiveValue(null);
-                    mFilePathCallback = null;
+                if (activeFileChooserRequest != null) {
+                    FileChooserRequestSupport.cancel(activeFileChooserRequest);
+                    activeFileChooserRequest = null;
+                    syncFileChooserPublicFields();
                 }
-                tempCameraUri = null;
 
                 // Clear file inputs for security/privacy before destroying WebView
                 try {

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/FileChooserRequestSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/FileChooserRequestSupportTest.java
@@ -1,0 +1,110 @@
+package ee.forgr.capacitor_inappbrowser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.net.Uri;
+import android.webkit.ValueCallback;
+import org.junit.Test;
+
+public class FileChooserRequestSupportTest {
+
+    private static final class RecordingCallback implements ValueCallback<Uri[]> {
+
+        Uri[] lastValue;
+        int callCount;
+
+        @Override
+        public void onReceiveValue(Uri[] value) {
+            callCount++;
+            lastValue = value;
+        }
+    }
+
+    @Test
+    public void activeRequestIdentityMatchesOnlyCurrentRequest() {
+        RecordingCallback firstCallback = new RecordingCallback();
+        RecordingCallback secondCallback = new RecordingCallback();
+        FileChooserRequestSupport.FileChooserRequest first = new FileChooserRequestSupport.FileChooserRequest(
+            firstCallback,
+            "image/*",
+            false
+        );
+        FileChooserRequestSupport.FileChooserRequest second = new FileChooserRequestSupport.FileChooserRequest(
+            secondCallback,
+            "application/pdf",
+            true
+        );
+
+        assertTrue(FileChooserRequestSupport.isActive(first, first));
+        assertFalse(FileChooserRequestSupport.isActive(first, second));
+    }
+
+    @Test
+    public void supersededRequestDoesNotReceiveCompletion() {
+        RecordingCallback firstCallback = new RecordingCallback();
+        RecordingCallback secondCallback = new RecordingCallback();
+        FileChooserRequestSupport.FileChooserRequest first = new FileChooserRequestSupport.FileChooserRequest(
+            firstCallback,
+            "image/*",
+            false
+        );
+        FileChooserRequestSupport.FileChooserRequest second = new FileChooserRequestSupport.FileChooserRequest(
+            secondCallback,
+            "image/*",
+            false
+        );
+
+        Uri[] cameraResult = new Uri[1];
+        assertFalse(FileChooserRequestSupport.completeIfActive(first, second, cameraResult));
+
+        assertEquals(0, firstCallback.callCount);
+        assertEquals(0, secondCallback.callCount);
+    }
+
+    @Test
+    public void activeRequestReceivesCompletion() {
+        RecordingCallback callback = new RecordingCallback();
+        FileChooserRequestSupport.FileChooserRequest request = new FileChooserRequestSupport.FileChooserRequest(callback, "image/*", false);
+        Uri[] cameraResult = new Uri[1];
+
+        assertTrue(FileChooserRequestSupport.completeIfActive(request, request, cameraResult));
+        assertEquals(1, callback.callCount);
+        assertEquals(cameraResult, callback.lastValue);
+    }
+
+    @Test
+    public void cancelNotifiesCallbackWithNull() {
+        RecordingCallback callback = new RecordingCallback();
+        FileChooserRequestSupport.FileChooserRequest request = new FileChooserRequestSupport.FileChooserRequest(callback, "*/*", false);
+
+        FileChooserRequestSupport.cancel(request);
+
+        assertEquals(1, callback.callCount);
+        assertEquals(null, callback.lastValue);
+    }
+
+    @Test
+    public void cancelIfActiveOnlyCancelsCurrentRequest() {
+        RecordingCallback firstCallback = new RecordingCallback();
+        RecordingCallback secondCallback = new RecordingCallback();
+        FileChooserRequestSupport.FileChooserRequest first = new FileChooserRequestSupport.FileChooserRequest(
+            firstCallback,
+            "image/*",
+            false
+        );
+        FileChooserRequestSupport.FileChooserRequest second = new FileChooserRequestSupport.FileChooserRequest(
+            secondCallback,
+            "image/*",
+            false
+        );
+
+        assertFalse(FileChooserRequestSupport.cancelIfActive(first, second));
+        assertEquals(0, firstCallback.callCount);
+
+        assertTrue(FileChooserRequestSupport.cancelIfActive(second, second));
+        assertEquals(1, secondCallback.callCount);
+        assertEquals(null, secondCallback.lastValue);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #664

## What
- Introduce request-scoped `FileChooserRequest` state for Android `onShowFileChooser` flows
- Guard async camera detection, permission prompts, camera activity results, and file-picker results with active-request identity checks
- Add unit tests for request supersession and completion/cancel behavior

## Why
The camera/file-chooser path stored per-request state in shared fields (`mFilePathCallback`, `tempCameraUri`). Because capture detection and camera permission are asynchronous, a second `onShowFileChooser` could overwrite those fields while the first flow was still pending. The first flow's continuation then delivered its result to the wrong HTML input.

## How
- Added `FileChooserRequestSupport` with a `FileChooserRequest` holder (callback, accept type, multiple flag, temp camera URI)
- `beginFileChooserRequest()` cancels any in-flight request and registers a new active one
- Every async continuation captures its request and no-ops unless `request == activeFileChooserRequest`
- Public `mFilePathCallback` / `tempCameraUri` remain synced for the legacy `startActivityForResult` plugin path

This change is scoped to the race in #664 and does not touch accept-type handling from #661 / PR #662.

## Testing
- `FileChooserRequestSupportTest` (5 unit tests) — superseded requests do not receive completion/cancel
- `./gradlew testDebugUnitTest` — all 111 Android unit tests pass locally

### Manual test plan
1. Open a page with two `<input type="file" accept="image/*" capture>` fields
2. Tap the first input to start the camera flow (do not finish)
3. Quickly tap the second input to trigger a second chooser
4. Complete the camera/chooser for the second input
5. Verify only the second input receives the file/photo; the first input stays empty/cancelled

## Not Tested
- Device/emulator manual overlap scenario (no automated instrumentation test for concurrent chooser UI)
- iOS (unchanged)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db535a45-1cc9-475a-9f42-7104a042adcd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db535a45-1cc9-475a-9f42-7104a042adcd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-inappbrowser/pr/665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789467482&installation_model_id=430928&pr_number=665&repository=Cap-go%2Fcapacitor-inappbrowser&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-inappbrowser%2Fpull%2F665&signature=f72d6c1676f5b16ce118e7ce5be7803f7dfa9b0361868a149bc76a42d66bdb07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

