### PR TITLE
fix(android): make disableGoBackOnNativeApplication actually block back/gesture (#681)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
     lintOptions {
         abortOnError = false
     }
@@ -56,6 +61,8 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.window:window:1.5.1"
     testImplementation "junit:junit:$junitVersion"
+    testImplementation 'org.robolectric:robolectric:4.14.1'
+    testImplementation 'androidx.activity:activity:1.10.1'
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation "androidx.browser:browser:$androidxBrowserVersion"

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/CapgoInAppBrowserPlugin.java
@@ -428,12 +428,21 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
         webViewStack.addLast(id);
         if (makeActive || activeWebViewId == null || webViewDialog == null) {
             setActiveWebView(id, dialog);
+        } else {
+            dialog.setActiveForBackNavigation(false);
         }
     }
 
     private void setActiveWebView(String id, WebViewDialog dialog) {
         activeWebViewId = id;
         webViewDialog = dialog;
+        syncActiveWebViewBackNavigation();
+    }
+
+    private void syncActiveWebViewBackNavigation() {
+        for (Map.Entry<String, WebViewDialog> entry : webViewDialogs.entrySet()) {
+            entry.getValue().setActiveForBackNavigation(java.util.Objects.equals(entry.getKey(), activeWebViewId));
+        }
     }
 
     private void unregisterWebView(String id) {
@@ -441,6 +450,7 @@ public class CapgoInAppBrowserPlugin extends Plugin implements WebViewDialog.Per
         webViewStack.remove(id);
         activeWebViewId = webViewStack.peekLast();
         webViewDialog = activeWebViewId != null ? webViewDialogs.get(activeWebViewId) : null;
+        syncActiveWebViewBackNavigation();
         if (webViewDialog != null) {
             String url = webViewDialog.getUrl();
             if (url != null) {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewBackNavigationSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewBackNavigationSupport.java
@@ -40,8 +40,12 @@ final class WebViewBackNavigationSupport {
         boolean isShowing,
         boolean backLayerActive,
         boolean hiddenMode,
-        boolean disableGoBackOnNativeApplication
+        boolean disableGoBackOnNativeApplication,
+        boolean isActiveForBackNavigation
     ) {
+        if (!isActiveForBackNavigation) {
+            return false;
+        }
         if (hiddenMode) {
             return false;
         }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewBackNavigationSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewBackNavigationSupport.java
@@ -22,6 +22,35 @@ final class WebViewBackNavigationSupport {
         return isShowing && !hiddenMode && !backLayerActive;
     }
 
+    /**
+     * When {@code disableGoBackOnNativeApplication} is true, the dialog must not be cancelable on
+     * back/gesture. Otherwise {@link androidx.activity.ComponentDialog}'s built-in back callback
+     * dismisses the dialog before our handler can return {@link Action#IGNORE}.
+     */
+    static boolean isCancelableOnBack(boolean disableGoBackOnNativeApplication) {
+        return !disableGoBackOnNativeApplication;
+    }
+
+    /**
+     * Activity-level back handling is required when the overlay is hosted on the activity window
+     * (back layer) or when predictive-back can bypass the dialog dispatcher while the flag blocks
+     * dismiss.
+     */
+    static boolean shouldRegisterActivityBackHandler(
+        boolean isShowing,
+        boolean backLayerActive,
+        boolean hiddenMode,
+        boolean disableGoBackOnNativeApplication
+    ) {
+        if (hiddenMode) {
+            return false;
+        }
+        if (!isShowing && !backLayerActive) {
+            return false;
+        }
+        return backLayerActive || disableGoBackOnNativeApplication;
+    }
+
     static Action resolveAction(
         boolean customFullscreenActive,
         boolean webViewCanGoBack,

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -346,6 +346,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
     private OnBackPressedCallback customFullscreenBackCallback;
     private OnBackPressedCallback dialogBackCallback;
     private OnBackPressedCallback dialogActivityBackCallback;
+    private boolean activeForBackNavigation = true;
     private Toolbar _toolbar;
     private Options _options = null;
     private final Context _context;
@@ -2965,8 +2966,29 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
             isShowing(),
             backLayerActive,
             isHiddenModeActive,
-            _options != null && _options.getDisableGoBackOnNativeApplication()
+            _options != null && _options.getDisableGoBackOnNativeApplication(),
+            activeForBackNavigation
         );
+    }
+
+    void setActiveForBackNavigation(boolean active) {
+        if (activeForBackNavigation == active) {
+            return;
+        }
+        activeForBackNavigation = active;
+        syncBackNavigationHandlers();
+    }
+
+    boolean isActiveForBackNavigation() {
+        return activeForBackNavigation;
+    }
+
+    boolean isBackLayerActive() {
+        return backLayerActive;
+    }
+
+    boolean isActivityBackHandlerEnabled() {
+        return dialogActivityBackCallback != null && dialogActivityBackCallback.isEnabled();
     }
 
     private void unregisterDialogBackHandler() {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -345,6 +345,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
     private Window customFullscreenWindow;
     private OnBackPressedCallback customFullscreenBackCallback;
     private OnBackPressedCallback dialogBackCallback;
+    private OnBackPressedCallback dialogActivityBackCallback;
     private Toolbar _toolbar;
     private Options _options = null;
     private final Context _context;
@@ -461,17 +462,18 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
     void bindToHostActivity() {
         ensureFileChooserLaunchers();
         registerDialogBackHandler();
+        registerDialogActivityBackHandler();
     }
 
     @Override
     protected void onStart() {
         super.onStart();
-        syncDialogBackCallbackEnabled();
+        syncBackNavigationHandlers();
     }
 
     @Override
     protected void onStop() {
-        syncDialogBackCallbackEnabled();
+        syncBackNavigationHandlers();
         super.onStop();
     }
 
@@ -670,7 +672,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
         backLayerActive = false;
         backLayerParent = null;
         restoreHostTransparency();
-        syncDialogBackCallbackEnabled();
+        syncBackNavigationHandlers();
     }
 
     private void attachContentToDialogWindow() {
@@ -713,7 +715,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
             super.hide();
         }
         refreshInsetsForHostingLayer();
-        syncDialogBackCallbackEnabled();
+        syncBackNavigationHandlers();
         return true;
     }
 
@@ -2145,7 +2147,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
     @SuppressLint({ "SetJavaScriptEnabled", "AddJavascriptInterface" })
     public void presentWebView() {
         requestWindowFeature(Window.FEATURE_NO_TITLE);
-        setCancelable(true);
+        applyBackNavigationPolicy();
         setContentView(R.layout.activity_browser);
 
         // If custom dimensions are set, configure for touch passthrough
@@ -2926,19 +2928,55 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
             }
         };
         getOnBackPressedDispatcher().addCallback(dialogBackCallback);
-        syncDialogBackCallbackEnabled();
+        syncBackNavigationHandlers();
     }
 
