### PR TITLE
fix(android): paint dialog window background for all toolbar types

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/OrientationLayoutSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/OrientationLayoutSupport.java
@@ -16,11 +16,13 @@ final class OrientationLayoutSupport {
         Integer previousScreenHeightDp,
         Integer previousSmallestScreenWidthDp,
         Integer previousDensityDpi,
+        Integer previousUiMode,
         int currentOrientation,
         int currentScreenWidthDp,
         int currentScreenHeightDp,
         int currentSmallestScreenWidthDp,
-        int currentDensityDpi
+        int currentDensityDpi,
+        int currentUiMode
     ) {
         if (previousOrientation == null) {
             return true;
@@ -35,7 +37,9 @@ final class OrientationLayoutSupport {
             previousSmallestScreenWidthDp == null ||
             previousSmallestScreenWidthDp != currentSmallestScreenWidthDp ||
             previousDensityDpi == null ||
-            previousDensityDpi != currentDensityDpi
+            previousDensityDpi != currentDensityDpi ||
+            previousUiMode == null ||
+            previousUiMode != currentUiMode
         );
     }
 }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/SystemUiChromeSupport.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/SystemUiChromeSupport.java
@@ -34,6 +34,17 @@ final class SystemUiChromeSupport {
         return !edgeToEdge && shouldUsePreApi30LayoutFlags(sdkInt);
     }
 
