### PR TITLE
fix(android): enable iframe/HTML5 fullscreen for embedded video

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupport.java
@@ -34,6 +34,14 @@ final class WebViewCustomFullscreenSupport {
         );
     }
 
+    static boolean shouldUseHostActivityWindow(boolean backLayerActive) {
+        return backLayerActive;
+    }
+
+    static boolean shouldRegisterHostBackHandler(boolean backLayerActive) {
+        return backLayerActive;
+    }
+
     @SuppressWarnings("deprecation")
     static int restoredSystemUiVisibility() {
         return View.SYSTEM_UI_FLAG_VISIBLE;

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupport.java
@@ -1,0 +1,41 @@
+package ee.forgr.capacitor_inappbrowser;
+
+import android.view.View;
+
+/**
+ * Testable helpers for HTML5/iframe fullscreen routed through WebChromeClient custom views
+ * (e.g. embedded YouTube fullscreen).
+ */
+final class WebViewCustomFullscreenSupport {
+
+    private WebViewCustomFullscreenSupport() {}
+
+    static boolean isCustomFullscreenActive(View customFullscreenView) {
+        return customFullscreenView != null;
+    }
+
+    static boolean shouldRejectDuplicateShow(boolean isActive) {
+        return isActive;
+    }
+
+    static boolean shouldConsumeBackPress(boolean isActive) {
+        return isActive;
+    }
+
+    @SuppressWarnings("deprecation")
+    static int immersiveFullscreenSystemUiVisibility() {
+        return (
+            View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
+            View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
+            View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
+            View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
+            View.SYSTEM_UI_FLAG_FULLSCREEN |
+            View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+        );
+    }
+
+    @SuppressWarnings("deprecation")
+    static int restoredSystemUiVisibility() {
+        return View.SYSTEM_UI_FLAG_VISIBLE;
+    }
+}

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupport.java
@@ -10,7 +10,7 @@ final class WebViewCustomFullscreenSupport {
 
     private WebViewCustomFullscreenSupport() {}
 
-    static boolean isCustomFullscreenActive(View customFullscreenView) {
+    static boolean isCustomFullscreenActive(Object customFullscreenView) {
         return customFullscreenView != null;
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -70,6 +70,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.Toolbar;
 import androidx.activity.ComponentActivity;
+import androidx.activity.OnBackPressedCallback;
 import androidx.activity.result.ActivityResult;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -341,6 +342,8 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
     private View customFullscreenView;
     private WebChromeClient.CustomViewCallback customViewCallback;
     private FrameLayout fullscreenContainer;
+    private Window customFullscreenWindow;
+    private OnBackPressedCallback customFullscreenBackCallback;
     private Toolbar _toolbar;
     private Options _options = null;
     private final Context _context;
@@ -2932,7 +2935,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             return;
         }
 
-        Window window = getWindow();
+        Window window = resolveCustomFullscreenWindow();
         View decorView = window != null ? window.getDecorView() : null;
         if (!(decorView instanceof ViewGroup)) {
             callback.onCustomViewHidden();
@@ -2941,15 +2944,18 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
 
         customFullscreenView = view;
         customViewCallback = callback;
+        customFullscreenWindow = window;
 
         if (fullscreenContainer == null) {
             fullscreenContainer = new FrameLayout(getContext());
             fullscreenContainer.setBackgroundColor(Color.BLACK);
-            ((ViewGroup) decorView).addView(
-                fullscreenContainer,
-                new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
-            );
+        } else if (fullscreenContainer.getParent() instanceof ViewGroup oldParent) {
+            oldParent.removeView(fullscreenContainer);
         }
+        ((ViewGroup) decorView).addView(
+            fullscreenContainer,
+            new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+        );
         fullscreenContainer.addView(
             view,
             new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
@@ -2960,9 +2966,43 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             _webView.setVisibility(View.INVISIBLE);
         }
 
-        if (window != null) {
-            window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-            decorView.setSystemUiVisibility(WebViewCustomFullscreenSupport.immersiveFullscreenSystemUiVisibility());
+        window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+        decorView.setSystemUiVisibility(WebViewCustomFullscreenSupport.immersiveFullscreenSystemUiVisibility());
+
+        if (WebViewCustomFullscreenSupport.shouldRegisterHostBackHandler(backLayerActive)) {
+            registerCustomFullscreenBackHandler();
+        }
+    }
+
+    private Window resolveCustomFullscreenWindow() {
+        if (WebViewCustomFullscreenSupport.shouldUseHostActivityWindow(backLayerActive) && activity != null) {
+            Window hostWindow = activity.getWindow();
+            if (hostWindow != null) {
+                return hostWindow;
+            }
+        }
+        return getWindow();
+    }
+
+    private void registerCustomFullscreenBackHandler() {
+        if (!(activity instanceof ComponentActivity componentActivity) || customFullscreenBackCallback != null) {
+            return;
+        }
+        customFullscreenBackCallback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (WebViewCustomFullscreenSupport.isCustomFullscreenActive(customFullscreenView)) {
+                    exitCustomFullscreenView();
+                }
+            }
+        };
+        componentActivity.getOnBackPressedDispatcher().addCallback(componentActivity, customFullscreenBackCallback);
+    }
+
+    private void unregisterCustomFullscreenBackHandler() {
+        if (customFullscreenBackCallback != null) {
+            customFullscreenBackCallback.remove();
+            customFullscreenBackCallback = null;
         }
     }
 
@@ -2979,7 +3019,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             _webView.setVisibility(View.VISIBLE);
         }
 
-        Window window = getWindow();
+        Window window = customFullscreenWindow != null ? customFullscreenWindow : getWindow();
         if (window != null) {
             window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
             window.getDecorView().setSystemUiVisibility(WebViewCustomFullscreenSupport.restoredSystemUiVisibility());
@@ -2989,11 +3029,14 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             }
         }
 