-    private void syncDialogBackCallbackEnabled() {
+    private void registerDialogActivityBackHandler() {
+        if (!(activity instanceof ComponentActivity componentActivity) || dialogActivityBackCallback != null) {
+            return;
+        }
+        dialogActivityBackCallback = new OnBackPressedCallback(false) {
+            @Override
+            public void handleOnBackPressed() {
+                handleBrowserBackNavigation();
+            }
+        };
+        componentActivity.getOnBackPressedDispatcher().addCallback(componentActivity, dialogActivityBackCallback);
+        syncBackNavigationHandlers();
+    }
+
+    void applyBackNavigationPolicy() {
+        boolean disableGoBack = _options != null && _options.getDisableGoBackOnNativeApplication();
+        setCancelable(WebViewBackNavigationSupport.isCancelableOnBack(disableGoBack));
+        syncBackNavigationHandlers();
+    }
+
+    private void syncBackNavigationHandlers() {
         if (dialogBackCallback != null) {
             dialogBackCallback.setEnabled(shouldConsumeBackPress());
         }
+        if (dialogActivityBackCallback != null) {
+            dialogActivityBackCallback.setEnabled(shouldRegisterActivityBackHandler());
+        }
+    }
+
+    private boolean shouldRegisterActivityBackHandler() {
+        return WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(
+            isShowing(),
+            backLayerActive,
+            isHiddenModeActive,
+            _options != null && _options.getDisableGoBackOnNativeApplication()
+        );
     }
 
     private void unregisterDialogBackHandler() {
         if (dialogBackCallback != null) {
             dialogBackCallback.remove();
             dialogBackCallback = null;
+        }
+        if (dialogActivityBackCallback != null) {
+            dialogActivityBackCallback.remove();
+            dialogActivityBackCallback = null;
         }
     }
 
@@ -3146,7 +3184,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
         }
 
         isHiddenModeActive = true;
