### PR TITLE
fix(android): restore webview history back when disableGoBack is set

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewBackNavigationSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewBackNavigationSupport.java
@@ -25,7 +25,9 @@ final class WebViewBackNavigationSupport {
     /**
      * When {@code disableGoBackOnNativeApplication} is true, the dialog must not be cancelable on
      * back/gesture. Otherwise {@link androidx.activity.ComponentDialog}'s built-in back callback
-     * dismisses the dialog before our handler can return {@link Action#IGNORE}.
+     * dismisses the dialog before our handler can return {@link Action#IGNORE}. While cancelable is
+     * false that built-in callback still consumes back without dismissing, so {@link WebViewDialog}
+     * must keep its own callback registered last on the dispatcher.
      */
     static boolean isCancelableOnBack(boolean disableGoBackOnNativeApplication) {
         return !disableGoBackOnNativeApplication;

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -469,7 +469,9 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
     @Override
     protected void onStart() {
         super.onStart();
-        syncBackNavigationHandlers();
+        // ComponentDialog registers its own back callback in onCreate; re-add ours last so
+        // handleBrowserBackNavigation runs before the built-in cancel callback (LIFO order).
+        ensureDialogBackHandlerOnTop();
     }
 
     @Override
@@ -2921,6 +2923,19 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
         if (dialogBackCallback != null) {
             return;
         }
+        ensureDialogBackHandlerOnTop();
+    }
+
+    /**
+     * Re-register the dialog back callback so it sits above {@link ComponentDialog}'s built-in
+     * callback. That callback is always enabled and consumes back without dismissing when
+     * {@link #setCancelable(boolean)} is false, which would block webview history navigation.
+     */
+    private void ensureDialogBackHandlerOnTop() {
+        if (dialogBackCallback != null) {
+            dialogBackCallback.remove();
+            dialogBackCallback = null;
+        }
         // Predictive back (API 33+) never delivers KEYCODE_BACK to Dialog OnKeyListener.
         dialogBackCallback = new OnBackPressedCallback(false) {
             @Override
@@ -2949,7 +2964,11 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
     void applyBackNavigationPolicy() {
         boolean disableGoBack = _options != null && _options.getDisableGoBackOnNativeApplication();
         setCancelable(WebViewBackNavigationSupport.isCancelableOnBack(disableGoBack));
-        syncBackNavigationHandlers();
+        if (isShowing()) {
+            ensureDialogBackHandlerOnTop();
+        } else {
+            syncBackNavigationHandlers();
+        }
     }
 
     private void syncBackNavigationHandlers() {

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewDialogBackNavigationRobolectricTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/WebViewDialogBackNavigationRobolectricTest.java
@@ -1,5 +1,6 @@
 package ee.forgr.capacitor_inappbrowser;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -9,12 +10,14 @@ import android.content.Context;
 import android.os.Message;
 import android.view.View;
 import android.webkit.PermissionRequest;
+import android.webkit.WebView;
 import android.widget.FrameLayout;
 import androidx.activity.ComponentActivity;
 import androidx.activity.ComponentDialog;
 import androidx.activity.OnBackPressedCallback;
 import androidx.activity.OnBackPressedDispatcher;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import java.lang.reflect.Field;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -91,6 +94,54 @@ public class WebViewDialogBackNavigationRobolectricTest {
 
         assertTrue(dialog.isShowing());
         dialog.getOnBackPressedDispatcher().onBackPressed();
+        assertTrue(dialog.isShowing());
+    }
+
+    @Test
+    public void webViewDialogWithActiveNativeNavigationAndDisableGoBackGoesBackInHistory() throws Exception {
+        ActivityController<ComponentActivity> controller = Robolectric.buildActivity(ComponentActivity.class).setup();
+        ComponentActivity activity = controller.get();
+        activity.setContentView(new FrameLayout(activity));
+
+        Options options = new Options();
+        options.setDisableGoBackOnNativeApplication(true);
+        options.setActiveNativeNavigationForWebview(true);
+
+        WebViewDialog dialog = createBoundDialog(activity, options);
+        TrackingWebView trackingWebView = new TrackingWebView(activity);
+        trackingWebView.canGoBackResult = true;
+        setWebView(dialog, trackingWebView);
+        showDialog(dialog);
+
+        assertTrue(dialog.isShowing());
+        assertEquals(0, trackingWebView.goBackCallCount);
+
+        dialog.getOnBackPressedDispatcher().onBackPressed();
+
+        assertEquals(1, trackingWebView.goBackCallCount);
+        assertTrue(dialog.isShowing());
+    }
+
+    @Test
+    public void webViewDialogWithActiveNativeNavigationAndDisableGoBackStaysOpenWhenNoHistory() throws Exception {
+        ActivityController<ComponentActivity> controller = Robolectric.buildActivity(ComponentActivity.class).setup();
+        ComponentActivity activity = controller.get();
+        activity.setContentView(new FrameLayout(activity));
+
+        Options options = new Options();
+        options.setDisableGoBackOnNativeApplication(true);
+        options.setActiveNativeNavigationForWebview(true);
+
+        WebViewDialog dialog = createBoundDialog(activity, options);
+        TrackingWebView trackingWebView = new TrackingWebView(activity);
+        trackingWebView.canGoBackResult = false;
+        setWebView(dialog, trackingWebView);
+        showDialog(dialog);
+
+        assertTrue(dialog.isShowing());
+        dialog.getOnBackPressedDispatcher().onBackPressed();
+
+        assertEquals(0, trackingWebView.goBackCallCount);
         assertTrue(dialog.isShowing());
     }
 
@@ -267,6 +318,32 @@ public class WebViewDialogBackNavigationRobolectricTest {
         View overlayContent = dialog.findViewById(R.id.coordinator_layout);
         assertNotNull(overlayContent);
         return overlayContent;
+    }
+
+    private static void setWebView(WebViewDialog dialog, WebView webView) throws Exception {
+        Field field = WebViewDialog.class.getDeclaredField("_webView");
+        field.setAccessible(true);
+        field.set(dialog, webView);
+    }
+
+    private static class TrackingWebView extends WebView {
+
+        boolean canGoBackResult;
+        int goBackCallCount;
+
+        TrackingWebView(Context context) {
+            super(context);
+        }
+
+        @Override
+        public boolean canGoBack() {
+            return canGoBackResult;
+        }
+
+        @Override
+        public void goBack() {
+            goBackCallCount++;
+        }
     }
 
     private static WebViewDialog.PermissionHandler noopPermissionHandler() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes regression from #688 reported on #681. Do not merge.

## What
- Re-register the WebView dialog `OnBackPressedCallback` after `ComponentDialog.onCreate` so our handler runs before the built-in cancel callback when `disableGoBackOnNativeApplication` is enabled.
- Add Robolectric tests covering `activeNativeNavigationForWebview` + `disableGoBackOnNativeApplication` together (history back vs. stay open).

## Why
- #688 set `setCancelable(false)` when `disableGoBackOnNativeApplication` is true so the overlay is not dismissed on back.
- `ComponentDialog` still registers an always-enabled back callback that consumes the event without dismissing when cancelable is false.
- That callback is registered after ours (LIFO), so `handleBrowserBackNavigation()` never ran and `activeNativeNavigationForWebview` could not call `WebView.goBack()`.

## How
- Added `ensureDialogBackHandlerOnTop()` to remove and re-add the dialog back callback on the dispatcher.
- Call it from `onStart()` (after `super.onStart()`) and from `applyBackNavigationPolicy()` when the dialog is already showing.
- Kept `setCancelable(false)` for disable-go-back and the activity-level safety-net callback unchanged.

## Testing
- `./gradlew testDebugUnitTest --tests "ee.forgr.capacitor_inappbrowser.WebViewBackNavigationSupportTest" --tests "ee.forgr.capacitor_inappbrowser.WebViewDialogBackNavigationRobolectricTest"` (all pass)
- New tests: both flags + `canGoBack=true` invokes `goBack()` and stays open; both flags + `canGoBack=false` stays open without dismiss.

## Not Tested
- Physical device predictive-back gesture with both options enabled (Robolectric only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff2de252-8769-4ee7-9b03-0f608d7b30e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff2de252-8769-4ee7-9b03-0f608d7b30e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-inappbrowser/pr/692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791361459&installation_model_id=430928&pr_number=692&repository=Cap-go%2Fcapacitor-inappbrowser&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-inappbrowser%2Fpull%2F692&signature=b0f947a06095be9c1bd6ed5df96b58cb942d0ff983a9fc6036ef401c34087d59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android back-button handling in the in-app browser.
  * Back navigation now moves through WebView history when available.
  * The browser dialog remains open when no WebView history exists, preventing unintended dismissal.

* **Documentation**
  * Clarified back-navigation behavior for non-cancelable browser dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->