+        unregisterCustomFullscreenBackHandler();
+
         if (customViewCallback != null) {
             customViewCallback.onCustomViewHidden();
         }
         customFullscreenView = null;
         customViewCallback = null;
+        customFullscreenWindow = null;
     }
 
     private void applyHiddenMode() {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -3014,6 +3014,9 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         if (fullscreenContainer != null) {
             fullscreenContainer.removeView(customFullscreenView);
             fullscreenContainer.setVisibility(View.GONE);
+            if (fullscreenContainer.getParent() instanceof ViewGroup parent) {
+                parent.removeView(fullscreenContainer);
+            }
         }
         if (_webView != null) {
             _webView.setVisibility(View.VISIBLE);

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -337,6 +337,10 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
     private SwipeRefreshLayout swipeRefreshLayout;
     private boolean reloadFromGestureInProgress = false;
     private WebView _webView;
+    // HTML5/iframe fullscreen (e.g. embedded YouTube) routes through WebChromeClient custom views.
+    private View customFullscreenView;
+    private WebChromeClient.CustomViewCallback customViewCallback;
+    private FrameLayout fullscreenContainer;
     private Toolbar _toolbar;
     private Options _options = null;
     private final Context _context;
@@ -2305,6 +2309,17 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                     return super.onConsoleMessage(consoleMessage);
                 }
 
+                // Enable HTML5/iframe fullscreen (e.g. embedded YouTube player fullscreen button).
+                @Override
+                public void onShowCustomView(View view, WebChromeClient.CustomViewCallback callback) {
+                    showCustomFullscreenView(view, callback);
+                }
+
+                @Override
+                public void onHideCustomView() {
+                    exitCustomFullscreenView();
+                }
+
                 // Enable file open dialog
                 @Override
                 public boolean onShowFileChooser(
@@ -2880,6 +2895,11 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
     }
 
     private void handleBrowserBackNavigation() {
+        if (WebViewCustomFullscreenSupport.shouldConsumeBackPress(customFullscreenView != null)) {
+            exitCustomFullscreenView();
+            return;
+        }
+
         if (_options == null) {
             dismiss();
             return;
@@ -2903,6 +2923,77 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             _options.getCallbacks().closeEvent(currentUrl);
         }
         dismiss();
+    }
+
+    // Shows a native fullscreen view requested via the HTML5 Fullscreen API (e.g. embedded YouTube).
+    private void showCustomFullscreenView(View view, WebChromeClient.CustomViewCallback callback) {
+        if (WebViewCustomFullscreenSupport.shouldRejectDuplicateShow(customFullscreenView != null)) {
+            callback.onCustomViewHidden();
+            return;
+        }
+
+        Window window = getWindow();
+        View decorView = window != null ? window.getDecorView() : null;
+        if (!(decorView instanceof ViewGroup)) {
+            callback.onCustomViewHidden();
+            return;
+        }
+
+        customFullscreenView = view;
+        customViewCallback = callback;
+
+        if (fullscreenContainer == null) {
+            fullscreenContainer = new FrameLayout(getContext());
+            fullscreenContainer.setBackgroundColor(Color.BLACK);
+            ((ViewGroup) decorView).addView(
+                fullscreenContainer,
+                new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+            );
+        }
+        fullscreenContainer.addView(
+            view,
+            new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+        );
+        fullscreenContainer.setVisibility(View.VISIBLE);
+
+        if (_webView != null) {
+            _webView.setVisibility(View.INVISIBLE);
+        }
+
+        if (window != null) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            decorView.setSystemUiVisibility(WebViewCustomFullscreenSupport.immersiveFullscreenSystemUiVisibility());
+        }
+    }
+
+    private void exitCustomFullscreenView() {
+        if (!WebViewCustomFullscreenSupport.isCustomFullscreenActive(customFullscreenView)) {
+            return;
+        }
+
+        if (fullscreenContainer != null) {
+            fullscreenContainer.removeView(customFullscreenView);
+            fullscreenContainer.setVisibility(View.GONE);
+        }
+        if (_webView != null) {
+            _webView.setVisibility(View.VISIBLE);
+        }
+
+        Window window = getWindow();
+        if (window != null) {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            window.getDecorView().setSystemUiVisibility(WebViewCustomFullscreenSupport.restoredSystemUiVisibility());
+            reapplyInsetsFromWindowRoot();
+            if (SystemUiChromeSupport.requiresEdgeToEdgeChrome(Build.VERSION.SDK_INT)) {
+                refreshEdgeToEdgeChrome();
+            }
+        }
+
+        if (customViewCallback != null) {
+            customViewCallback.onCustomViewHidden();
+        }
+        customFullscreenView = null;
+        customViewCallback = null;
     }
 
     private void applyHiddenMode() {
@@ -6260,6 +6351,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
 
     @Override
     public void dismiss() {
+        exitCustomFullscreenView();
         unregisterConfigurationCallbacks();
         scheduleHostWebViewInsetRestore();
         detachBackLayer();

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupportTest.java
@@ -1,0 +1,39 @@
+package ee.forgr.capacitor_inappbrowser;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.view.View;
+import org.junit.Test;
+
+public class WebViewCustomFullscreenSupportTest {
+
+    @Test
+    public void customFullscreenInactiveWhenViewIsNull() {
+        assertFalse(WebViewCustomFullscreenSupport.isCustomFullscreenActive(null));
+    }
+
+    @Test
+    public void customFullscreenActiveWhenViewIsPresent() {
+        assertTrue(WebViewCustomFullscreenSupport.isCustomFullscreenActive(new View(null)));
+    }
+
+    @Test
+    public void duplicateShowRejectedWhileFullscreenActive() {
+        assertTrue(WebViewCustomFullscreenSupport.shouldRejectDuplicateShow(true));
+        assertFalse(WebViewCustomFullscreenSupport.shouldRejectDuplicateShow(false));
+    }
+
+    @Test
+    public void backPressConsumedWhileFullscreenActive() {
+        assertTrue(WebViewCustomFullscreenSupport.shouldConsumeBackPress(true));
+        assertFalse(WebViewCustomFullscreenSupport.shouldConsumeBackPress(false));
+    }
+
+    @Test
+    public void immersiveFlagsIncludeFullscreenAndImmersiveSticky() {
+        int flags = WebViewCustomFullscreenSupport.immersiveFullscreenSystemUiVisibility();
+        assertTrue((flags & View.SYSTEM_UI_FLAG_FULLSCREEN) != 0);
+        assertTrue((flags & View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY) != 0);
+    }
+}

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupportTest.java
@@ -14,8 +14,8 @@ public class WebViewCustomFullscreenSupportTest {
     }
 
     @Test
-    public void customFullscreenActiveWhenViewIsPresent() {
-        assertTrue(WebViewCustomFullscreenSupport.isCustomFullscreenActive(new View(null)));
+    public void customFullscreenActiveForNonNullReference() {
+        assertTrue(WebViewCustomFullscreenSupport.isCustomFullscreenActive(new Object()));
     }
 
     @Test

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupportTest.java
@@ -36,4 +36,16 @@ public class WebViewCustomFullscreenSupportTest {
         assertTrue((flags & View.SYSTEM_UI_FLAG_FULLSCREEN) != 0);
         assertTrue((flags & View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY) != 0);
     }
+
+    @Test
+    public void backLayerModeUsesHostActivityWindow() {
+        assertTrue(WebViewCustomFullscreenSupport.shouldUseHostActivityWindow(true));
+        assertFalse(WebViewCustomFullscreenSupport.shouldUseHostActivityWindow(false));
+    }
+
+    @Test
+    public void backLayerModeRegistersHostBackHandler() {
+        assertTrue(WebViewCustomFullscreenSupport.shouldRegisterHostBackHandler(true));
+        assertFalse(WebViewCustomFullscreenSupport.shouldRegisterHostBackHandler(false));
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Implement `WebChromeClient.onShowCustomView` / `onHideCustomView` in `WebViewDialog` so embedded HTML5/iframe video (e.g. YouTube embed fullscreen button) works on Android.
- Handle back press to exit custom fullscreen instead of closing the browser.
- Add `WebViewCustomFullscreenSupport` helper with JVM unit tests for fullscreen state/back-press logic.

## Why
- Android WebView routes iframe fullscreen through `WebChromeClient` custom views. The plugin's default `WebChromeClient` did not implement these callbacks, so fullscreen was a no-op (Fixes #676).

## How
- Track `customFullscreenView`, `customViewCallback`, and a black `fullscreenContainer` overlay on the dialog decor.
- `showCustomFullscreenView`: add the custom view, hide the WebView, apply immersive fullscreen flags.
- `exitCustomFullscreenView`: remove the overlay, restore WebView visibility, clear fullscreen flags, notify the callback, and re-apply safe-area/edge-to-edge chrome on API 35+.
- `handleBrowserBackNavigation`: exit custom fullscreen first when active.
- Reject duplicate `onShowCustomView` calls while fullscreen is already showing.

## Testing
- Added `WebViewCustomFullscreenSupportTest` (state, duplicate-show rejection, back-press consumption, immersive flags).
- `bun run fmt` locally.

## Not Tested
- Manual YouTube embed fullscreen on a physical Android device (no device/emulator in this environment). CI `verify:android` should run the new unit tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-978fc600-e0c1-40bc-bb9d-c1a011113106?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-978fc600-e0c1-40bc-bb9d-c1a011113106&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-inappbrowser/pr/677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790441641&installation_model_id=430928&pr_number=677&repository=Cap-go%2Fcapacitor-inappbrowser&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-inappbrowser%2Fpull%2F677&signature=c78402d5d600b97a60432665a45b0ed78d5487bcc5c2bbd5c552bd9bbcf3ffe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTML5 fullscreen support for embedded Android web content.
  * Fullscreen content now uses immersive display mode and a dedicated fullscreen view.
  * System UI, window settings, and the embedded page are restored when fullscreen ends.

* **Bug Fixes**
  * Prevented duplicate or invalid fullscreen requests while fullscreen mode is active.
  * Back navigation and dialog dismissal now exit fullscreen cleanly and restore the previous display state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->