### PR TITLE
fix(android): replace deprecated edge-to-edge APIs flagged by Play Console (#684)

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/SystemUiChromeSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/SystemUiChromeSupport.java
@@ -41,14 +41,14 @@ final class SystemUiChromeSupport {
         WindowCompat.setDecorFitsSystemWindows(window, decorFitsSystemWindows);
     }
 
-    static void prepareInitialDialogWindow(Window window) {
+    static void prepareInitialDialogWindow(Window window, View statusBarColorView) {
         if (window == null) {
             return;
         }
 
         window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
         if (shouldApplyLegacySystemBarColors(Build.VERSION.SDK_INT)) {
-            applyLegacySystemBarColors(window, Color.TRANSPARENT, null);
+            applyLegacyStatusBarColorViaView(statusBarColorView, Color.TRANSPARENT);
             clearLegacyTranslucentStatusFlag(window);
         }
     }
@@ -56,9 +56,9 @@ final class SystemUiChromeSupport {
     static void applyDialogWindowChrome(
         Window window,
         View decorView,
+        View statusBarColorView,
         boolean edgeToEdge,
         Integer statusBarColor,
-        Integer navigationBarColor,
         Boolean lightStatusBars
     ) {
         if (window == null || decorView == null) {
@@ -69,10 +69,10 @@ final class SystemUiChromeSupport {
             setDecorFitsSystemWindows(window, false);
         } else if (!shouldUsePreApi30LayoutFlags(Build.VERSION.SDK_INT)) {
             setDecorFitsSystemWindows(window, true);
-            applyLegacySystemBarColors(window, statusBarColor, navigationBarColor);
+            applyLegacyStatusBarColorViaView(statusBarColorView, statusBarColor);
         } else {
-            applyPreApi30LayoutBehindNavigationBar(decorView);
-            applyLegacySystemBarColors(window, statusBarColor, navigationBarColor);
+            setDecorFitsSystemWindows(window, false);
+            applyLegacyStatusBarColorViaView(statusBarColorView, statusBarColor);
         }
 
         WindowInsetsControllerCompat controller = new WindowInsetsControllerCompat(window, decorView);
@@ -81,22 +81,13 @@ final class SystemUiChromeSupport {
         }
     }
 
-    @SuppressWarnings("deprecation")
-    private static void applyPreApi30LayoutBehindNavigationBar(View decorView) {
-        decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION);
-    }
-
-    @SuppressWarnings("deprecation")
-    static void applyLegacySystemBarColors(Window window, Integer statusBarColor, Integer navigationBarColor) {
-        if (window == null || !shouldApplyLegacySystemBarColors(Build.VERSION.SDK_INT)) {
+    static void applyLegacyStatusBarColorViaView(View statusBarColorView, Integer statusBarColor) {
+        if (!shouldApplyLegacySystemBarColors(Build.VERSION.SDK_INT)) {
             return;
         }
 
-        if (statusBarColor != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            window.setStatusBarColor(statusBarColor);
-        }
-        if (navigationBarColor != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            window.setNavigationBarColor(navigationBarColor);
+        if (statusBarColor != null && statusBarColorView != null) {
+            statusBarColorView.setBackgroundColor(statusBarColor);
         }
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupport.java
@@ -1,6 +1,10 @@
 package ee.forgr.capacitor_inappbrowser;
 
 import android.view.View;
+import android.view.Window;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 
 /**
  * Testable helpers for HTML5/iframe fullscreen routed through WebChromeClient custom views
@@ -22,16 +26,28 @@ final class WebViewCustomFullscreenSupport {
         return isActive;
     }
 
-    @SuppressWarnings("deprecation")
-    static int immersiveFullscreenSystemUiVisibility() {
-        return (
-            View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
-            View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
-            View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
-            View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
-            View.SYSTEM_UI_FLAG_FULLSCREEN |
-            View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-        );
+    static int immersiveSystemBarsBehavior() {
+        return WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE;
+    }
+
+    static void enterImmersiveFullscreen(Window window, View decorView) {
+        if (window == null || decorView == null) {
+            return;
+        }
+
+        WindowCompat.setDecorFitsSystemWindows(window, false);
+        WindowInsetsControllerCompat controller = new WindowInsetsControllerCompat(window, decorView);
+        controller.hide(WindowInsetsCompat.Type.systemBars());
+        controller.setSystemBarsBehavior(immersiveSystemBarsBehavior());
+    }
+
+    static void exitImmersiveFullscreen(Window window, View decorView) {
+        if (window == null || decorView == null) {
+            return;
+        }
+
+        WindowInsetsControllerCompat controller = new WindowInsetsControllerCompat(window, decorView);
+        controller.show(WindowInsetsCompat.Type.systemBars());
     }
 
     static boolean shouldUseHostActivityWindow(boolean backLayerActive) {
@@ -40,10 +56,5 @@ final class WebViewCustomFullscreenSupport {
 
     static boolean shouldRegisterHostBackHandler(boolean backLayerActive) {
         return backLayerActive;
-    }
-
-    @SuppressWarnings("deprecation")
-    static int restoredSystemUiVisibility() {
-        return View.SYSTEM_UI_FLAG_VISIBLE;
     }
 }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -2172,7 +2172,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
         // Set dimensions if specified, otherwise fullscreen
         applyDimensions();
 
-        SystemUiChromeSupport.prepareInitialDialogWindow(getWindow());
+        SystemUiChromeSupport.prepareInitialDialogWindow(getWindow(), findViewById(R.id.status_bar_color_view));
 
         WindowInsetsControllerCompat insetsController = new WindowInsetsControllerCompat(
             getWindow(),
@@ -3020,7 +3020,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
         }
 
         window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-        decorView.setSystemUiVisibility(WebViewCustomFullscreenSupport.immersiveFullscreenSystemUiVisibility());
+        WebViewCustomFullscreenSupport.enterImmersiveFullscreen(window, decorView);
 
         if (WebViewCustomFullscreenSupport.shouldRegisterHostBackHandler(backLayerActive)) {
             registerCustomFullscreenBackHandler();
@@ -3078,7 +3078,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
         Window window = customFullscreenWindow != null ? customFullscreenWindow : getWindow();
         if (window != null) {
             window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-            window.getDecorView().setSystemUiVisibility(WebViewCustomFullscreenSupport.restoredSystemUiVisibility());
+            WebViewCustomFullscreenSupport.exitImmersiveFullscreen(window, window.getDecorView());
             reapplyInsetsFromWindowRoot();
             if (SystemUiChromeSupport.requiresEdgeToEdgeChrome(Build.VERSION.SDK_INT)) {
                 refreshEdgeToEdgeChrome();
@@ -3275,7 +3275,6 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
         if (getWindow() != null) {
             View decorView = getWindow().getDecorView();
             Integer statusBarColor = null;
-            Integer navigationBarColor = Color.TRANSPARENT;
             Boolean lightStatusBars = null;
 
             if (isAndroid15Plus) {
@@ -3316,9 +3315,9 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
             SystemUiChromeSupport.applyDialogWindowChrome(
                 getWindow(),
                 decorView,
+                findViewById(R.id.status_bar_color_view),
                 isAndroid15Plus,
                 statusBarColor,
-                navigationBarColor,
                 lightStatusBars
             );
         }
@@ -4913,7 +4912,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
 
                 // Also ensure status bar gets the color
                 if (getWindow() != null) {
-                    SystemUiChromeSupport.applyLegacySystemBarColors(getWindow(), toolbarColor, null);
+                    SystemUiChromeSupport.applyLegacyStatusBarColorViaView(findViewById(R.id.status_bar_color_view), toolbarColor);
 
                     // Determine proper status bar text color (light or dark icons)
                     boolean isDarkBackground = isDarkColor(toolbarColor);

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupportTest.java
@@ -1,9 +1,10 @@
 package ee.forgr.capacitor_inappbrowser;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import android.view.View;
+import androidx.core.view.WindowInsetsControllerCompat;
 import org.junit.Test;
 
 public class WebViewCustomFullscreenSupportTest {
@@ -31,10 +32,21 @@ public class WebViewCustomFullscreenSupportTest {
     }
 
     @Test
-    public void immersiveFlagsIncludeFullscreenAndImmersiveSticky() {
-        int flags = WebViewCustomFullscreenSupport.immersiveFullscreenSystemUiVisibility();
-        assertTrue((flags & View.SYSTEM_UI_FLAG_FULLSCREEN) != 0);
-        assertTrue((flags & View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY) != 0);
+    public void immersiveFullscreenUsesTransientBarsBySwipeBehavior() {
+        assertEquals(
+            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE,
+            WebViewCustomFullscreenSupport.immersiveSystemBarsBehavior()
+        );
+    }
+
+    @Test
+    public void enterImmersiveFullscreenNoOpForNullWindow() {
+        WebViewCustomFullscreenSupport.enterImmersiveFullscreen(null, null);
+    }
+
+    @Test
+    public void exitImmersiveFullscreenNoOpForNullWindow() {
+        WebViewCustomFullscreenSupport.exitImmersiveFullscreen(null, null);
     }
 
     @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Replace immersive fullscreen `setSystemUiVisibility` / `SYSTEM_UI_FLAG_*` usage with `WindowInsetsControllerCompat.hide/show` and `BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE`.
- Replace `Window.setStatusBarColor` / `setNavigationBarColor` on API 24–34 with coloring `status_bar_color_view` instead, so Play’s static scan no longer sees deprecated window bar-color setters in WebView chrome paths.
- Pre-API 30 layout-behind-navigation uses `WindowCompat.setDecorFitsSystemWindows(false)` instead of deprecated layout flags.

## Why
- Fixes #684 — Google Play App optimization report flags deprecated edge-to-edge APIs from this plugin’s bytecode, even when runtime SDK guards skip them on API 35+.

## How
- `WebViewCustomFullscreenSupport`: `enterImmersiveFullscreen` / `exitImmersiveFullscreen` via `WindowInsetsControllerCompat`; removed flag bitmask helpers.
- `WebViewDialog`: custom HTML5/iframe fullscreen calls the new helpers; chrome setup passes `status_bar_color_view` into `SystemUiChromeSupport`.
- `SystemUiChromeSupport`: `applyLegacyStatusBarColorViaView` paints the status bar overlay view; navigation bar color window setter removed (was always transparent in `applyInsets`).
- **Custom Tabs**: `CustomTabColorSchemeParams.Builder.setNavigationBarColor` kept — androidx.browser 1.9.0 has no non-deprecated replacement; public color API must remain.

## Testing
- `bun run fmt`
- `./gradlew testDebugUnitTest` (all JVM unit tests pass, including `WebViewCustomFullscreenSupportTest`)
- `./gradlew clean build`
- Bytecode check: no `setSystemUiVisibility` / `SYSTEM_UI_FLAG_*` / `setStatusBarColor` / `setNavigationBarColor` in `SystemUiChromeSupport`, `WebViewCustomFullscreenSupport`, or `WebViewDialog`

## Not Tested
- Manual YouTube/iframe fullscreen on physical devices (API 24–34 and 35+)
- Play Console static scan re-run after release
- Custom Tabs navigation bar color on device (unchanged behavior; deprecated androidx API retained)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77c786a3-5bce-4181-a4e9-50421367399c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77c786a3-5bce-4181-a4e9-50421367399c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-inappbrowser/pr/685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791057765&installation_model_id=430928&pr_number=685&repository=Cap-go%2Fcapacitor-inappbrowser&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-inappbrowser%2Fpull%2F685&signature=c06de86c74d33d1da0ecc6950b69a703c3605a2510e498fa06af3763e4456840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Android immersive fullscreen behavior to use modern system UI controls, hiding system bars during fullscreen and allowing them to reappear temporarily with a swipe.
  * Improved status-bar color handling across initial, edge-to-edge, fullscreen, and legacy Android window configurations.
  * Fullscreen transitions now handle unavailable windows safely without causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->