+    /**
+     * Color painted behind the browser content, visible in the system bar insets. Follows the toolbar
+     * color when one is set, otherwise the system theme, so the dialog theme's default never shows.
+     */
+    static int resolveWindowBackgroundColor(Integer toolbarColor, boolean darkTheme) {
+        if (toolbarColor != null) {
+            return toolbarColor;
+        }
+        return darkTheme ? Color.BLACK : Color.WHITE;
+    }
+
     static void setDecorFitsSystemWindows(Window window, boolean decorFitsSystemWindows) {
         if (window == null) {
             return;

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -2214,9 +2214,9 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
                                 boolean isDarkBackground = isDarkColor(toolbarColor);
                                 insetsController.setAppearanceLightStatusBars(!isDarkBackground);
                             } catch (IllegalArgumentException e) {
-                                // Fallback to default black if color parsing fails
-                                statusBarColorView.setBackgroundColor(Color.BLACK);
-                                insetsController.setAppearanceLightStatusBars(false);
+                                int fallbackColor = resolveWindowBackgroundColor();
+                                statusBarColorView.setBackgroundColor(fallbackColor);
+                                insetsController.setAppearanceLightStatusBars(!isDarkThemeEnabled());
                             }
                         } else {
                             // Follow system dark mode if no toolbar color provided

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -3450,6 +3450,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
         Integer previousScreenHeightDp = lastConfiguration != null ? lastConfiguration.screenHeightDp : null;
         Integer previousSmallestScreenWidthDp = lastConfiguration != null ? lastConfiguration.smallestScreenWidthDp : null;
         Integer previousDensityDpi = lastConfiguration != null ? lastConfiguration.densityDpi : null;
+        Integer previousUiMode = lastConfiguration != null ? lastConfiguration.uiMode : null;
 
         int currentOrientation = newConfig != null ? newConfig.orientation : (previousOrientation != null ? previousOrientation : 0);
         int currentScreenWidthDp =
@@ -3461,6 +3462,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
                 ? newConfig.smallestScreenWidthDp
                 : (previousSmallestScreenWidthDp != null ? previousSmallestScreenWidthDp : 0);
         int currentDensityDpi = newConfig != null ? newConfig.densityDpi : (previousDensityDpi != null ? previousDensityDpi : 0);
+        int currentUiMode = newConfig != null ? newConfig.uiMode : (previousUiMode != null ? previousUiMode : 0);
 
         boolean shouldRefresh = OrientationLayoutSupport.shouldRefreshBrowserLayout(
             previousOrientation,
@@ -3468,11 +3470,13 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
             previousScreenHeightDp,
             previousSmallestScreenWidthDp,
             previousDensityDpi,
+            previousUiMode,
             currentOrientation,
             currentScreenWidthDp,
             currentScreenHeightDp,
             currentSmallestScreenWidthDp,
-            currentDensityDpi
+            currentDensityDpi,
+            currentUiMode
         );
 
         if (newConfig != null) {
@@ -3513,6 +3517,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
         }
 
         ensureContentBrowserMatchParentHeight();
+        applyWindowBackgroundColor();
 
         boolean isBlankToolbar = _options != null && TextUtils.equals(_options.getToolbarType(), "blank");
         if (isBlankToolbar) {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -4972,55 +4972,55 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
 
         // Apply toolbar color early, for ALL toolbar types, before any view configuration
         if (_options.getToolbarColor() != null && !_options.getToolbarColor().isEmpty()) {
+            int toolbarColor;
             try {
-                int toolbarColor = Color.parseColor(_options.getToolbarColor());
-                _toolbar.setBackgroundColor(toolbarColor);
+                toolbarColor = Color.parseColor(_options.getToolbarColor());
+            } catch (IllegalArgumentException e) {
+                Log.e("InAppBrowser", "Invalid toolbar color, using theme default: " + e.getMessage());
+                toolbarColor = resolveWindowBackgroundColor();
+            }
 
-                // Get toolbar title and ensure it gets the right color
-                TextView titleText = _toolbar.findViewById(R.id.titleText);
+            _toolbar.setBackgroundColor(toolbarColor);
 
-                // Determine icon and text color
-                cachedTitleIconDrawable = null;
-                cachedTitleIconResolved = false;
+            // Get toolbar title and ensure it gets the right color
+            TextView titleText = _toolbar.findViewById(R.id.titleText);
 
-                int iconColor;
-                if (_options.getToolbarTextColor() != null && !_options.getToolbarTextColor().isEmpty()) {
-                    try {
-                        iconColor = Color.parseColor(_options.getToolbarTextColor());
-                    } catch (IllegalArgumentException e) {
-                        // Fallback to automatic detection if parsing fails
-                        boolean isDarkBackground = isDarkColor(toolbarColor);
-                        iconColor = isDarkBackground ? Color.WHITE : Color.BLACK;
-                    }
-                } else {
-                    // No explicit toolbarTextColor, use automatic detection based on background
+            // Determine icon and text color
+            cachedTitleIconDrawable = null;
+            cachedTitleIconResolved = false;
+
+            int iconColor;
+            if (_options.getToolbarTextColor() != null && !_options.getToolbarTextColor().isEmpty()) {
+                try {
+                    iconColor = Color.parseColor(_options.getToolbarTextColor());
+                } catch (IllegalArgumentException e) {
+                    // Fallback to automatic detection if parsing fails
                     boolean isDarkBackground = isDarkColor(toolbarColor);
                     iconColor = isDarkBackground ? Color.WHITE : Color.BLACK;
                 }
+            } else {
+                // No explicit toolbarTextColor, use automatic detection based on background
+                boolean isDarkBackground = isDarkColor(toolbarColor);
+                iconColor = isDarkBackground ? Color.WHITE : Color.BLACK;
+            }
 
-                // Store for later use with navigation buttons
-                this.iconColor = iconColor;
+            // Store for later use with navigation buttons
+            this.iconColor = iconColor;
 
-                // Set title text color directly
-                titleText.setTextColor(iconColor);
+            // Set title text color directly
+            titleText.setTextColor(iconColor);
 
-                // Apply colors to all buttons
-                applyColorToAllButtons(toolbarColor, iconColor);
+            // Apply colors to all buttons
+            applyColorToAllButtons(toolbarColor, iconColor);
 
-                // Also ensure status bar gets the color
-                if (getWindow() != null) {
-                    SystemUiChromeSupport.applyLegacyStatusBarColorViaView(findViewById(R.id.status_bar_color_view), toolbarColor);
+            // Also ensure status bar gets the color
+            if (getWindow() != null) {
+                SystemUiChromeSupport.applyLegacyStatusBarColorViaView(findViewById(R.id.status_bar_color_view), toolbarColor);
 
-                    // Determine proper status bar text color (light or dark icons)
-                    boolean isDarkBackground = isDarkColor(toolbarColor);
-                    WindowInsetsControllerCompat insetsController = new WindowInsetsControllerCompat(
-                        getWindow(),
-                        getWindow().getDecorView()
-                    );
-                    insetsController.setAppearanceLightStatusBars(!isDarkBackground);
-                }
-            } catch (IllegalArgumentException e) {
-                Log.e("InAppBrowser", "Invalid toolbar color: " + _options.getToolbarColor());
+                // Determine proper status bar text color (light or dark icons)
+                boolean isDarkBackground = isDarkColor(toolbarColor);
+                WindowInsetsControllerCompat insetsController = new WindowInsetsControllerCompat(getWindow(), getWindow().getDecorView());
+                insetsController.setAppearanceLightStatusBars(!isDarkBackground);
             }
         }
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -3624,6 +3624,12 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
 
             applyAppBarTopInset(appBarLayout, appBarHandlesTopInset(toolbarView) ? statusBarHeight : 0);
             appBarLayout.setBackgroundColor(finalBgColor);
+
+            Window window = getWindow();
+            if (window != null) {
+                WindowInsetsControllerCompat insetsController = new WindowInsetsControllerCompat(window, window.getDecorView());
+                insetsController.setAppearanceLightStatusBars(!isDarkColor(finalBgColor));
+            }
         });
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -3874,6 +3874,29 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
         }
     }
 
