### PR TITLE
fix(android): honor disableGoBackOnNativeApplication on predictive back

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewBackNavigationSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewBackNavigationSupport.java
@@ -1,0 +1,43 @@
+package ee.forgr.capacitor_inappbrowser;
+
+/**
+ * Testable Android back-button decisions for the in-app browser dialog.
+ *
+ * Predictive back (API 33+) no longer delivers {@code KEYCODE_BACK} to dialog
+ * {@code OnKeyListener}s, so {@link WebViewDialog} must honor these actions from
+ * {@link androidx.activity.OnBackPressedCallback}.
+ */
+final class WebViewBackNavigationSupport {
+
+    enum Action {
+        EXIT_FULLSCREEN,
+        WEBVIEW_GO_BACK,
+        IGNORE,
+        DISMISS
+    }
+
+    private WebViewBackNavigationSupport() {}
+
+    static boolean shouldConsumeBackPress(boolean isShowing, boolean hiddenMode, boolean backLayerActive) {
+        return isShowing && !hiddenMode && !backLayerActive;
+    }
+
+    static Action resolveAction(
+        boolean customFullscreenActive,
+        boolean webViewCanGoBack,
+        boolean navigationToolbar,
+        boolean activeNativeNavigationForWebview,
+        boolean disableGoBackOnNativeApplication
+    ) {
+        if (customFullscreenActive) {
+            return Action.EXIT_FULLSCREEN;
+        }
+        if (webViewCanGoBack && (navigationToolbar || activeNativeNavigationForWebview)) {
+            return Action.WEBVIEW_GO_BACK;
+        }
+        if (disableGoBackOnNativeApplication) {
+            return Action.IGNORE;
+        }
+        return Action.DISMISS;
+    }
+}

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -3,7 +3,6 @@ package ee.forgr.capacitor_inappbrowser;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.app.Dialog;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentCallbacks2;
 import android.content.Context;
@@ -70,6 +69,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.Toolbar;
 import androidx.activity.ComponentActivity;
+import androidx.activity.ComponentDialog;
 import androidx.activity.OnBackPressedCallback;
 import androidx.activity.result.ActivityResult;
 import androidx.activity.result.ActivityResultLauncher;