-        syncDialogBackCallbackEnabled();
+        syncBackNavigationHandlers();
     }
 
     private void restoreVisibleMode() {
@@ -3184,7 +3222,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
         previousWebViewAlpha = 1f;
         previousWebViewVisibility = View.VISIBLE;
         isHiddenModeActive = false;
-        syncDialogBackCallbackEnabled();
+        syncBackNavigationHandlers();
     }
 
     public void setHidden(boolean hidden) {
@@ -3210,7 +3248,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
                         // Set flag immediately to prevent race condition if setHidden(false)
                         // is called before the posted runnable executes
                         isHiddenModeActive = true;
-                        syncDialogBackCallbackEnabled();
+                        syncBackNavigationHandlers();
                         decorView.post(this::applyHiddenMode);
                     } catch (Exception e) {
                         Log.w("InAppBrowser", "Unable to show dialog before hiding", e);

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewBackNavigationSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewBackNavigationSupportTest.java
@@ -71,20 +71,31 @@ public class WebViewBackNavigationSupportTest {
     }
 
     @Test
-    public void activityBackHandlerRegisteredForBackLayerOrStayInWebView() {
-        assertTrue(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(false, true, false, false));
-        assertTrue(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(true, false, false, true));
-        assertTrue(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(true, true, false, true));
+    public void activityBackHandlerRegisteredForDisableGoBackWhenActive() {
+        assertTrue(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(true, false, false, true, true));
+        assertTrue(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(true, true, false, true, true));
+    }
+
+    @Test
+    public void activityBackHandlerRegisteredForBackLayerWhenActiveRegardlessOfDisableGoBackFlag() {
+        assertTrue(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(false, true, false, false, true));
+        assertTrue(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(false, true, false, true, true));
     }
 
     @Test
     public void activityBackHandlerNotRegisteredForNormalDismissibleDialog() {
-        assertFalse(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(true, false, false, false));
+        assertFalse(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(true, false, false, false, true));
     }
 
     @Test
     public void activityBackHandlerNotRegisteredWhenHiddenOrNotVisible() {
-        assertFalse(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(true, false, true, true));
-        assertFalse(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(false, false, false, true));
+        assertFalse(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(true, false, true, true, true));
+        assertFalse(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(false, false, false, true, true));
+    }
+
+    @Test
+    public void activityBackHandlerNotRegisteredForInactiveDialog() {
+        assertFalse(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(true, false, false, true, false));
+        assertFalse(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(false, true, false, false, false));
     }
 }

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewBackNavigationSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewBackNavigationSupportTest.java
@@ -63,4 +63,28 @@ public class WebViewBackNavigationSupportTest {
             WebViewBackNavigationSupport.resolveAction(false, false, false, false, false)
         );
     }
+
+    @Test
+    public void dialogNotCancelableOnBackWhenStayInWebViewEnabled() {
+        assertFalse(WebViewBackNavigationSupport.isCancelableOnBack(true));
+        assertTrue(WebViewBackNavigationSupport.isCancelableOnBack(false));
+    }
+
+    @Test
+    public void activityBackHandlerRegisteredForBackLayerOrStayInWebView() {
+        assertTrue(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(false, true, false, false));
+        assertTrue(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(true, false, false, true));
+        assertTrue(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(true, true, false, true));
+    }
+
+    @Test
+    public void activityBackHandlerNotRegisteredForNormalDismissibleDialog() {
+        assertFalse(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(true, false, false, false));
+    }
+
+    @Test
+    public void activityBackHandlerNotRegisteredWhenHiddenOrNotVisible() {
+        assertFalse(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(true, false, true, true));
+        assertFalse(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(false, false, false, true));
+    }
 }

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewDialogBackNavigationRobolectricTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewDialogBackNavigationRobolectricTest.java
@@ -1,16 +1,20 @@
 package ee.forgr.capacitor_inappbrowser;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
 import android.os.Message;
