### PR TITLE
fix(android): paint dialog window background for all toolbar types

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/SystemUiChromeSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/SystemUiChromeSupport.java
@@ -34,6 +34,17 @@ final class SystemUiChromeSupport {
         return !edgeToEdge && shouldUsePreApi30LayoutFlags(sdkInt);
     }
 
+    /**
+     * Color painted behind the browser content, visible in the system bar insets. Follows the toolbar
+     * color when one is set, otherwise the system theme, so the dialog theme's default never shows.
+     */
+    static int resolveWindowBackgroundColor(Integer toolbarColor, boolean darkTheme) {
+        if (toolbarColor != null) {
+            return toolbarColor;
+        }
+        return darkTheme ? Color.BLACK : Color.WHITE;
+    }
+
     static void setDecorFitsSystemWindows(Window window, boolean decorFitsSystemWindows) {
         if (window == null) {
             return;

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -3874,6 +3874,29 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
         }
     }
 
+    private int resolveWindowBackgroundColor() {
+        Integer toolbarColor = null;
+        if (_options.getToolbarColor() != null && !_options.getToolbarColor().isEmpty()) {
+            try {
+                toolbarColor = Color.parseColor(_options.getToolbarColor());
+            } catch (IllegalArgumentException e) {
+                Log.e("InAppBrowser", "Invalid toolbar color, using theme default: " + e.getMessage());
+            }
+        }
+        return SystemUiChromeSupport.resolveWindowBackgroundColor(toolbarColor, isDarkThemeEnabled());
+    }
+
+    private void applyWindowBackgroundColor() {
+        // Custom dimensions keep the window transparent for touch passthrough
+        if (_options.getWidth() != null || _options.getHeight() != null) {
+            return;
+        }
+        Window window = getWindow();
+        if (window != null) {
+            window.getDecorView().setBackgroundColor(resolveWindowBackgroundColor());
+        }
+    }
+
     private int getSystemStatusBarHeight() {
         int resourceId = getContext().getResources().getIdentifier("status_bar_height", "dimen", "android");
         if (resourceId <= 0) {
@@ -4951,6 +4974,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
 
     private void setupToolbar() {
         _toolbar = findViewById(R.id.tool_bar);
+        applyWindowBackgroundColor();
 
         // Apply toolbar color early, for ALL toolbar types, before any view configuration
         if (_options.getToolbarColor() != null && !_options.getToolbarColor().isEmpty()) {
@@ -5110,41 +5134,10 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
             configureBlankToolbarLayout();
             requestSafeAreaInsets();
 
-            // Also set window background color to match status bar for blank toolbar
+            // Without a toolbar the status bar view is the only chrome, so it follows the window color
             View statusBarColorView = findViewById(R.id.status_bar_color_view);
-            if (_options.getToolbarColor() != null && !_options.getToolbarColor().isEmpty()) {
-                try {
-                    int toolbarColor = Color.parseColor(_options.getToolbarColor());
-                    if (getWindow() != null) {
-                        getWindow().getDecorView().setBackgroundColor(toolbarColor);
-                    }
-                    // Also set status bar color view background if available
-                    if (statusBarColorView != null) {
-                        statusBarColorView.setBackgroundColor(toolbarColor);
-                    }
-                } catch (IllegalArgumentException e) {
-                    // Fallback to system default if color parsing fails
-                    boolean isDarkTheme = isDarkThemeEnabled();
-                    int windowBackgroundColor = isDarkTheme ? Color.BLACK : Color.WHITE;
-                    if (getWindow() != null) {
-                        getWindow().getDecorView().setBackgroundColor(windowBackgroundColor);
-                    }
-                    // Also set status bar color view background if available
-                    if (statusBarColorView != null) {
-                        statusBarColorView.setBackgroundColor(windowBackgroundColor);
-                    }
-                }
-            } else {
-                // Follow system dark mode
-                boolean isDarkTheme = isDarkThemeEnabled();
-                int windowBackgroundColor = isDarkTheme ? Color.BLACK : Color.WHITE;
-                if (getWindow() != null) {
-                    getWindow().getDecorView().setBackgroundColor(windowBackgroundColor);
-                }
-                // Also set status bar color view background if available
-                if (statusBarColorView != null) {
-                    statusBarColorView.setBackgroundColor(windowBackgroundColor);
-                }
+            if (statusBarColorView != null) {
+                statusBarColorView.setBackgroundColor(resolveWindowBackgroundColor());
             }
         } else {
             _toolbar.findViewById(R.id.forwardButton).setVisibility(View.GONE);

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/SystemUiChromeSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/SystemUiChromeSupportTest.java
@@ -1,12 +1,26 @@
 package ee.forgr.capacitor_inappbrowser;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import android.graphics.Color;
 import android.os.Build;
 import org.junit.Test;
 
 public class SystemUiChromeSupportTest {
+
+    @Test
+    public void windowBackgroundFollowsToolbarColorWhenSet() {
+        assertEquals(0xFF123456, SystemUiChromeSupport.resolveWindowBackgroundColor(0xFF123456, true));
+        assertEquals(0xFF123456, SystemUiChromeSupport.resolveWindowBackgroundColor(0xFF123456, false));
+    }
+
+    @Test
+    public void windowBackgroundFollowsThemeWithoutToolbarColor() {
+        assertEquals(Color.BLACK, SystemUiChromeSupport.resolveWindowBackgroundColor(null, true));
+        assertEquals(Color.WHITE, SystemUiChromeSupport.resolveWindowBackgroundColor(null, false));
+    }
 
     @Test
     public void edgeToEdgeChromeRequiredFromApi35() {


### PR DESCRIPTION
## What
- Paint the browser dialog's window background with `toolbarColor` (or the system theme color when unset) for every `toolbarType`, not only for `blank`.
- Skip the paint when custom dimensions are set, because that mode relies on a transparent window for touch passthrough.
- Move the color decision into `SystemUiChromeSupport.resolveWindowBackgroundColor` and cover it with unit tests; the `blank` branch reuses it for the status bar view.

## Why
The dialog is created with `android.R.style.Theme_NoTitleBar`, whose window background is dark grey. On Android 15+ (edge-to-edge) the content container gets bottom padding for the navigation bar inset, and that padding shows the window background. With `toolbarType: 'compact'` (or the default, `activity`, `navigation`) and a white toolbar, users see a dark grey band above the gesture bar. `blank` already painted the window with the toolbar color, so the other toolbar types were inconsistent with it.

## How
- `setupToolbar()` now calls `applyWindowBackgroundColor()` first for all toolbar types.
- `resolveWindowBackgroundColor()` parses `toolbarColor` and falls back to black/white by system theme (same rule the `blank` branch used before); invalid colors log and fall back.
- The `blank` branch keeps setting the status bar view but drops its duplicated window logic.

## Testing
- `./gradlew testDebugUnitTest`: 166 tests pass, including two new `SystemUiChromeSupportTest` cases.
- Prettier (`prettier-plugin-java`) passes on the changed files.
- Manual, after the fix: on an Android emulator the bottom inset is now white (matching `toolbarColor`) with `toolbarType: 'compact'`.
- Manual, before the fix: Android emulators API 34/35/37 with `toolbarType: 'compact'`, `toolbarColor: '#ffffff'`, `enabledSafeBottomMargin: true` show a dark grey bottom inset; `uiautomator dump` confirms the padding area is the window's decor view.

## Not Tested
- Custom-dimension (touch passthrough) mode and fullscreen video restore paths were reviewed for compatibility, not exercised.
- SwiftLint/iOS not affected (Android-only change).

Written with the help of an AI agent (Claude); reviewed and tested by a human.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-inappbrowser/pr/696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791638827&installation_model_id=430928&pr_number=696&repository=Cap-go%2Fcapacitor-inappbrowser&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-inappbrowser%2Fpull%2F696&signature=99ec7fadf2f53540e075342e44c6d0f5623505f1f525605b3bb22c83bb993b99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android in-app browser window background color handling.
  * Configured toolbar colors are now applied consistently, with theme-appropriate black or white fallbacks when no color is specified.
  * Preserved transparent backgrounds for custom-sized windows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->