### PR TITLE
fix(ios): stop WKWebView handlesURLScheme swizzle stack overflow with proxy

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/WKWebView+SchemeHandling.swift
+++ b/ios/Sources/InAppBrowserPlugin/WKWebView+SchemeHandling.swift
@@ -5,6 +5,10 @@ import WebKit
 extension WKWebView {
     private static var _overriddenSchemes = Set<String>()
     private static let _overriddenSchemesLock = NSLock()
+    private static var _originalHandlesURLSchemeIMP: IMP?
+
+    // Original +[WKWebView handlesURLScheme:] IMP (saved before swizzle).
+    private typealias HandlesURLSchemeIMP = @convention(c) (AnyClass, Selector, NSString) -> Bool
 
     private static let _swizzleOnce: Void = {
         let original = class_getClassMethod(WKWebView.self, #selector(WKWebView.handlesURLScheme(_:)))
@@ -18,6 +22,7 @@ extension WKWebView {
             return
         }
 
+        _originalHandlesURLSchemeIMP = method_getImplementation(original)
         method_exchangeImplementations(original, swizzled)
     }()
 
@@ -28,7 +33,14 @@ extension WKWebView {
         _overriddenSchemesLock.unlock()
 
         if isOverridden { return false }
-        return _capgo_handlesURLScheme(urlScheme)
+
+        guard let imp = _originalHandlesURLSchemeIMP else {
+            print("[InAppBrowser][Proxy] WARNING: Original handlesURLScheme IMP missing; assuming not handled")
+            return false
+        }
+
+        let original: HandlesURLSchemeIMP = unsafeBitCast(imp, to: HandlesURLSchemeIMP.self)
+        return original(WKWebView.self, #selector(WKWebView.handlesURLScheme(_:)), urlScheme as NSString)
     }
 
     static func enableCustomSchemeHandling(for schemes: [String]) {

--- a/ios/Tests/InAppBrowserPluginTests/WKWebViewSchemeHandlingSupportTests.swift
+++ b/ios/Tests/InAppBrowserPluginTests/WKWebViewSchemeHandlingSupportTests.swift
@@ -1,0 +1,24 @@
+import WebKit
+import XCTest
+@testable import InappbrowserPlugin
+
+final class WKWebViewSchemeHandlingSupportTests: XCTestCase {
+    func testProxySchemeOverrideReturnsFalseForHttpSchemes() {
+        WKWebView.enableCustomSchemeHandling(for: ["https", "http"])
+
+        XCTAssertFalse(WKWebView.handlesURLScheme("https"))
+        XCTAssertFalse(WKWebView.handlesURLScheme("http"))
+        XCTAssertFalse(WKWebView.handlesURLScheme("HTTPS"))
+    }
+
+    func testNonOverriddenSchemesCallThroughToOriginalImplementation() {
+        WKWebView.enableCustomSchemeHandling(for: ["https", "http"])
+
+        // Regression for #681: calling a non-overridden scheme must not recurse through the
+        // swizzled Swift method (stack overflow / EXC_BAD_ACCESS). These calls should return
+        // immediately with WebKit's original answer.
+        _ = WKWebView.handlesURLScheme("capacitor")
+        _ = WKWebView.handlesURLScheme("file")
+        _ = WKWebView.handlesURLScheme("capgo-regression-scheme")
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Fix iOS crash (`EXC_BAD_ACCESS`) when opening a WebView with `outboundProxyRules` enabled while bundled-asset / `capacitor` scheme handling is active.
- Add regression tests for the `WKWebView.handlesURLScheme` swizzle used by the proxy path.

## Why
- Reported in #681: newer plugin versions crash on iOS when proxy rules are enabled. The crash occurs inside the swizzled `handlesURLScheme` implementation while WebKit queries the `capacitor` scheme.
- Root cause: after `method_exchangeImplementations`, the swizzled Swift method called itself by name instead of the original implementation, causing infinite recursion / stack overflow (surfacing as `EXC_BAD_ACCESS` on `_overriddenSchemesLock.lock()`).

## How
- Save the original `handlesURLScheme` IMP before exchanging implementations.
- For schemes listed in `_overriddenSchemes` (`http`/`https` when proxy is enabled), return `false` so custom `WKURLSchemeHandler` registration works.
- For all other schemes (including `capacitor`), invoke the saved original IMP via a typed function pointer — never recurse through the Swift method name.
- Keep existing `NSLock` protection around `_overriddenSchemes`; swizzle init remains in a `static let` (thread-safe once).

## Testing
- Added `WKWebViewSchemeHandlingSupportTests` covering:
  - overridden `http`/`https` schemes return `false`
  - non-overridden schemes (`capacitor`, `file`, custom) call through without recursion/crash
- Ran `bun run fmt` locally (SwiftLint skipped on Linux)
- iOS `swift test` / `xcodebuild` not available in Linux cloud agent — CI must validate on macOS

## Not Tested
- On-device iOS manual repro with `outboundProxyRules` + bundled assets (awaiting CI macOS build/test)
- Android changes (tracked separately in #688)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cfab6f55-2f6e-4e05-8fd9-727ecc934a60?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cfab6f55-2f6e-4e05-8fd9-727ecc934a60&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-inappbrowser/pr/689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791131174&installation_model_id=430928&pr_number=689&repository=Cap-go%2Fcapacitor-inappbrowser&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-inappbrowser%2Fpull%2F689&signature=ee6881f5d372aa6fc4e9dc8e9b4289728b79de8114a946115891617c0899fe00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed custom URL scheme handling in the iOS in-app browser to avoid recursive calls and potential stack overflows.
  - Preserved correct handling for HTTP and HTTPS schemes regardless of letter casing.
  - Added a safe fallback when the original WebKit handling is unavailable.

- **Tests**
  - Added coverage for standard web schemes and other URL schemes to verify stable, non-recursive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->