+import android.view.View;
 import android.webkit.PermissionRequest;
 import android.widget.FrameLayout;
 import androidx.activity.ComponentActivity;
 import androidx.activity.ComponentDialog;
 import androidx.activity.OnBackPressedCallback;
 import androidx.activity.OnBackPressedDispatcher;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -18,6 +22,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLooper;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 34)
@@ -107,22 +112,161 @@ public class WebViewDialogBackNavigationRobolectricTest {
     }
 
     @Test
-    public void activityBackHandlerKeepsDisableGoBackOverlayOpenOnBackLayer() {
+    public void activityBackHandlerKeepsDisableGoBackOverlayOpenWhenDialogIsShowing() {
         ActivityController<ComponentActivity> controller = Robolectric.buildActivity(ComponentActivity.class).setup();
         ComponentActivity activity = controller.get();
+        activity.setContentView(new FrameLayout(activity));
         Options options = new Options();
         options.setDisableGoBackOnNativeApplication(true);
 
+        WebViewDialog dialog = createBoundDialog(activity, options);
+        showDialog(dialog);
+
+        assertTrue(dialog.isActivityBackHandlerEnabled());
+        activity.getOnBackPressedDispatcher().onBackPressed();
+        assertTrue(dialog.isShowing());
+    }
+
+    @Test
+    public void activityBackHandlerKeepsBackLayerOverlayOpenWhenDisableGoBackEnabled() {
+        ActivityController<ComponentActivity> controller = Robolectric.buildActivity(ComponentActivity.class).setup();
+        ComponentActivity activity = controller.get();
+        activity.setContentView(new FrameLayout(activity));
+
+        WebViewDialog dialog = createBoundDialog(activity, optionsWithDisableGoBack(true));
+        showDialog(dialog);
+
+        View overlayContent = requireOverlayContent(dialog);
+        assertTrue(dialog.sendToBack(false));
+        idleMainLooper();
+        assertFalse(dialog.isShowing());
+        assertTrue(dialog.isBackLayerActive());
+        assertTrue(dialog.isActivityBackHandlerEnabled());
+        assertNotNull(overlayContent.getParent());
+
+        activity.getOnBackPressedDispatcher().onBackPressed();
+
+        assertTrue(dialog.isBackLayerActive());
+        assertNotNull(overlayContent.getParent());
+    }
+
+    @Test
+    public void activityBackHandlerDismissesBackLayerOverlayWhenDisableGoBackDisabled() {
+        ActivityController<ComponentActivity> controller = Robolectric.buildActivity(ComponentActivity.class).setup();
+        ComponentActivity activity = controller.get();
+        activity.setContentView(new FrameLayout(activity));
+
+        WebViewDialog dialog = createBoundDialog(activity, optionsWithDisableGoBack(false));
+        showDialog(dialog);
+
+        View overlayContent = requireOverlayContent(dialog);
+        assertTrue(dialog.sendToBack(false));
+        idleMainLooper();
+        assertFalse(dialog.isShowing());
+        assertTrue(dialog.isBackLayerActive());
+        assertTrue(dialog.isActivityBackHandlerEnabled());
+
+        activity.getOnBackPressedDispatcher().onBackPressed();
+
+        assertFalse(dialog.isBackLayerActive());
+        assertNull(overlayContent.getParent());
+    }
+
+    @Test
+    public void onlyActiveDialogRegistersActivityBackHandlerAmongMultipleDialogs() {
+        ActivityController<ComponentActivity> controller = Robolectric.buildActivity(ComponentActivity.class).setup();
+        ComponentActivity activity = controller.get();
+        activity.setContentView(new FrameLayout(activity));
+
+        WebViewDialog activeDialog = createBoundDialog(activity, optionsWithDisableGoBack(true));
+        showDialog(activeDialog);
+
+        WebViewDialog inactiveDialog = createBoundDialog(activity, optionsWithDisableGoBack(true));
+        showDialog(inactiveDialog);
+
+        activeDialog.setActiveForBackNavigation(true);
+        inactiveDialog.setActiveForBackNavigation(false);
+        idleMainLooper();
+
+        assertTrue(activeDialog.isActivityBackHandlerEnabled());
+        assertFalse(inactiveDialog.isActivityBackHandlerEnabled());
+
+        activity.getOnBackPressedDispatcher().onBackPressed();
+        assertTrue(activeDialog.isShowing());
+        assertTrue(inactiveDialog.isShowing());
+
+        activeDialog.setActiveForBackNavigation(false);
+        inactiveDialog.setActiveForBackNavigation(true);
+        idleMainLooper();
+
+        assertFalse(activeDialog.isActivityBackHandlerEnabled());
+        assertTrue(inactiveDialog.isActivityBackHandlerEnabled());
+    }
+
+    @Test
+    public void bringingOlderDialogForwardRoutesActivityBackToIt() {
+        ActivityController<ComponentActivity> controller = Robolectric.buildActivity(ComponentActivity.class).setup();
+        ComponentActivity activity = controller.get();
+        activity.setContentView(new FrameLayout(activity));
+
+        WebViewDialog olderDialog = createBoundDialog(activity, optionsWithDisableGoBack(true));
+        showDialog(olderDialog);
+
+        WebViewDialog newerDialog = createBoundDialog(activity, optionsWithDisableGoBack(true));
+        showDialog(newerDialog);
+
+        newerDialog.setActiveForBackNavigation(true);
+        olderDialog.setActiveForBackNavigation(false);
+        idleMainLooper();
+        assertTrue(newerDialog.isActivityBackHandlerEnabled());
+        assertFalse(olderDialog.isActivityBackHandlerEnabled());
+
+        olderDialog.setActiveForBackNavigation(true);
+        newerDialog.setActiveForBackNavigation(false);
+        idleMainLooper();
+        assertTrue(olderDialog.isActivityBackHandlerEnabled());
+        assertFalse(newerDialog.isActivityBackHandlerEnabled());
+
+        activity.getOnBackPressedDispatcher().onBackPressed();
+        assertTrue(olderDialog.isShowing());
+        assertTrue(newerDialog.isShowing());
+    }
+
+    private static void showDialog(WebViewDialog dialog) {
+        dialog.show();
+        idleMainLooper();
+        dialog.applyBackNavigationPolicy();
+    }
+
+    private static void idleMainLooper() {
+        ShadowLooper.shadowMainLooper().idle();
+    }
+
+    private static Options optionsWithDisableGoBack(boolean disableGoBack) {
+        Options options = new Options();
+        options.setDisableGoBackOnNativeApplication(disableGoBack);
+        return options;
+    }
+
+    private static WebViewDialog createBoundDialog(ComponentActivity activity, Options options) {
         WebViewDialog dialog = new WebViewDialog(activity, android.R.style.Theme_NoTitleBar, options, noopPermissionHandler(), null);
         dialog.activity = activity;
         dialog.bindToHostActivity();
         dialog.applyBackNavigationPolicy();
-        dialog.setContentView(new FrameLayout(activity));
-        dialog.show();
+        setBrowserContent(dialog, activity);
+        return dialog;
+    }
 
-        assertTrue(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(true, false, false, true));
-        activity.getOnBackPressedDispatcher().onBackPressed();
-        assertTrue(dialog.isShowing());
+    private static void setBrowserContent(WebViewDialog dialog, ComponentActivity activity) {
+        CoordinatorLayout coordinatorLayout = new CoordinatorLayout(activity);
+        coordinatorLayout.setId(R.id.coordinator_layout);
+        dialog.setContentView(coordinatorLayout);
+    }
+
+    private static View requireOverlayContent(WebViewDialog dialog) {
+        View overlayContent = dialog.findViewById(R.id.coordinator_layout);
+        assertNotNull(overlayContent);
+        return overlayContent;
     }
 
     private static WebViewDialog.PermissionHandler noopPermissionHandler() {

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewDialogBackNavigationRobolectricTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewDialogBackNavigationRobolectricTest.java
@@ -1,0 +1,145 @@
+package ee.forgr.capacitor_inappbrowser;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.os.Message;
+import android.webkit.PermissionRequest;
+import android.widget.FrameLayout;
+import androidx.activity.ComponentActivity;
+import androidx.activity.ComponentDialog;
+import androidx.activity.OnBackPressedCallback;
+import androidx.activity.OnBackPressedDispatcher;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class WebViewDialogBackNavigationRobolectricTest {
+
+    @Test
+    public void cancelableDialogDismissesOnBackWhenStayInWebViewDisabled() {
+        Context context = RuntimeEnvironment.getApplication();
+        ComponentDialog dialog = new ComponentDialog(context);
+        dialog.setCancelable(WebViewBackNavigationSupport.isCancelableOnBack(false));
+        dialog.setContentView(new FrameLayout(context));
+        dialog.show();
+
+        assertTrue(dialog.isShowing());
+        dialog.getOnBackPressedDispatcher().onBackPressed();
+        assertFalse(dialog.isShowing());
+    }
+
+    @Test
+    public void nonCancelableDialogStaysOpenOnBackWithoutDismissHandler() {
+        Context context = RuntimeEnvironment.getApplication();
+        ComponentDialog dialog = new ComponentDialog(context);
+        dialog.setCancelable(WebViewBackNavigationSupport.isCancelableOnBack(true));
+        dialog.setContentView(new FrameLayout(context));
+        dialog.show();
+
+        assertTrue(dialog.isShowing());
+        dialog.getOnBackPressedDispatcher().onBackPressed();
+        assertTrue(dialog.isShowing());
+    }
+
+    @Test
+    public void enabledBackCallbackConsumesBackWithoutDismissingWhenStayInWebViewEnabled() {
+        Context context = RuntimeEnvironment.getApplication();
+        ComponentDialog dialog = new ComponentDialog(context);
+        dialog.setCancelable(WebViewBackNavigationSupport.isCancelableOnBack(true));
+        dialog.setContentView(new FrameLayout(context));
+
+        OnBackPressedDispatcher dispatcher = dialog.getOnBackPressedDispatcher();
+        dispatcher.addCallback(
+            new OnBackPressedCallback(true) {
+                @Override
+                public void handleOnBackPressed() {
+                    // Mirrors WebViewDialog IGNORE path for disableGoBackOnNativeApplication.
+                }
+            }
+        );
+
+        dialog.show();
+        assertTrue(dialog.isShowing());
+        dispatcher.onBackPressed();
+        assertTrue(dialog.isShowing());
+    }
+
+    @Test
+    public void webViewDialogWithDisableGoBackStaysOpenOnBack() {
+        Context context = RuntimeEnvironment.getApplication();
+        Options options = new Options();
+        options.setDisableGoBackOnNativeApplication(true);
+
+        WebViewDialog dialog = new WebViewDialog(context, android.R.style.Theme_NoTitleBar, options, noopPermissionHandler(), null);
+        dialog.bindToHostActivity();
+        dialog.applyBackNavigationPolicy();
+        dialog.setContentView(new FrameLayout(context));
+        dialog.show();
+
+        assertTrue(dialog.isShowing());
+        dialog.getOnBackPressedDispatcher().onBackPressed();
+        assertTrue(dialog.isShowing());
+    }
+
+    @Test
+    public void webViewDialogWithoutDisableGoBackDismissesOnBack() {
+        Context context = RuntimeEnvironment.getApplication();
+        Options options = new Options();
+        options.setDisableGoBackOnNativeApplication(false);
+
+        WebViewDialog dialog = new WebViewDialog(context, android.R.style.Theme_NoTitleBar, options, noopPermissionHandler(), null);
+        dialog.bindToHostActivity();
+        dialog.applyBackNavigationPolicy();
+        dialog.setContentView(new FrameLayout(context));
+        dialog.show();
+
+        assertTrue(dialog.isShowing());
+        dialog.getOnBackPressedDispatcher().onBackPressed();
+        assertFalse(dialog.isShowing());
+    }
+
+    @Test
+    public void activityBackHandlerKeepsDisableGoBackOverlayOpenOnBackLayer() {
+        ActivityController<ComponentActivity> controller = Robolectric.buildActivity(ComponentActivity.class).setup();
+        ComponentActivity activity = controller.get();
+        Options options = new Options();
+        options.setDisableGoBackOnNativeApplication(true);
+
+        WebViewDialog dialog = new WebViewDialog(activity, android.R.style.Theme_NoTitleBar, options, noopPermissionHandler(), null);
+        dialog.activity = activity;
+        dialog.bindToHostActivity();
+        dialog.applyBackNavigationPolicy();
+        dialog.setContentView(new FrameLayout(activity));
+        dialog.show();
+
+        assertTrue(WebViewBackNavigationSupport.shouldRegisterActivityBackHandler(true, false, false, true));
+        activity.getOnBackPressedDispatcher().onBackPressed();
+        assertTrue(dialog.isShowing());
+    }
+
+    private static WebViewDialog.PermissionHandler noopPermissionHandler() {
+        return new WebViewDialog.PermissionHandler() {
+            @Override
+            public void handleCameraPermissionRequest(PermissionRequest request) {}
+
+            @Override
+            public void handleMicrophonePermissionRequest(PermissionRequest request) {}
+
+            @Override
+            public void clearPendingPermissionRequest(PermissionRequest request) {}
+
+            @Override
+            public boolean createManagedPopupWindow(WebViewDialog parentDialog, Message resultMsg, boolean isUserGesture, String popupUrl) {
+                return false;
+            }
+        };
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- When `disableGoBackOnNativeApplication: true`, the Android WebView dialog no longer dismisses on system back or predictive-back gesture.
- Added activity-level back interception as a safety net for back-layer hosting and predictive-back edge cases.
- Expanded unit tests and added Robolectric tests that exercise dialog cancelable policy and `OnBackPressedDispatcher` behavior.

Fixes #681

## Why
#683 added `OnBackPressedCallback` with `IGNORE` when the flag is set, but `presentWebView()` still called `setCancelable(true)` unconditionally. `ComponentDialog` registers its own back callback that calls `cancel()` when cancelable — on predictive back (API 33+) and in some callback-order cases this dismiss path wins before our handler can consume the event. Reporter delagen confirmed the issue persisted after #683.

Related: #681

## How
1. **`setCancelable(false)` when flag is true** — disables `ComponentDialog`'s built-in dismiss-on-back path; our callback still consumes back and returns `IGNORE`.
2. **Activity-level `OnBackPressedCallback`** — registered while overlay is visible when `disableGoBackOnNativeApplication` is true or content is on the back layer (where dialog dispatcher is inactive). Unregistered on dismiss.
3. **`WebViewBackNavigationSupport` helpers** — `isCancelableOnBack()` and `shouldRegisterActivityBackHandler()` for testable policy decisions.
4. **Preserved existing behavior** when flag is false: `setCancelable(true)`, back dismisses and fires `closeEvent`. Fullscreen exit and navigation-toolbar `goBack` remain higher priority than `IGNORE`.

## Testing
- `./gradlew test` (debug + release unit tests) — **BUILD SUCCESSFUL**
- `WebViewBackNavigationSupportTest` — policy helpers for cancelable/activity registration
- `WebViewDialogBackNavigationRobolectricTest` — Robolectric SDK 34:
  - cancelable dialog dismisses on back (flag false)
  - non-cancelable dialog stays open on back (flag true)
  - enabled callback consumes back without dismiss (IGNORE path)
  - `WebViewDialog` with `disableGoBackOnNativeApplication: true` stays open after `onBackPressed()`
  - `WebViewDialog` with flag false dismisses on back
  - activity dispatcher keeps dialog open when flag true
- `bun run fmt` — passed

## Not Tested
- Physical device QA (system back button + predictive-back gesture on API 34+ hardware/emulator)
- Hidden mode / back-layer combinations beyond unit policy coverage
- iOS (Android-only flag)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c79f9302-9bd2-46d5-98a0-d430dd0df28e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c79f9302-9bd2-46d5-98a0-d430dd0df28e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-inappbrowser/pr/688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791120673&installation_model_id=430928&pr_number=688&repository=Cap-go%2Fcapacitor-inappbrowser&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-inappbrowser%2Fpull%2F688&signature=0692ef2ab7e548372e016ef65bb3888dc5c98aef9b6a7048c0e343d32e5b8b76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android back-button handling for in-app browser dialogs and back-navigation layers.
  - Dialogs now remain open when configured to prevent native application back navigation.
  - Back presses are handled consistently when staying in the WebView, using back layers, or switching visibility states.
  - Standard dismissible dialogs continue to close normally when back navigation is allowed.

- **Tests**
  - Added coverage for Android back-navigation behavior across supported dialog and visibility configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->