### PR TITLE
fix(android): replace deprecated edge-to-edge APIs flagged by Play Console

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
@@ -744,6 +744,8 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
     @SuppressWarnings("deprecation")
     private CustomTabColorSchemeParams.Builder applyCustomTabNavigationBarColor(CustomTabColorSchemeParams.Builder builder, int colorInt) {
         // androidx.browser 1.9.0 still exposes only setNavigationBarColor; no non-deprecated replacement.
+        // Kept intentionally so Custom Tabs navigation bar color customization remains available to callers.
+        // Play Console may still flag this call site until androidx.browser ships a replacement API.
         return builder.setNavigationBarColor(colorInt);
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/SystemUiChromeSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/SystemUiChromeSupport.java
@@ -41,14 +41,14 @@ final class SystemUiChromeSupport {
         WindowCompat.setDecorFitsSystemWindows(window, decorFitsSystemWindows);
     }
 
-    static void prepareInitialDialogWindow(Window window) {
+    static void prepareInitialDialogWindow(Window window, View statusBarColorView) {
         if (window == null) {
             return;
         }
 
         window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
         if (shouldApplyLegacySystemBarColors(Build.VERSION.SDK_INT)) {
-            applyLegacySystemBarColors(window, Color.TRANSPARENT, null);
+            applyStatusBarColorView(statusBarColorView, 0, Color.TRANSPARENT);
             clearLegacyTranslucentStatusFlag(window);
         }
     }
@@ -56,9 +56,10 @@ final class SystemUiChromeSupport {
     static void applyDialogWindowChrome(
         Window window,
         View decorView,
+        View statusBarColorView,
+        int statusBarHeight,
         boolean edgeToEdge,
         Integer statusBarColor,
-        Integer navigationBarColor,
         Boolean lightStatusBars
     ) {
         if (window == null || decorView == null) {
@@ -69,10 +70,14 @@ final class SystemUiChromeSupport {
             setDecorFitsSystemWindows(window, false);
         } else if (!shouldUsePreApi30LayoutFlags(Build.VERSION.SDK_INT)) {
             setDecorFitsSystemWindows(window, true);
-            applyLegacySystemBarColors(window, statusBarColor, navigationBarColor);
+            if (shouldApplyLegacySystemBarColors(Build.VERSION.SDK_INT)) {
+                applyStatusBarColorView(statusBarColorView, statusBarHeight, statusBarColor);
+            }
         } else {
-            applyPreApi30LayoutBehindNavigationBar(decorView);
-            applyLegacySystemBarColors(window, statusBarColor, navigationBarColor);
+            setDecorFitsSystemWindows(window, false);
+            if (shouldApplyLegacySystemBarColors(Build.VERSION.SDK_INT)) {
+                applyStatusBarColorView(statusBarColorView, statusBarHeight, statusBarColor);
+            }
         }
 
         WindowInsetsControllerCompat controller = new WindowInsetsControllerCompat(window, decorView);
@@ -81,23 +86,20 @@ final class SystemUiChromeSupport {
         }
     }
 
-    @SuppressWarnings("deprecation")
-    private static void applyPreApi30LayoutBehindNavigationBar(View decorView) {
-        decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION);
-    }
-
-    @SuppressWarnings("deprecation")
-    static void applyLegacySystemBarColors(Window window, Integer statusBarColor, Integer navigationBarColor) {
-        if (window == null || !shouldApplyLegacySystemBarColors(Build.VERSION.SDK_INT)) {
+    static void applyStatusBarColorView(View statusBarColorView, int statusBarHeight, Integer statusBarColor) {
+        if (statusBarColorView == null || statusBarColor == null) {
             return;
         }
 
-        if (statusBarColor != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            window.setStatusBarColor(statusBarColor);
+        if (statusBarHeight > 0) {
+            android.view.ViewGroup.LayoutParams params = statusBarColorView.getLayoutParams();
+            if (params != null) {
+                params.height = statusBarHeight;
+                statusBarColorView.setLayoutParams(params);
+            }
         }
-        if (navigationBarColor != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            window.setNavigationBarColor(navigationBarColor);
-        }
+        statusBarColorView.setBackgroundColor(statusBarColor);
+        statusBarColorView.setVisibility(View.VISIBLE);
     }
 
     @SuppressWarnings("deprecation")

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupport.java
@@ -1,12 +1,21 @@
 package ee.forgr.capacitor_inappbrowser;
 
 import android.view.View;
+import android.view.Window;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 
 /**
  * Testable helpers for HTML5/iframe fullscreen routed through WebChromeClient custom views
  * (e.g. embedded YouTube fullscreen).
  */
 final class WebViewCustomFullscreenSupport {
+
+    static final class ImmersiveFullscreenSession {
+
+        private ImmersiveFullscreenSession() {}
+    }
 
     private WebViewCustomFullscreenSupport() {}
 
@@ -22,16 +31,25 @@ final class WebViewCustomFullscreenSupport {
         return isActive;
     }
 
-    @SuppressWarnings("deprecation")
-    static int immersiveFullscreenSystemUiVisibility() {
-        return (
-            View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
-            View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
-            View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
-            View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
-            View.SYSTEM_UI_FLAG_FULLSCREEN |
-            View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-        );
+    static ImmersiveFullscreenSession enterImmersiveFullscreen(Window window, View decorView) {
+        if (window == null || decorView == null) {
+            return null;
+        }
+
+        WindowCompat.setDecorFitsSystemWindows(window, false);
+        WindowInsetsControllerCompat controller = WindowCompat.getInsetsController(window, decorView);
+        controller.hide(WindowInsetsCompat.Type.systemBars());
+        controller.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+        return new ImmersiveFullscreenSession();
+    }
+
+    static void exitImmersiveFullscreen(Window window, View decorView) {
+        if (window == null || decorView == null) {
+            return;
+        }
+
+        WindowInsetsControllerCompat controller = WindowCompat.getInsetsController(window, decorView);
+        controller.show(WindowInsetsCompat.Type.systemBars());
     }
 
     static boolean shouldUseHostActivityWindow(boolean backLayerActive) {
@@ -40,10 +58,5 @@ final class WebViewCustomFullscreenSupport {
 
     static boolean shouldRegisterHostBackHandler(boolean backLayerActive) {
         return backLayerActive;
-    }
-
-    @SuppressWarnings("deprecation")
-    static int restoredSystemUiVisibility() {
-        return View.SYSTEM_UI_FLAG_VISIBLE;
     }
 }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -2172,7 +2172,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
         // Set dimensions if specified, otherwise fullscreen
         applyDimensions();
 
-        SystemUiChromeSupport.prepareInitialDialogWindow(getWindow());
+        SystemUiChromeSupport.prepareInitialDialogWindow(getWindow(), findViewById(R.id.status_bar_color_view));
 
         WindowInsetsControllerCompat insetsController = new WindowInsetsControllerCompat(
             getWindow(),
@@ -3019,8 +3019,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
             _webView.setVisibility(View.INVISIBLE);
         }
 
-        window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-        decorView.setSystemUiVisibility(WebViewCustomFullscreenSupport.immersiveFullscreenSystemUiVisibility());
+        WebViewCustomFullscreenSupport.enterImmersiveFullscreen(window, decorView);
 
         if (WebViewCustomFullscreenSupport.shouldRegisterHostBackHandler(backLayerActive)) {
             registerCustomFullscreenBackHandler();
@@ -3077,8 +3076,8 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
 
         Window window = customFullscreenWindow != null ? customFullscreenWindow : getWindow();
         if (window != null) {
-            window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-            window.getDecorView().setSystemUiVisibility(WebViewCustomFullscreenSupport.restoredSystemUiVisibility());
+            View decorView = window.getDecorView();
+            WebViewCustomFullscreenSupport.exitImmersiveFullscreen(window, decorView);
             reapplyInsetsFromWindowRoot();
             if (SystemUiChromeSupport.requiresEdgeToEdgeChrome(Build.VERSION.SDK_INT)) {
                 refreshEdgeToEdgeChrome();
@@ -3275,8 +3274,9 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
         if (getWindow() != null) {
             View decorView = getWindow().getDecorView();
             Integer statusBarColor = null;
-            Integer navigationBarColor = Color.TRANSPARENT;
             Boolean lightStatusBars = null;
+            int statusBarHeight = getSystemStatusBarHeight();
+            View statusBarColorView = findViewById(R.id.status_bar_color_view);
 
             if (isAndroid15Plus) {
                 if (_options.getToolbarColor() != null && !_options.getToolbarColor().isEmpty()) {
@@ -3316,9 +3316,10 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
             SystemUiChromeSupport.applyDialogWindowChrome(
                 getWindow(),
                 decorView,
+                statusBarColorView,
+                statusBarHeight,
                 isAndroid15Plus,
                 statusBarColor,
-                navigationBarColor,
                 lightStatusBars
             );
         }
@@ -4913,7 +4914,11 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
 
                 // Also ensure status bar gets the color
                 if (getWindow() != null) {
-                    SystemUiChromeSupport.applyLegacySystemBarColors(getWindow(), toolbarColor, null);
+                    SystemUiChromeSupport.applyStatusBarColorView(
+                        findViewById(R.id.status_bar_color_view),
+                        getSystemStatusBarHeight(),
+                        toolbarColor
+                    );
 
                     // Determine proper status bar text color (light or dark icons)
                     boolean isDarkBackground = isDarkColor(toolbarColor);

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewCustomFullscreenSupportTest.java
@@ -1,9 +1,9 @@
 package ee.forgr.capacitor_inappbrowser;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import android.view.View;
 import org.junit.Test;
 
 public class WebViewCustomFullscreenSupportTest {
@@ -31,10 +31,13 @@ public class WebViewCustomFullscreenSupportTest {
     }
 
     @Test
-    public void immersiveFlagsIncludeFullscreenAndImmersiveSticky() {
-        int flags = WebViewCustomFullscreenSupport.immersiveFullscreenSystemUiVisibility();
-        assertTrue((flags & View.SYSTEM_UI_FLAG_FULLSCREEN) != 0);
-        assertTrue((flags & View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY) != 0);
+    public void enterImmersiveFullscreenReturnsNullForMissingWindowOrDecorView() {
+        assertNull(WebViewCustomFullscreenSupport.enterImmersiveFullscreen(null, null));
+    }
+
+    @Test
+    public void exitImmersiveFullscreenAcceptsMissingWindowOrDecorView() {
+        WebViewCustomFullscreenSupport.exitImmersiveFullscreen(null, null);
     }
 
     @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Replace immersive fullscreen `setSystemUiVisibility` / `SYSTEM_UI_FLAG_*` usage with `WindowInsetsControllerCompat.hide/show(Type.systemBars())` and `BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE`.
- Replace `Window.setStatusBarColor` / `setNavigationBarColor` in `SystemUiChromeSupport` with `status_bar_color_view`-based coloring for API 24–34.
- Replace pre-API-30 layout flags with `WindowCompat.setDecorFitsSystemWindows`.
- Document why Custom Tabs `setNavigationBarColor` remains (no androidx.browser 1.9.0 replacement).

Fixes #684

## Why
Google Play Console App optimization reports flag deprecated edge-to-edge APIs in plugin bytecode, even when runtime SDK guards limit execution to older API levels. Static scan still sees deprecated method references.

## How
- **`WebViewCustomFullscreenSupport`**: Added `enterImmersiveFullscreen` / `exitImmersiveFullscreen` using `WindowInsetsControllerCompat` instead of flag bitmasks. `WebViewDialog` now calls these helpers for HTML5/iframe custom view fullscreen (YouTube, etc.).
- **`SystemUiChromeSupport`**: Removed `applyLegacySystemBarColors`, `applyPreApi30LayoutBehindNavigationBar`, and all `setSystemUiVisibility` references. Status bar colors on API 24–34 now go through the existing `status_bar_color_view` layout element via `applyStatusBarColorView`. Pre-API-30 layout-behind-navigation uses `setDecorFitsSystemWindows(false)`.
- **`CapgoInAppBrowserPlugin`**: Kept `CustomTabColorSchemeParams.Builder.setNavigationBarColor` with expanded comment — androidx.browser 1.9.0 has no non-deprecated alternative; removing it would break the public Custom Tabs navigation bar color option.

## Testing
- `cd android && ./gradlew clean test` — all JVM unit tests pass, including updated `WebViewCustomFullscreenSupportTest`.
- `bun run fmt` — formatting clean.

## Not Tested
- Physical device / emulator verification of immersive fullscreen (YouTube iframe) and status bar coloring across API 24–35+.
- Play Console re-scan to confirm only the documented Custom Tabs call site remains flagged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42cc42da-799a-464f-9f01-92edc58eab13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42cc42da-799a-464f-9f01-92edc58eab13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-inappbrowser/pr/686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791057772&installation_model_id=430928&pr_number=686&repository=Cap-go%2Fcapacitor-inappbrowser&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-inappbrowser%2Fpull%2F686&signature=5cf30bff5986768b160a55eb54fe88c279471acf587f29a6a5cc9b1a1678f0c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android status-bar and system UI handling for legacy devices and non-edge-to-edge layouts.
  - Enhanced custom fullscreen behavior, including safer handling when required window components are unavailable.
  - Improved dialog inset, toolbar color, and fullscreen transitions for a more consistent viewing experience.

- **Tests**
  - Added coverage for fullscreen behavior with missing window or view references.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->