+    private int resolveWindowBackgroundColor() {
+        Integer toolbarColor = null;
+        if (_options.getToolbarColor() != null && !_options.getToolbarColor().isEmpty()) {
+            try {
+                toolbarColor = Color.parseColor(_options.getToolbarColor());
+            } catch (IllegalArgumentException e) {
+                Log.e("InAppBrowser", "Invalid toolbar color, using theme default: " + e.getMessage());
+            }
+        }
+        return SystemUiChromeSupport.resolveWindowBackgroundColor(toolbarColor, isDarkThemeEnabled());
+    }
+
+    private void applyWindowBackgroundColor() {
+        // Custom dimensions keep the window transparent for touch passthrough
+        if (_options.getWidth() != null || _options.getHeight() != null) {
+            return;
+        }
+        Window window = getWindow();
+        if (window != null) {
+            window.getDecorView().setBackgroundColor(resolveWindowBackgroundColor());
+        }
+    }
+
     private int getSystemStatusBarHeight() {
         int resourceId = getContext().getResources().getIdentifier("status_bar_height", "dimen", "android");
         if (resourceId <= 0) {
@@ -4951,6 +4974,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
 
     private void setupToolbar() {
         _toolbar = findViewById(R.id.tool_bar);
+        applyWindowBackgroundColor();
 
         // Apply toolbar color early, for ALL toolbar types, before any view configuration
         if (_options.getToolbarColor() != null && !_options.getToolbarColor().isEmpty()) {
@@ -5110,41 +5134,10 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
             configureBlankToolbarLayout();
             requestSafeAreaInsets();
 
-            // Also set window background color to match status bar for blank toolbar
+            // Without a toolbar the status bar view is the only chrome, so it follows the window color
             View statusBarColorView = findViewById(R.id.status_bar_color_view);
-            if (_options.getToolbarColor() != null && !_options.getToolbarColor().isEmpty()) {
-                try {
-                    int toolbarColor = Color.parseColor(_options.getToolbarColor());
-                    if (getWindow() != null) {
-                        getWindow().getDecorView().setBackgroundColor(toolbarColor);
-                    }
-                    // Also set status bar color view background if available
-                    if (statusBarColorView != null) {
-                        statusBarColorView.setBackgroundColor(toolbarColor);
-                    }
-                } catch (IllegalArgumentException e) {
-                    // Fallback to system default if color parsing fails
-                    boolean isDarkTheme = isDarkThemeEnabled();
-                    int windowBackgroundColor = isDarkTheme ? Color.BLACK : Color.WHITE;
-                    if (getWindow() != null) {
-                        getWindow().getDecorView().setBackgroundColor(windowBackgroundColor);
-                    }
-                    // Also set status bar color view background if available
-                    if (statusBarColorView != null) {
-                        statusBarColorView.setBackgroundColor(windowBackgroundColor);
-                    }
-                }
-            } else {
-                // Follow system dark mode
-                boolean isDarkTheme = isDarkThemeEnabled();
-                int windowBackgroundColor = isDarkTheme ? Color.BLACK : Color.WHITE;
-                if (getWindow() != null) {
-                    getWindow().getDecorView().setBackgroundColor(windowBackgroundColor);
-                }
-                // Also set status bar color view background if available
-                if (statusBarColorView != null) {
-                    statusBarColorView.setBackgroundColor(windowBackgroundColor);
-                }
+            if (statusBarColorView != null) {
+                statusBarColorView.setBackgroundColor(resolveWindowBackgroundColor());
             }
         } else {
             _toolbar.findViewById(R.id.forwardButton).setVisibility(View.GONE);

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -3599,18 +3599,7 @@ public class WebViewDialog extends ComponentDialog implements ProxyResponseRouti
         appBarLayout.setStateListAnimator(null);
         appBarLayout.setOutlineProvider(null);
 
-        int backgroundColor = Color.BLACK;
-        if (_options.getToolbarColor() != null && !_options.getToolbarColor().isEmpty()) {
-            try {
-                backgroundColor = Color.parseColor(_options.getToolbarColor());
-            } catch (IllegalArgumentException e) {
-                Log.e("InAppBrowser", "Invalid toolbar color, using black: " + e.getMessage());
-            }
-        } else {
-            backgroundColor = isDarkThemeEnabled() ? Color.BLACK : Color.WHITE;
-        }
-
-        final int finalBgColor = backgroundColor;
+        final int finalBgColor = resolveWindowBackgroundColor();
         _webView.post(() -> {
             if (_webView == null) {
                 return;

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/OrientationLayoutSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/OrientationLayoutSupportTest.java
@@ -3,32 +3,53 @@ package ee.forgr.capacitor_inappbrowser;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import android.content.res.Configuration;
 import org.junit.Test;
 
 public class OrientationLayoutSupportTest {
 
     @Test
     public void refreshesWhenPreviousConfigurationIsMissing() {
-        assertTrue(OrientationLayoutSupport.shouldRefreshBrowserLayout(null, null, null, null, null, 2, 800, 360, 360, 420));
+        assertTrue(OrientationLayoutSupport.shouldRefreshBrowserLayout(null, null, null, null, null, null, 2, 800, 360, 360, 420, 0));
     }
 
     @Test
     public void refreshesOnOrientationChange() {
-        assertTrue(OrientationLayoutSupport.shouldRefreshBrowserLayout(1, 360, 800, 360, 420, 2, 800, 360, 360, 420));
+        assertTrue(OrientationLayoutSupport.shouldRefreshBrowserLayout(1, 360, 800, 360, 420, 16, 2, 800, 360, 360, 420, 16));
     }
 
     @Test
     public void refreshesOnScreenSizeChangeWithoutOrientationFlip() {
-        assertTrue(OrientationLayoutSupport.shouldRefreshBrowserLayout(1, 360, 800, 360, 420, 1, 600, 800, 600, 420));
+        assertTrue(OrientationLayoutSupport.shouldRefreshBrowserLayout(1, 360, 800, 360, 420, 16, 1, 600, 800, 600, 420, 16));
     }
 
     @Test
     public void refreshesOnDensityChange() {
-        assertTrue(OrientationLayoutSupport.shouldRefreshBrowserLayout(1, 360, 800, 360, 160, 1, 360, 800, 360, 480));
+        assertTrue(OrientationLayoutSupport.shouldRefreshBrowserLayout(1, 360, 800, 360, 160, 16, 1, 360, 800, 360, 480, 16));
+    }
+
+    @Test
+    public void refreshesOnUiModeChange() {
+        assertTrue(
+            OrientationLayoutSupport.shouldRefreshBrowserLayout(
+                1,
+                360,
+                800,
+                360,
+                420,
+                Configuration.UI_MODE_NIGHT_NO,
+                1,
+                360,
+                800,
+                360,
+                420,
+                Configuration.UI_MODE_NIGHT_YES
+            )
+        );
     }
 
     @Test
     public void skipsUnrelatedConfigurationChanges() {
-        assertFalse(OrientationLayoutSupport.shouldRefreshBrowserLayout(1, 360, 800, 360, 420, 1, 360, 800, 360, 420));
+        assertFalse(OrientationLayoutSupport.shouldRefreshBrowserLayout(1, 360, 800, 360, 420, 16, 1, 360, 800, 360, 420, 16));
     }
 }

--- a/android/src/test/java/ee/forgr/capacitor_inappbrowser/SystemUiChromeSupportTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_inappbrowser/SystemUiChromeSupportTest.java
@@ -1,12 +1,26 @@
 package ee.forgr.capacitor_inappbrowser;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import android.graphics.Color;
 import android.os.Build;
 import org.junit.Test;
 
 public class SystemUiChromeSupportTest {
+
+    @Test
+    public void windowBackgroundFollowsToolbarColorWhenSet() {
+        assertEquals(0xFF123456, SystemUiChromeSupport.resolveWindowBackgroundColor(0xFF123456, true));
+        assertEquals(0xFF123456, SystemUiChromeSupport.resolveWindowBackgroundColor(0xFF123456, false));
+    }
+
+    @Test
+    public void windowBackgroundFollowsThemeWithoutToolbarColor() {
+        assertEquals(Color.BLACK, SystemUiChromeSupport.resolveWindowBackgroundColor(null, true));
+        assertEquals(Color.WHITE, SystemUiChromeSupport.resolveWindowBackgroundColor(null, false));
+    }
 
     @Test
     public void edgeToEdgeChromeRequiredFromApi35() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Paint the dialog window background for all toolbar types (not only `blank`) so system bar insets match toolbar/window chrome on Android 15+ edge-to-edge.
- Fix edge-to-edge refresh so invalid `toolbarColor` values use the same theme fallback as the decor background instead of painting status bar/app bar black.
- Align legacy status bar, toolbar, and configuration-change refresh paths with the same `resolveWindowBackgroundColor()` fallback.
- Refresh theme-dependent chrome on `uiMode` configuration changes and sync status bar icon appearance after edge-to-edge refresh.

## Why
- Supersedes cross-repo contribution Cap-go/capacitor-inappbrowser#696 (ergon fork; we cannot push there).
- On Android 15+ with a non-blank toolbar, an invalid `toolbarColor` left the decor using the theme fallback while `refreshEdgeToEdgeChrome()` painted the status bar inset and app bar black, causing a visible mismatch.

## How
- Reuse existing `resolveWindowBackgroundColor()` in `refreshEdgeToEdgeChrome()`, initial status bar setup, and invalid-color toolbar setup.
- Include `Configuration.uiMode` in `OrientationLayoutSupport.shouldRefreshBrowserLayout()` and call `applyWindowBackgroundColor()` during configuration refresh.
- Update status bar icon appearance in `refreshEdgeToEdgeChrome()` when the resolved background changes.

## Testing
- `bun run fmt`
- CI: Android/iOS builds, unit tests, SonarCloud, Socket Security — all green on HEAD

## Not Tested
- Manual device verification on Android 15+ hardware/emulator with invalid `toolbarColor`, non-blank toolbar types, and light/dark transitions.

Supersedes: https://github.com/Cap-go/capacitor-inappbrowser/pull/696
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2470f885-7436-4793-a98f-0d6a71545287?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2470f885-7436-4793-a98f-0d6a71545287&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-inappbrowser/pr/697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791644816&installation_model_id=430928&pr_number=697&repository=Cap-go%2Fcapacitor-inappbrowser&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-inappbrowser%2Fpull%2F697&signature=1a3e35d554c825e0081688232bf0ddcfd8e280c9188d48910ef073b4bf8d3991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-inappbrowser/pull/697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-app browser system bar backgrounds so they consistently match the selected toolbar color.
  * Added reliable black or white fallback backgrounds based on the active theme, preventing unintended colors from appearing behind browser content.
  * Preserved transparent backgrounds for custom-sized browser windows.
  * Browser layouts now refresh when the device switches between light and dark mode.

* **Tests**
  * Added coverage for custom toolbar colors, theme fallback behavior, and UI mode changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->