@@ -141,7 +141,7 @@ import javax.net.ssl.X509TrustManager;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyRequestLocator {
+public class WebViewDialog extends ComponentDialog implements ProxyResponseRouting.ProxyRequestLocator {
 
     private static final long HOST_WEBVIEW_INSET_RETRY_DELAY_MS = 160L;
 
@@ -344,6 +344,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
     private FrameLayout fullscreenContainer;
     private Window customFullscreenWindow;
     private OnBackPressedCallback customFullscreenBackCallback;
+    private OnBackPressedCallback dialogBackCallback;
     private Toolbar _toolbar;
     private Options _options = null;
     private final Context _context;
@@ -460,6 +461,18 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
     void bindToHostActivity() {
         ensureFileChooserLaunchers();
         registerDialogBackHandler();
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        syncDialogBackCallbackEnabled();
+    }
+
+    @Override
+    protected void onStop() {
+        syncDialogBackCallbackEnabled();
+        super.onStop();
     }
 
     public String getInstanceId() {
@@ -657,6 +670,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         backLayerActive = false;
         backLayerParent = null;
         restoreHostTransparency();
+        syncDialogBackCallbackEnabled();
     }
 
     private void attachContentToDialogWindow() {
@@ -699,6 +713,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
             super.hide();
         }
         refreshInsetsForHostingLayer();
+        syncDialogBackCallbackEnabled();
         return true;
     }
 
@@ -2878,54 +2893,70 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
     }
 
     private void registerDialogBackHandler() {
-        setOnKeyListener((dialogInterface, keyCode, event) -> {
-            if (keyCode != KeyEvent.KEYCODE_BACK) {
-                return false;
+        if (dialogBackCallback != null) {
+            return;
+        }
+        // Predictive back (API 33+) never delivers KEYCODE_BACK to Dialog OnKeyListener.
+        dialogBackCallback = new OnBackPressedCallback(false) {
+            @Override
+            public void handleOnBackPressed() {
+                handleBrowserBackNavigation();
             }
-            if (event.getAction() != KeyEvent.ACTION_UP) {
-                return true;
-            }
-            if (!shouldConsumeBackPress()) {
-                return false;
-            }
-            handleBrowserBackNavigation();
-            return true;
-        });
+        };
+        getOnBackPressedDispatcher().addCallback(dialogBackCallback);
+        syncDialogBackCallbackEnabled();
+    }
+
+    private void syncDialogBackCallbackEnabled() {
+        if (dialogBackCallback != null) {
+            dialogBackCallback.setEnabled(shouldConsumeBackPress());
+        }
+    }
+
+    private void unregisterDialogBackHandler() {
+        if (dialogBackCallback != null) {
+            dialogBackCallback.remove();
+            dialogBackCallback = null;
+        }
     }
 
     private boolean shouldConsumeBackPress() {
-        return isShowing() && !isHiddenModeActive && !backLayerActive;
+        return WebViewBackNavigationSupport.shouldConsumeBackPress(isShowing(), isHiddenModeActive, backLayerActive);
     }
 
     private void handleBrowserBackNavigation() {
-        if (WebViewCustomFullscreenSupport.shouldConsumeBackPress(customFullscreenView != null)) {
-            exitCustomFullscreenView();
-            return;
-        }
-
         if (_options == null) {
             dismiss();
             return;
         }
 
-        if (
-            _webView != null &&
-            _webView.canGoBack() &&
-            (TextUtils.equals(_options.getToolbarType(), "navigation") || _options.getActiveNativeNavigationForWebview())
-        ) {
-            _webView.goBack();
-            return;
-        }
+        WebViewBackNavigationSupport.Action action = WebViewBackNavigationSupport.resolveAction(
+            WebViewCustomFullscreenSupport.shouldConsumeBackPress(customFullscreenView != null),
+            _webView != null && _webView.canGoBack(),
+            TextUtils.equals(_options.getToolbarType(), "navigation"),
+            _options.getActiveNativeNavigationForWebview(),
+            _options.getDisableGoBackOnNativeApplication()
+        );
 
-        if (_options.getDisableGoBackOnNativeApplication()) {
-            return;
+        switch (action) {
+            case EXIT_FULLSCREEN:
+                exitCustomFullscreenView();
+                return;
+            case WEBVIEW_GO_BACK:
+                if (_webView != null) {
+                    _webView.goBack();
+                }
+                return;
+            case IGNORE:
+                return;
+            case DISMISS:
+            default:
+                String currentUrl = getUrl();
+                if (_options.getCallbacks() != null) {
+                    _options.getCallbacks().closeEvent(currentUrl);
+                }
+                dismiss();
         }
-
-        String currentUrl = getUrl();
-        if (_options.getCallbacks() != null) {
-            _options.getCallbacks().closeEvent(currentUrl);
-        }
-        dismiss();
     }
 
     // Shows a native fullscreen view requested via the HTML5 Fullscreen API (e.g. embedded YouTube).
@@ -3093,6 +3124,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         }
 
         isHiddenModeActive = true;
+        syncDialogBackCallbackEnabled();
     }
 
     private void restoreVisibleMode() {
@@ -3130,6 +3162,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         previousWebViewAlpha = 1f;
         previousWebViewVisibility = View.VISIBLE;
         isHiddenModeActive = false;
+        syncDialogBackCallbackEnabled();
     }
 
     public void setHidden(boolean hidden) {
@@ -3155,6 +3188,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
                         // Set flag immediately to prevent race condition if setHidden(false)
                         // is called before the posted runnable executes
                         isHiddenModeActive = true;
+                        syncDialogBackCallbackEnabled();
                         decorView.post(this::applyHiddenMode);
                     } catch (Exception e) {
                         Log.w("InAppBrowser", "Unable to show dialog before hiding", e);
@@ -6527,6 +6561,7 @@ public class WebViewDialog extends Dialog implements ProxyResponseRouting.ProxyR
         proxiedRequestsHashmap.clear();
 
         clearActivityResultLaunchers();
+        unregisterDialogBackHandler();
 
         try {
             super.dismiss();

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewBackNavigationSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewBackNavigationSupportTest.java
@@ -1,0 +1,66 @@
+package ee.forgr.capacitor_inappbrowser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class WebViewBackNavigationSupportTest {
+
+    @Test
+    public void consumeBackOnlyWhenVisibleOverlayDialog() {
+        assertTrue(WebViewBackNavigationSupport.shouldConsumeBackPress(true, false, false));
+        assertFalse(WebViewBackNavigationSupport.shouldConsumeBackPress(false, false, false));
+        assertFalse(WebViewBackNavigationSupport.shouldConsumeBackPress(true, true, false));
+        assertFalse(WebViewBackNavigationSupport.shouldConsumeBackPress(true, false, true));
+    }
+
+    @Test
+    public void fullscreenTakesPriorityOverStayInWebView() {
+        assertEquals(
+            WebViewBackNavigationSupport.Action.EXIT_FULLSCREEN,
+            WebViewBackNavigationSupport.resolveAction(true, true, true, true, true)
+        );
+    }
+
+    @Test
+    public void navigationToolbarGoesBackInWebViewHistory() {
+        assertEquals(
+            WebViewBackNavigationSupport.Action.WEBVIEW_GO_BACK,
+            WebViewBackNavigationSupport.resolveAction(false, true, true, false, true)
+        );
+    }
+
+    @Test
+    public void activeNativeNavigationGoesBackInWebViewHistory() {
+        assertEquals(
+            WebViewBackNavigationSupport.Action.WEBVIEW_GO_BACK,
+            WebViewBackNavigationSupport.resolveAction(false, true, false, true, true)
+        );
+    }
+
+    @Test
+    public void disableGoBackKeepsWebViewOpenWhenHistoryCannotGoBack() {
+        assertEquals(
+            WebViewBackNavigationSupport.Action.IGNORE,
+            WebViewBackNavigationSupport.resolveAction(false, false, false, false, true)
+        );
+    }
+
+    @Test
+    public void disableGoBackKeepsWebViewOpenWhenHistoryBackIsNotEnabled() {
+        assertEquals(
+            WebViewBackNavigationSupport.Action.IGNORE,
+            WebViewBackNavigationSupport.resolveAction(false, true, false, false, true)
+        );
+    }
+
+    @Test
+    public void backDismissesWhenStayInWebViewIsDisabled() {
+        assertEquals(
+            WebViewBackNavigationSupport.Action.DISMISS,
+            WebViewBackNavigationSupport.resolveAction(false, false, false, false, false)
+        );
+    }
+}


### PR DESCRIPTION
## What
- Restore `disableGoBackOnNativeApplication` so the Android system back button/gesture no longer closes the in-app webview.

## Why
- [#681](https://github.com/Cap-go/capacitor-inappbrowser/issues/681): with `disableGoBackOnNativeApplication: true`, back still dismissed the webview.
- PR #670 replaced `Dialog.onBackPressed()` with `OnKeyListener`. On Android 13+ (targetSdk 35 defaults to predictive back), `KEYCODE_BACK` is not delivered to dialogs, so the flag never ran and the cancelable dialog closed.

## How
- Switch `WebViewDialog` to `ComponentDialog` and handle back through `OnBackPressedDispatcher`.
- Keep existing behavior: exit HTML5 fullscreen, `goBack()` when navigation/native history is enabled, ignore back when `disableGoBackOnNativeApplication` is true, otherwise close.
- Extract decisions into `WebViewBackNavigationSupport` with unit tests.

## Testing
- `./gradlew testDebugUnitTest` (includes `WebViewBackNavigationSupportTest`)
- `bun run verify:android`

## Not Tested
- Device/emulator back gesture with `disableGoBackOnNativeApplication: true` on Android 14/15

Closes #681

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-inappbrowser/pr/683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790869392&installation_model_id=430928&pr_number=683&repository=Cap-go%2Fcapacitor-inappbrowser&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-inappbrowser%2Fpull%2F683&signature=764e8b1c98b09301a3cd9ec5b13c820b3fc0318f6d88e6d756a353e0d56db7a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Android back-button handling in the in-app browser.
  - Supports exiting fullscreen, navigating WebView history, and dismissing the browser in the correct order.
  - Added compatibility with Android predictive-back gestures.

- **Bug Fixes**
  - Back presses now respect visibility, navigation settings, and active overlays.

- **Tests**
  - Added coverage for fullscreen, WebView navigation, ignored back presses, and dismissal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->